### PR TITLE
Add SQLAlchemy db session management

### DIFF
--- a/app/utils/db_session.py
+++ b/app/utils/db_session.py
@@ -1,0 +1,24 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.utils.database import Base
+
+DATABASE_URL = "sqlite:///ces_inventory.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Ensure all tables are created
+Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    """Yield a database session and ensure it's closed after use."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- configure SQLAlchemy engine and session in `db_session.py`

## Testing
- `python -m py_compile app/utils/db_session.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684c7d19ac1c8324a4dc96d206e9f908