### PR TITLE
Implement basic user authentication

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,19 @@
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from starlette.middleware.sessions import SessionMiddleware
+
+from app.routes import auth_router
 
 app = FastAPI()
 
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 templates = Jinja2Templates(directory="app/templates")
+
+# Store login information in signed cookies
+app.add_middleware(SessionMiddleware, secret_key="change-me")
+
+app.include_router(auth_router)
 
 
 @app.get("/")

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -1,5 +1,13 @@
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Text
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    ForeignKey,
+    DateTime,
+    Text,
+    Boolean,
+)
 from sqlalchemy.orm import relationship
 
 from app.utils.database import Base
@@ -72,3 +80,16 @@ class ConfigBackup(Base):
     source = Column(String, nullable=False)
 
     device = relationship("Device", back_populates="backups")
+
+
+class User(Base):
+    """User account with role-based permissions."""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String, unique=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    role = Column(String, nullable=False, default="viewer")
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,0 +1,3 @@
+from .auth import router as auth_router
+
+__all__ = ["auth_router"]

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Request, Depends, Form
+from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from app.utils.db_session import get_db
+from app.utils import auth as auth_utils
+from app.models.models import User
+
+templates = Jinja2Templates(directory="app/templates")
+
+router = APIRouter()
+
+
+@router.get("/login")
+async def login_form(request: Request):
+    """Render the login form."""
+    context = {"request": request, "error": None}
+    return templates.TemplateResponse("login.html", context)
+
+
+@router.post("/login")
+async def login(request: Request, email: str = Form(...), password: str = Form(...), db: Session = Depends(get_db)):
+    """Process login form and create a session."""
+    user = db.query(User).filter(User.email == email, User.is_active == True).first()
+    if not user or not auth_utils.verify_password(password, user.hashed_password):
+        context = {"request": request, "error": "Invalid credentials"}
+        return templates.TemplateResponse("login.html", context)
+
+    request.session["user_id"] = user.id
+    response = RedirectResponse(url="/", status_code=302)
+    return response
+
+
+@router.get("/logout")
+async def logout(request: Request):
+    """Clear the user session and redirect to login."""
+    request.session.clear()
+    return RedirectResponse(url="/login", status_code=302)

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="max-w-sm mx-auto mt-10">
+  <h1 class="text-xl mb-4">Login</h1>
+  <form method="post" class="space-y-4">
+    <input type="text" name="email" placeholder="Email" class="w-full p-2 text-black" />
+    <input type="password" name="password" placeholder="Password" class="w-full p-2 text-black" />
+    {% if error %}
+    <p class="text-red-500">{{ error }}</p>
+    {% endif %}
+    <button type="submit" class="bg-blue-600 px-4 py-2">Login</button>
+  </form>
+</div>
+{% endblock %}

--- a/app/utils/auth.py
+++ b/app/utils/auth.py
@@ -1,0 +1,31 @@
+import hashlib
+from typing import Optional
+
+from fastapi import Request, Depends
+from sqlalchemy.orm import Session
+
+from app.utils.db_session import get_db
+from app.models.models import User
+
+
+ROLE_CHOICES = {"viewer", "user", "editor", "admin", "superadmin"}
+
+
+def get_password_hash(password: str) -> str:
+    """Return a SHA256 hash of the given password."""
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def verify_password(password: str, hashed_password: str) -> bool:
+    """Compare plain password with its hashed version."""
+    return get_password_hash(password) == hashed_password
+
+
+def get_current_user(
+    request: Request, db: Session = Depends(get_db)
+) -> Optional[User]:
+    """Retrieve the currently logged-in user from the session."""
+    user_id = request.session.get("user_id")
+    if not user_id:
+        return None
+    return db.query(User).filter(User.id == user_id, User.is_active == True).first()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ jinja2
 asyncssh
 python-dotenv
 python-multipart
+itsdangerous


### PR DESCRIPTION
## Summary
- extend models with `User` for role based auth
- add login/logout routes
- implement simple password hashing utilities
- enable SessionMiddleware in FastAPI app
- add login template
- add `itsdangerous` dependency

## Testing
- `pip install -r requirements.txt`
- `python - <<'EOF'
import app.main
print('main loaded')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684c7f6eb45c83249546443a867beec1