### PR TITLE
Add system tunables page and terminal editor

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,12 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, WebSocket
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.routes import auth_router, devices_router, vlans_router
+from app.routes.tunables import router as tunables_router
+from app.routes.editor import router as editor_router
+from app.websockets.editor import shell_ws
 
 app = FastAPI()
 
@@ -16,6 +19,8 @@ app.add_middleware(SessionMiddleware, secret_key="change-me")
 app.include_router(auth_router, prefix="/auth")
 app.include_router(devices_router)
 app.include_router(vlans_router)
+app.include_router(tunables_router)
+app.include_router(editor_router)
 
 
 @app.get("/")
@@ -23,4 +28,9 @@ async def read_root(request: Request):
     """Render the base template with a test message."""
     context = {"request": request, "message": "Hello, CES"}
     return templates.TemplateResponse("base.html", context)
+
+
+@app.websocket("/ws/editor")
+async def editor_ws(websocket: WebSocket, file: str = "/etc/hosts"):
+    await shell_ws(websocket, file)
 

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -93,3 +93,17 @@ class User(Base):
     role = Column(String, nullable=False, default="viewer")
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class SystemTunable(Base):
+    """Key/value settings that control system behavior."""
+
+    __tablename__ = "system_tunables"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True, nullable=False)
+    value = Column(String, nullable=False)
+    function = Column(String, nullable=False)
+    file_type = Column(String, nullable=False)
+    data_type = Column(String, nullable=False, default="text")
+    options = Column(String, nullable=True)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,5 +1,13 @@
 from .auth import router as auth_router
 from .devices import router as devices_router
 from .vlans import router as vlans_router
+from .tunables import router as tunables_router
+from .editor import router as editor_router
 
-__all__ = ["auth_router", "devices_router", "vlans_router"]
+__all__ = [
+    "auth_router",
+    "devices_router",
+    "vlans_router",
+    "tunables_router",
+    "editor_router",
+]

--- a/app/routes/editor.py
+++ b/app/routes/editor.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, Request, Depends
+from fastapi.templating import Jinja2Templates
+from app.utils.auth import require_role
+
+router = APIRouter()
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/editor")
+async def editor(request: Request, file: str = "/etc/hosts", current_user=Depends(require_role("admin"))):
+    context = {"request": request, "file_path": file}
+    return templates.TemplateResponse("editor.html", context)

--- a/app/routes/tunables.py
+++ b/app/routes/tunables.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Request, Depends, Form
+from fastapi.templating import Jinja2Templates
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from app.utils.db_session import get_db
+from app.utils.auth import require_role
+from app.models.models import SystemTunable
+
+templates = Jinja2Templates(directory="app/templates")
+
+router = APIRouter()
+
+
+def grouped_tunables(db: Session):
+    tunables = db.query(SystemTunable).all()
+    grouped = {}
+    for t in tunables:
+        grouped.setdefault(t.function, {}).setdefault(t.file_type, []).append(t)
+    return grouped
+
+
+@router.get("/tunables")
+async def list_tunables(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("admin")),
+):
+    context = {"request": request, "groups": grouped_tunables(db)}
+    return templates.TemplateResponse("tunables.html", context)
+
+
+@router.post("/tunables/{tunable_id}")
+async def update_tunable(
+    tunable_id: int,
+    request: Request,
+    value: str = Form(...),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("admin")),
+):
+    tunable = db.query(SystemTunable).filter(SystemTunable.id == tunable_id).first()
+    if tunable:
+        tunable.value = value
+        db.commit()
+    return RedirectResponse(url="/tunables", status_code=302)

--- a/app/templates/editor.html
+++ b/app/templates/editor.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">Editing {{ file_path }}</h1>
+<div id="terminal" style="height:500px;" class="bg-black text-white"></div>
+<script src="https://cdn.jsdelivr.net/npm/xterm@4.19.0/lib/xterm.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@4.19.0/css/xterm.css" />
+<script>
+  const term = new Terminal();
+  term.open(document.getElementById('terminal'));
+  const socket = new WebSocket(`ws://${location.host}/ws/editor?file={{ file_path }}`);
+  term.onData(data => socket.send(new TextEncoder().encode(data)));
+  socket.onmessage = evt => {
+    const reader = new FileReader();
+    reader.onload = () => term.write(reader.result);
+    reader.readAsText(evt.data);
+  };
+</script>
+{% endblock %}

--- a/app/templates/tunables.html
+++ b/app/templates/tunables.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">System Tunables</h1>
+{% for function, files in groups.items() %}
+  <h2 class="text-lg mt-4">{{ function }}</h2>
+  {% for file, tunables in files.items() %}
+    <h3 class="mt-2">{{ file }}</h3>
+    {% for tunable in tunables %}
+    <form method="post" action="/tunables/{{ tunable.id }}">
+      <div class="mb-2">
+        <label class="block">{{ tunable.name }}</label>
+        {% if tunable.data_type == 'bool' %}
+          <input type="checkbox" name="value" value="true" {% if tunable.value == 'true' %}checked{% endif %}>
+        {% elif tunable.data_type == 'choice' %}
+          <select name="value">
+            {% for opt in tunable.options.split(',') %}
+              <option value="{{ opt }}" {% if tunable.value == opt %}selected{% endif %}>{{ opt }}</option>
+            {% endfor %}
+          </select>
+        {% else %}
+          <input type="text" name="value" value="{{ tunable.value }}" class="text-black">
+        {% endif %}
+        <button type="submit" class="bg-blue-600 px-2 py-1 ml-2">Save</button>
+      </div>
+    </form>
+    {% endfor %}
+  {% endfor %}
+{% endfor %}
+{% endblock %}

--- a/app/websockets/__init__.py
+++ b/app/websockets/__init__.py
@@ -1,0 +1,3 @@
+from .editor import shell_ws
+
+__all__ = ["shell_ws"]

--- a/app/websockets/editor.py
+++ b/app/websockets/editor.py
@@ -1,0 +1,44 @@
+import os
+import pty
+import asyncio
+from fastapi import WebSocket
+from starlette.websockets import WebSocketDisconnect
+
+
+async def shell_ws(websocket: WebSocket, file_path: str):
+    await websocket.accept()
+    master, slave = pty.openpty()
+    process = await asyncio.create_subprocess_exec(
+        "bash",
+        "-c",
+        f"nano {file_path}",
+        stdin=slave,
+        stdout=slave,
+        stderr=slave,
+    )
+    os.close(slave)
+
+    loop = asyncio.get_running_loop()
+
+    async def read_output():
+        try:
+            while True:
+                data = await loop.run_in_executor(None, os.read, master, 1024)
+                if not data:
+                    break
+                await websocket.send_bytes(data)
+        except Exception:
+            pass
+
+    reader = asyncio.create_task(read_output())
+    try:
+        while True:
+            data = await websocket.receive_bytes()
+            os.write(master, data)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        reader.cancel()
+        process.terminate()
+        await process.wait()
+        os.close(master)

--- a/seed_tunables.py
+++ b/seed_tunables.py
@@ -1,0 +1,43 @@
+from app.utils.db_session import SessionLocal
+from app.models.models import SystemTunable
+
+
+def main():
+    db = SessionLocal()
+    try:
+        if db.query(SystemTunable).first():
+            print("Tunables already seeded")
+            return
+        samples = [
+            SystemTunable(
+                name="Enable SSH",
+                value="true",
+                function="SSH",
+                file_type="sshd_config",
+                data_type="bool",
+            ),
+            SystemTunable(
+                name="Config Backup Count",
+                value="10",
+                function="Backup",
+                file_type="application",
+                data_type="text",
+            ),
+            SystemTunable(
+                name="SNMP Version",
+                value="v2c",
+                function="SNMP",
+                file_type="snmpd.conf",
+                data_type="choice",
+                options="v1,v2c,v3",
+            ),
+        ]
+        db.add_all(samples)
+        db.commit()
+        print("Tunables seeded")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `SystemTunable` model
- implement `/tunables` management routes
- implement live terminal-based file editor with xterm.js
- expose websocket endpoint for the editor
- seed script for example tunables

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python seed_tunables.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684c8742f0908324957d4bd699c516a1