### PR TITLE
Add VLAN suggestion API and form integration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
 
-from app.routes import auth_router, devices_router, vlans_router
+from app.routes import auth_router, devices_router, vlans_router, api_router
 from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
 from app.websockets.editor import shell_ws
@@ -21,6 +21,7 @@ app.include_router(devices_router)
 app.include_router(vlans_router)
 app.include_router(tunables_router)
 app.include_router(editor_router)
+app.include_router(api_router)
 
 
 @app.get("/")

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -3,6 +3,7 @@ from .devices import router as devices_router
 from .vlans import router as vlans_router
 from .tunables import router as tunables_router
 from .editor import router as editor_router
+from .api import router as api_router
 
 __all__ = [
     "auth_router",
@@ -10,4 +11,5 @@ __all__ = [
     "vlans_router",
     "tunables_router",
     "editor_router",
+    "api_router",
 ]

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.utils.db_session import get_db
+from app.utils.auth import get_current_user
+from app.routes.devices import suggest_vlan_from_ip
+from app.models.models import VLAN
+
+router = APIRouter()
+
+
+@router.get("/api/suggest-vlan")
+async def suggest_vlan(ip: str, db: Session = Depends(get_db), current_user=Depends(get_current_user)):
+    """Suggest a VLAN based on the given IP address."""
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    vlan_id, label = suggest_vlan_from_ip(db, ip)
+    if vlan_id or label:
+        response = {}
+        if vlan_id:
+            response["suggested_vlan_id"] = vlan_id
+            vlan = db.query(VLAN).filter(VLAN.id == vlan_id).first()
+            if vlan and vlan.description:
+                response.setdefault("label", vlan.description)
+        if label:
+            response["label"] = label
+        return response
+    return {"error": "No match"}

--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -53,6 +53,26 @@ def _load_form_options(db: Session):
     return vlans, ssh_credentials, snmp_communities
 
 
+def suggest_vlan_from_ip(db: Session, ip: str):
+    """Return VLAN suggestion based on the IP's second octet."""
+    try:
+        second_octet = int(ip.split(".")[1])
+    except (IndexError, ValueError):
+        return None, None
+
+    if second_octet == 100:
+        # Special case mapping
+        return 1, None
+    if second_octet == 101:
+        # Label for CAPWAP networks
+        return None, "CAPWAP"
+
+    vlan = db.query(VLAN).filter(VLAN.tag == second_octet).first()
+    if vlan:
+        return vlan.id, vlan.description
+    return None, None
+
+
 @router.get("/devices/new")
 async def new_device_form(
     request: Request,

--- a/app/templates/device_form.html
+++ b/app/templates/device_form.html
@@ -9,7 +9,7 @@
   </div>
   <div>
     <label class="block">IP Address</label>
-    <input type="text" name="ip" value="{{ device.ip if device else '' }}" class="w-full p-2 text-black" required />
+    <input type="text" name="ip" id="ip-field" value="{{ device.ip if device else '' }}" class="w-full p-2 text-black" required />
   </div>
   <div>
     <label class="block">MAC Address</label>
@@ -33,8 +33,8 @@
     </select>
   </div>
   <div>
-    <label class="block">VLAN</label>
-    <select name="vlan_id" class="w-full p-2 text-black">
+    <label class="block">VLAN <span id="vlan-suggestion" class="ml-2 text-sm text-green-400"></span></label>
+    <select name="vlan_id" id="vlan-field" class="w-full p-2 text-black">
       <option value="">---</option>
       {% for vlan in vlans %}
       <option value="{{ vlan.id }}" {% if device and device.vlan_id == vlan.id %}selected{% endif %}>{{ vlan.tag }} - {{ vlan.description or '' }}</option>
@@ -64,4 +64,34 @@
     <a href="/devices" class="ml-2 underline">Cancel</a>
   </div>
 </form>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const ipField = document.getElementById('ip-field');
+  const vlanField = document.getElementById('vlan-field');
+  const note = document.getElementById('vlan-suggestion');
+
+  async function fetchSuggestion() {
+    const ip = ipField.value.trim();
+    if (!ip) return;
+    try {
+      const res = await fetch(`/api/suggest-vlan?ip=${encodeURIComponent(ip)}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.suggested_vlan_id) {
+        vlanField.value = data.suggested_vlan_id;
+        note.textContent = `VLAN ${data.suggested_vlan_id} suggested based on IP`;
+      } else if (data.label) {
+        note.textContent = data.label;
+      } else {
+        note.textContent = '';
+      }
+    } catch (err) {
+      console.error('suggest-vlan', err);
+    }
+  }
+
+  ipField.addEventListener('change', fetchSuggestion);
+  ipField.addEventListener('blur', fetchSuggestion);
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add VLAN suggestion utility to devices routes
- create `/api/suggest-vlan` endpoint
- include api router in main app
- update device form to auto-suggest VLAN on IP entry

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c896cf1688324bf7a1deea9c78509