### PR TITLE
Add superadmin SSH/SNMP profile management

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
 
-from app.routes import auth_router, devices_router, vlans_router, api_router
+from app.routes import auth_router, devices_router, vlans_router, api_router, admin_profiles_router
 from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
 from app.websockets.editor import shell_ws
@@ -22,6 +22,7 @@ app.include_router(vlans_router)
 app.include_router(tunables_router)
 app.include_router(editor_router)
 app.include_router(api_router)
+app.include_router(admin_profiles_router)
 
 
 @app.get("/")

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -4,6 +4,7 @@ from .vlans import router as vlans_router
 from .tunables import router as tunables_router
 from .editor import router as editor_router
 from .api import router as api_router
+from .admin_profiles import router as admin_profiles_router
 
 __all__ = [
     "auth_router",
@@ -12,4 +13,5 @@ __all__ = [
     "tunables_router",
     "editor_router",
     "api_router",
+    "admin_profiles_router",
 ]

--- a/app/routes/admin_profiles.py
+++ b/app/routes/admin_profiles.py
@@ -1,0 +1,231 @@
+from fastapi import APIRouter, Request, Depends, HTTPException, Form
+from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from app.utils.db_session import get_db
+from app.utils.auth import require_role
+from app.models.models import SSHCredential, SNMPCommunity
+
+templates = Jinja2Templates(directory="app/templates")
+
+router = APIRouter()
+
+
+@router.get("/admin/ssh")
+async def list_ssh_credentials(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    creds = db.query(SSHCredential).all()
+    context = {"request": request, "creds": creds, "current_user": current_user}
+    return templates.TemplateResponse("ssh_list.html", context)
+
+
+@router.get("/admin/ssh/new")
+async def new_ssh_form(request: Request, current_user=Depends(require_role("superadmin"))):
+    context = {"request": request, "cred": None, "form_title": "New SSH Profile", "error": None}
+    return templates.TemplateResponse("ssh_form.html", context)
+
+
+@router.post("/admin/ssh/new")
+async def create_ssh_credential(
+    request: Request,
+    name: str = Form(...),
+    username: str = Form(...),
+    password: str = Form(None),
+    private_key: str = Form(None),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    existing = db.query(SSHCredential).filter(SSHCredential.name == name).first()
+    if existing:
+        context = {
+            "request": request,
+            "cred": {"name": name, "username": username, "password": password, "private_key": private_key},
+            "form_title": "New SSH Profile",
+            "error": "Name already exists",
+        }
+        return templates.TemplateResponse("ssh_form.html", context)
+
+    cred = SSHCredential(
+        name=name,
+        username=username,
+        password=password or None,
+        private_key=private_key or None,
+    )
+    db.add(cred)
+    db.commit()
+    return RedirectResponse(url="/admin/ssh", status_code=302)
+
+
+@router.get("/admin/ssh/{cred_id}/edit")
+async def edit_ssh_form(
+    cred_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    cred = db.query(SSHCredential).filter(SSHCredential.id == cred_id).first()
+    if not cred:
+        raise HTTPException(status_code=404, detail="SSH credential not found")
+    context = {"request": request, "cred": cred, "form_title": "Edit SSH Profile", "error": None}
+    return templates.TemplateResponse("ssh_form.html", context)
+
+
+@router.post("/admin/ssh/{cred_id}/edit")
+async def update_ssh_credential(
+    cred_id: int,
+    request: Request,
+    name: str = Form(...),
+    username: str = Form(...),
+    password: str = Form(None),
+    private_key: str = Form(None),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    cred = db.query(SSHCredential).filter(SSHCredential.id == cred_id).first()
+    if not cred:
+        raise HTTPException(status_code=404, detail="SSH credential not found")
+
+    existing = db.query(SSHCredential).filter(SSHCredential.name == name, SSHCredential.id != cred_id).first()
+    if existing:
+        context = {
+            "request": request,
+            "cred": cred,
+            "form_title": "Edit SSH Profile",
+            "error": "Name already exists",
+        }
+        cred.name = name
+        cred.username = username
+        cred.password = password
+        cred.private_key = private_key
+        return templates.TemplateResponse("ssh_form.html", context)
+
+    cred.name = name
+    cred.username = username
+    cred.password = password or None
+    cred.private_key = private_key or None
+    db.commit()
+    return RedirectResponse(url="/admin/ssh", status_code=302)
+
+
+@router.post("/admin/ssh/{cred_id}/delete")
+async def delete_ssh_credential(
+    cred_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    cred = db.query(SSHCredential).filter(SSHCredential.id == cred_id).first()
+    if not cred:
+        raise HTTPException(status_code=404, detail="SSH credential not found")
+
+    db.delete(cred)
+    db.commit()
+    return RedirectResponse(url="/admin/ssh", status_code=302)
+
+
+@router.get("/admin/snmp")
+async def list_snmp_profiles(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    profiles = db.query(SNMPCommunity).all()
+    context = {"request": request, "profiles": profiles, "current_user": current_user}
+    return templates.TemplateResponse("snmp_list.html", context)
+
+
+@router.get("/admin/snmp/new")
+async def new_snmp_form(request: Request, current_user=Depends(require_role("superadmin"))):
+    context = {"request": request, "profile": None, "form_title": "New SNMP Profile", "error": None}
+    return templates.TemplateResponse("snmp_form.html", context)
+
+
+@router.post("/admin/snmp/new")
+async def create_snmp_profile(
+    request: Request,
+    name: str = Form(...),
+    community_string: str = Form(...),
+    version: str = Form("2c"),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    existing = db.query(SNMPCommunity).filter(SNMPCommunity.name == name).first()
+    if existing:
+        context = {
+            "request": request,
+            "profile": {"name": name, "community_string": community_string, "version": version},
+            "form_title": "New SNMP Profile",
+            "error": "Name already exists",
+        }
+        return templates.TemplateResponse("snmp_form.html", context)
+
+    profile = SNMPCommunity(name=name, community_string=community_string, version=version or "2c")
+    db.add(profile)
+    db.commit()
+    return RedirectResponse(url="/admin/snmp", status_code=302)
+
+
+@router.get("/admin/snmp/{profile_id}/edit")
+async def edit_snmp_form(
+    profile_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    profile = db.query(SNMPCommunity).filter(SNMPCommunity.id == profile_id).first()
+    if not profile:
+        raise HTTPException(status_code=404, detail="SNMP profile not found")
+    context = {"request": request, "profile": profile, "form_title": "Edit SNMP Profile", "error": None}
+    return templates.TemplateResponse("snmp_form.html", context)
+
+
+@router.post("/admin/snmp/{profile_id}/edit")
+async def update_snmp_profile(
+    profile_id: int,
+    request: Request,
+    name: str = Form(...),
+    community_string: str = Form(...),
+    version: str = Form("2c"),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    profile = db.query(SNMPCommunity).filter(SNMPCommunity.id == profile_id).first()
+    if not profile:
+        raise HTTPException(status_code=404, detail="SNMP profile not found")
+
+    existing = db.query(SNMPCommunity).filter(SNMPCommunity.name == name, SNMPCommunity.id != profile_id).first()
+    if existing:
+        context = {
+            "request": request,
+            "profile": profile,
+            "form_title": "Edit SNMP Profile",
+            "error": "Name already exists",
+        }
+        profile.name = name
+        profile.community_string = community_string
+        profile.version = version
+        return templates.TemplateResponse("snmp_form.html", context)
+
+    profile.name = name
+    profile.community_string = community_string
+    profile.version = version or "2c"
+    db.commit()
+    return RedirectResponse(url="/admin/snmp", status_code=302)
+
+
+@router.post("/admin/snmp/{profile_id}/delete")
+async def delete_snmp_profile(
+    profile_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    profile = db.query(SNMPCommunity).filter(SNMPCommunity.id == profile_id).first()
+    if not profile:
+        raise HTTPException(status_code=404, detail="SNMP profile not found")
+
+    db.delete(profile)
+    db.commit()
+    return RedirectResponse(url="/admin/snmp", status_code=302)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,10 @@
             <li><a href="#" class="hover:underline">Dashboard</a></li>
             <li><a href="/devices" class="hover:underline">Devices</a></li>
             <li><a href="/vlans" class="hover:underline">VLANs</a></li>
-            <li><a href="#" class="hover:underline">Admin</a></li>
+            {% if current_user and current_user.role == 'superadmin' %}
+            <li><a href="/admin/ssh" class="hover:underline">SSH Profiles</a></li>
+            <li><a href="/admin/snmp" class="hover:underline">SNMP Profiles</a></li>
+            {% endif %}
         </ul>
     </nav>
     <div class="container mx-auto p-4">

--- a/app/templates/snmp_form.html
+++ b/app/templates/snmp_form.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">{{ form_title }}</h1>
+<form method="post" class="space-y-4">
+  <div>
+    <label class="block">Name</label>
+    <input type="text" name="name" value="{{ profile.name if profile else '' }}" class="w-full p-2 text-black" required />
+  </div>
+  <div>
+    <label class="block">Community String</label>
+    <input type="text" name="community_string" value="{{ profile.community_string if profile else '' }}" class="w-full p-2 text-black" required />
+  </div>
+  <div>
+    <label class="block">Version</label>
+    <input type="text" name="version" value="{{ profile.version if profile else '2c' }}" class="w-full p-2 text-black" />
+  </div>
+  {% if error %}
+  <p class="text-red-500">{{ error }}</p>
+  {% endif %}
+  <div>
+    <button type="submit" class="bg-blue-600 px-4 py-2">Submit</button>
+    <a href="/admin/snmp" class="ml-2 underline">Cancel</a>
+  </div>
+</form>
+{% endblock %}

--- a/app/templates/snmp_list.html
+++ b/app/templates/snmp_list.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">SNMP Communities</h1>
+<a href="/admin/snmp/new" class="underline">Add SNMP Profile</a>
+<table class="min-w-full bg-gray-800 mt-4">
+  <thead>
+    <tr>
+      <th class="px-4 py-2 text-left">Name</th>
+      <th class="px-4 py-2 text-left">Community</th>
+      <th class="px-4 py-2 text-left">Version</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for profile in profiles %}
+    <tr class="border-t border-gray-700">
+      <td class="px-4 py-2">{{ profile.name }}</td>
+      <td class="px-4 py-2">{{ profile.community_string }}</td>
+      <td class="px-4 py-2">{{ profile.version }}</td>
+      <td class="px-4 py-2">
+        <a href="/admin/snmp/{{ profile.id }}/edit" class="text-blue-400 underline mr-2">Edit</a>
+        <form method="post" action="/admin/snmp/{{ profile.id }}/delete" style="display:inline">
+          <button type="submit" class="text-red-400 underline" onclick="return confirm('Delete profile?')">Delete</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/ssh_form.html
+++ b/app/templates/ssh_form.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">{{ form_title }}</h1>
+<form method="post" class="space-y-4">
+  <div>
+    <label class="block">Name</label>
+    <input type="text" name="name" value="{{ cred.name if cred else '' }}" class="w-full p-2 text-black" required />
+  </div>
+  <div>
+    <label class="block">Username</label>
+    <input type="text" name="username" value="{{ cred.username if cred else '' }}" class="w-full p-2 text-black" required />
+  </div>
+  <div>
+    <label class="block">Password</label>
+    <input type="password" name="password" value="{{ cred.password if cred else '' }}" class="w-full p-2 text-black" />
+  </div>
+  <div>
+    <label class="block">Private Key</label>
+    <textarea name="private_key" class="w-full p-2 text-black">{{ cred.private_key if cred else '' }}</textarea>
+  </div>
+  {% if error %}
+  <p class="text-red-500">{{ error }}</p>
+  {% endif %}
+  <div>
+    <button type="submit" class="bg-blue-600 px-4 py-2">Submit</button>
+    <a href="/admin/ssh" class="ml-2 underline">Cancel</a>
+  </div>
+</form>
+{% endblock %}

--- a/app/templates/ssh_list.html
+++ b/app/templates/ssh_list.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">SSH Credentials</h1>
+<a href="/admin/ssh/new" class="underline">Add SSH Credential</a>
+<table class="min-w-full bg-gray-800 mt-4">
+  <thead>
+    <tr>
+      <th class="px-4 py-2 text-left">Name</th>
+      <th class="px-4 py-2 text-left">Username</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for cred in creds %}
+    <tr class="border-t border-gray-700">
+      <td class="px-4 py-2">{{ cred.name }}</td>
+      <td class="px-4 py-2">{{ cred.username }}</td>
+      <td class="px-4 py-2">
+        <a href="/admin/ssh/{{ cred.id }}/edit" class="text-blue-400 underline mr-2">Edit</a>
+        <form method="post" action="/admin/ssh/{{ cred.id }}/delete" style="display:inline">
+          <button type="submit" class="text-red-400 underline" onclick="return confirm('Delete profile?')">Delete</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- manage SSH and SNMP credential profiles
- add templates for viewing and editing SSH/SNMP profiles
- show links for superadmins in navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c8a87d5c88324924b3f6ac20ff486