### PR TITLE
Add SSH config pull route

### DIFF
--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -36,6 +36,9 @@
         <form method="post" action="/devices/{{ device.id }}/delete" style="display:inline">
           <button type="submit" class="text-red-400 underline" onclick="return confirm('Delete device?')">Delete</button>
         </form>
+        <form method="post" action="/devices/{{ device.id }}/pull-config" style="display:inline">
+          <button type="submit" class="text-green-400 underline ml-2">Pull Config</button>
+        </form>
       </td>
       {% endif %}
     </tr>


### PR DESCRIPTION
## Summary
- allow storing config backups pulled via AsyncSSH
- show a `Pull Config` button for editors+ on the device list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c8bac6c888324b12e71de75b9630c