### PR TITLE
Implement manual config push via AsyncSSH

### DIFF
--- a/app/templates/config_push_form.html
+++ b/app/templates/config_push_form.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Push Config to {{ device.hostname }}</h1>
+<form method="post" class="space-y-4">
+  <div>
+    <label class="block">Configuration</label>
+    <textarea name="config_text" rows="10" class="w-full p-2 text-black" required></textarea>
+  </div>
+  {% if error %}
+  <p class="text-red-500">{{ error }}</p>
+  {% endif %}
+  <div>
+    <button type="submit" class="bg-blue-600 px-4 py-2">Push Config to Device</button>
+    <a href="/devices" class="ml-2 underline">Cancel</a>
+  </div>
+</form>
+{% endblock %}

--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -39,6 +39,7 @@
         <form method="post" action="/devices/{{ device.id }}/pull-config" style="display:inline">
           <button type="submit" class="text-green-400 underline ml-2">Pull Config</button>
         </form>
+        <a href="/devices/{{ device.id }}/push-config" class="text-purple-400 underline ml-2">Push Config</a>
       </td>
       {% endif %}
     </tr>


### PR DESCRIPTION
## Summary
- allow config snippets to be pushed to a device
- show button on device list to push config
- log manually pushed configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8cf072f88324bca56977f109889d