### PR TITLE
Add SNMP port status monitoring

### DIFF
--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -46,6 +46,9 @@
         </form>
         <a href="/devices/{{ device.id }}/push-config" class="text-purple-400 underline ml-2">Push Config</a>
         <a href="/devices/{{ device.id }}/configs" class="text-yellow-400 underline ml-2">Configs</a>
+        {% if device.snmp_community %}
+        <a href="/devices/{{ device.id }}/ports" class="text-indigo-400 underline ml-2">Port Status</a>
+        {% endif %}
       </td>
       {% endif %}
     </tr>

--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Port Status for {{ device.hostname }}</h1>
+{% if error %}
+  <p class="text-red-500 mb-4">{{ error }}</p>
+{% endif %}
+<table class="min-w-full bg-gray-800">
+  <thead>
+    <tr>
+      <th class="px-4 py-2 text-left">Port Name</th>
+      <th class="px-4 py-2 text-left">Status</th>
+      <th class="px-4 py-2 text-left">Admin State</th>
+      <th class="px-4 py-2 text-left">Speed</th>
+      <th class="px-4 py-2 text-left">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for port in ports %}
+    <tr class="border-t border-gray-700">
+      <td class="px-4 py-2">{{ port.name or port.descr }}</td>
+      <td class="px-4 py-2">
+        {% if port.oper_status == 'up' %}
+          <span class="text-green-400">up</span>
+        {% else %}
+          <span class="text-red-400">down</span>
+        {% endif %}
+      </td>
+      <td class="px-4 py-2">{{ port.admin_status }}</td>
+      <td class="px-4 py-2">{{ port.speed }}</td>
+      <td class="px-4 py-2">{{ port.alias or '' }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv
 python-multipart
 itsdangerous
 bcrypt
+puresnmp


### PR DESCRIPTION
## Summary
- add `puresnmp` to requirements
- enable SNMP based port status route
- show Port Status link on device list
- render port information table

## Testing
- `python -m py_compile app/routes/devices.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c919b7c7483249e5631938ecd98c1