### PR TITLE
Implement SSH Web Terminal

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ from app.routes import (
 from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
 from app.websockets.editor import shell_ws
+from app.websockets.terminal import router as terminal_ws_router
 from app.tasks import start_queue_worker
 
 app = FastAPI()
@@ -37,6 +38,7 @@ app.include_router(admin_profiles_router)
 app.include_router(configs_router)
 app.include_router(admin_router)
 app.include_router(audit_router)
+app.include_router(terminal_ws_router)
 
 
 @app.get("/")

--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -441,3 +441,19 @@ async def port_status(
         "current_user": current_user,
     }
     return templates.TemplateResponse("port_status.html", context)
+
+
+@router.get("/devices/{device_id}/terminal")
+async def device_terminal(
+    device_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("editor")),
+):
+    """Render a page with an interactive terminal for the device."""
+    device = db.query(Device).filter(Device.id == device_id).first()
+    if not device:
+        raise HTTPException(status_code=404, detail="Device not found")
+
+    context = {"request": request, "device": device, "current_user": current_user}
+    return templates.TemplateResponse("terminal.html", context)

--- a/app/static/js/terminal.js
+++ b/app/static/js/terminal.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const term = new Terminal({ theme: { background: '#1e1e1e' } });
+  const container = document.getElementById('terminal');
+  term.open(container);
+  term.write('Connecting...\r\n');
+
+  const socket = new WebSocket(`ws://${location.host}/ws/terminal/${window.deviceId}`);
+
+  socket.addEventListener('open', () => term.clear());
+  socket.addEventListener('message', (evt) => term.write(evt.data));
+  socket.addEventListener('close', () => term.write('\r\n*** Disconnected ***\r\n'));
+
+  term.onData(data => socket.send(data));
+});

--- a/app/templates/terminal.html
+++ b/app/templates/terminal.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Terminal - {{ device.hostname }}</h1>
+<div id="terminal" class="w-full h-screen bg-black text-white"></div>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@4.19.0/css/xterm.css" />
+<script src="https://cdn.jsdelivr.net/npm/xterm@4.19.0/lib/xterm.min.js"></script>
+<script>
+  window.deviceId = {{ device.id }};
+</script>
+<script src="/static/js/terminal.js"></script>
+{% endblock %}

--- a/app/websockets/__init__.py
+++ b/app/websockets/__init__.py
@@ -1,3 +1,4 @@
 from .editor import shell_ws
+from .terminal import router as terminal_router
 
-__all__ = ["shell_ws"]
+__all__ = ["shell_ws", "terminal_router"]

--- a/app/websockets/terminal.py
+++ b/app/websockets/terminal.py
@@ -1,0 +1,72 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from sqlalchemy.orm import Session
+import asyncssh
+import asyncio
+
+from app.utils.db_session import SessionLocal
+from app.models.models import Device, User
+from app.utils.auth import ROLE_HIERARCHY
+
+router = APIRouter()
+
+
+@router.websocket("/ws/terminal/{device_id}")
+async def terminal_ws(websocket: WebSocket, device_id: int):
+    """Interactive SSH terminal over WebSocket."""
+    await websocket.accept()
+    db: Session = SessionLocal()
+    try:
+        user_id = websocket.session.get("user_id") if hasattr(websocket, "session") else None
+        if not user_id:
+            await websocket.close(code=1008)
+            return
+
+        user = db.query(User).filter(User.id == user_id, User.is_active == True).first()
+        if not user or ROLE_HIERARCHY.index(user.role) < ROLE_HIERARCHY.index("editor"):
+            await websocket.close(code=1008)
+            return
+
+        device = db.query(Device).filter(Device.id == device_id).first()
+        if not device or not device.ssh_credential:
+            await websocket.send_text("Device or SSH credentials not found")
+            await websocket.close()
+            return
+
+        cred = device.ssh_credential
+        conn_kwargs = {"username": cred.username}
+        if cred.password:
+            conn_kwargs["password"] = cred.password
+        if cred.private_key:
+            try:
+                conn_kwargs["client_keys"] = [asyncssh.import_private_key(cred.private_key)]
+            except Exception:
+                pass
+
+        try:
+            async with asyncssh.connect(device.ip, **conn_kwargs) as conn:
+                session = await conn.create_session(asyncssh.SSHClientProcess)
+
+                async def ws_to_ssh():
+                    try:
+                        while True:
+                            data = await asyncio.wait_for(websocket.receive_text(), timeout=900)
+                            session.stdin.write(data)
+                    except (WebSocketDisconnect, asyncio.TimeoutError):
+                        pass
+
+                async def ssh_to_ws():
+                    try:
+                        while True:
+                            data = await asyncio.wait_for(session.stdout.read(1024), timeout=900)
+                            if not data:
+                                break
+                            await websocket.send_text(data)
+                    except asyncio.TimeoutError:
+                        pass
+
+                await asyncio.gather(ws_to_ssh(), ssh_to_ws())
+        except Exception as exc:
+            await websocket.send_text(f"Connection error: {exc}")
+    finally:
+        db.close()
+        await websocket.close()


### PR DESCRIPTION
## Summary
- add websocket handler for interactive SSH sessions
- expose `/devices/{device_id}/terminal` page and template
- register websocket router in main app
- bundle xterm.js logic in `terminal.js`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c93993a048324916bd94a6afd647d