### PR TITLE
Implement auto-expiring SSH terminal sessions

### DIFF
--- a/app/static/js/terminal.js
+++ b/app/static/js/terminal.js
@@ -8,7 +8,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
   socket.addEventListener('open', () => term.clear());
   socket.addEventListener('message', (evt) => term.write(evt.data));
-  socket.addEventListener('close', () => term.write('\r\n*** Disconnected ***\r\n'));
+  socket.addEventListener('close', () => {
+    term.write('\r\n*** Disconnected ***\r\n');
+    clearInterval(pingInterval);
+  });
 
-  term.onData(data => socket.send(data));
+  term.onData(data => {
+    if (socket.readyState === WebSocket.OPEN) {
+      socket.send(data);
+    }
+  });
+
+  const pingInterval = setInterval(() => {
+    if (socket.readyState === WebSocket.OPEN) {
+      socket.send('');
+    }
+  }, 60000);
 });


### PR DESCRIPTION
## Summary
- expire idle SSH terminal sessions after 15 minutes
- close sessions and notify users of inactivity timeout
- send periodic heartbeat pings from the frontend

## Testing
- `python -m py_compile app/websockets/terminal.py`
- `node --check app/static/js/terminal.js`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9485bf54832480ce5a6377a2838a