### PR TITLE
Add debug log viewer and logging

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from app.routes import (
     configs_router,
     admin_router,
     audit_router,
+    admin_debug_router,
 )
 from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
@@ -38,6 +39,7 @@ app.include_router(admin_profiles_router)
 app.include_router(configs_router)
 app.include_router(admin_router)
 app.include_router(audit_router)
+app.include_router(admin_debug_router)
 app.include_router(terminal_ws_router)
 
 

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -8,6 +8,7 @@ from .admin_profiles import router as admin_profiles_router
 from .configs import router as configs_router
 from .admin import router as admin_router
 from .audit import router as audit_router
+from .admin_debug import router as admin_debug_router
 
 __all__ = [
     "auth_router",
@@ -20,4 +21,5 @@ __all__ = [
     "configs_router",
     "admin_router",
     "audit_router",
+    "admin_debug_router",
 ]

--- a/app/routes/admin_debug.py
+++ b/app/routes/admin_debug.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, Request, Depends, HTTPException
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+from typing import Optional
+
+from app.utils.db_session import get_db
+from app.utils.auth import require_role
+from app.models.models import AuditLog, User, Device
+
+templates = Jinja2Templates(directory="app/templates")
+
+router = APIRouter()
+
+
+@router.get("/admin/debug")
+async def debug_logs(
+    request: Request,
+    show: str = "debug",
+    device_id: Optional[int] = None,
+    user_id: Optional[int] = None,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    query = db.query(AuditLog).order_by(AuditLog.timestamp.desc())
+    if show != "all":
+        query = query.filter(AuditLog.action_type == "debug")
+    if device_id:
+        query = query.filter(AuditLog.device_id == device_id)
+    if user_id:
+        query = query.filter(AuditLog.user_id == user_id)
+    logs = query.limit(200).all()
+    devices = db.query(Device).all()
+    users = db.query(User).all()
+    context = {
+        "request": request,
+        "logs": logs,
+        "show": show,
+        "device_id": device_id,
+        "user_id": user_id,
+        "devices": devices,
+        "users": users,
+        "current_user": current_user,
+    }
+    return templates.TemplateResponse("debug_log.html", context)
+
+
+@router.get("/admin/debug/{log_id}")
+async def debug_detail(
+    log_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    log = db.query(AuditLog).filter(AuditLog.id == log_id).first()
+    if not log:
+        raise HTTPException(status_code=404, detail="Log entry not found")
+    context = {"request": request, "log": log, "current_user": current_user}
+    return templates.TemplateResponse("debug_detail.html", context)

--- a/app/routes/configs.py
+++ b/app/routes/configs.py
@@ -84,4 +84,5 @@ async def diff_config(
         "diff_lines": diff_lines,
         "current_user": current_user,
     }
+    log_audit(db, current_user, "debug", backup.device, f"Viewed config diff {backup.id}")
     return templates.TemplateResponse("config_diff.html", context)

--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -251,6 +251,7 @@ async def pull_device_config(
             result = await conn.run("echo test-config", check=False)
             output = result.stdout
     except Exception as exc:
+        log_audit(db, current_user, "debug", device, f"SSH pull error: {exc}")
         return RedirectResponse(
             url=f"/devices?message=SSH+error:+{str(exc)}", status_code=302
         )
@@ -338,8 +339,9 @@ async def push_device_config(
             session.stdin.write("exit\n")
             await session.wait_closed()
             success = True
-    except Exception:
+    except Exception as exc:
         success = False
+        log_audit(db, current_user, "debug", device, f"SSH push error: {exc}")
 
     backup = ConfigBackup(
         device_id=device.id,
@@ -455,8 +457,9 @@ async def push_template_config(
             session.stdin.write("exit\n")
             await session.wait_closed()
             success = True
-    except Exception:
+    except Exception as exc:
         success = False
+        log_audit(db, current_user, "debug", device, f"SSH template push error: {exc}")
 
     backup = ConfigBackup(
         device_id=device.id,
@@ -535,6 +538,7 @@ async def port_status(
         speed = await _gather_snmp_table(client, "1.3.6.1.2.1.2.2.1.5")
         alias = await _gather_snmp_table(client, "1.3.6.1.2.1.31.1.1.1.18")
     except SnmpError as exc:
+        log_audit(db, current_user, "debug", device, f"SNMP error: {exc}")
         context = {
             "request": request,
             "device": device,
@@ -544,6 +548,7 @@ async def port_status(
         }
         return templates.TemplateResponse("port_status.html", context)
     except Exception as exc:
+        log_audit(db, current_user, "debug", device, f"SNMP exception: {exc}")
         context = {
             "request": request,
             "device": device,

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -38,8 +38,9 @@ async def run_push_queue_once():
             backup.status = "pushed"
             backup.created_at = datetime.utcnow()
             log_audit(db, None, "push", device, f"Queued config pushed to {device.ip}")
-        except Exception:
+        except Exception as exc:
             backup.status = "pending"
+            log_audit(db, None, "debug", device, f"Queue push error: {exc}")
         db.commit()
     db.close()
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,6 +16,7 @@
             <li><a href="/admin/ssh" class="hover:underline">SSH Profiles</a></li>
             <li><a href="/admin/snmp" class="hover:underline">SNMP Profiles</a></li>
             <li><a href="/admin/audit" class="hover:underline">Audit Log</a></li>
+            <li><a href="/admin/debug" class="hover:underline">Debug Logs</a></li>
             {% endif %}
         </ul>
     </nav>

--- a/app/templates/debug_detail.html
+++ b/app/templates/debug_detail.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Debug Log Detail</h1>
+<div class="mb-4">
+  <strong>Timestamp:</strong> {{ log.timestamp }}<br>
+  <strong>Device:</strong> {{ log.device.hostname if log.device else '' }}<br>
+  <strong>User:</strong> {{ log.user.email if log.user else 'System' }}<br>
+  <strong>Action Type:</strong> {{ log.action_type }}
+</div>
+<pre class="bg-gray-800 p-4 whitespace-pre-wrap overflow-x-auto">{{ log.details }}</pre>
+<a href="/admin/debug" class="underline">Back to Debug Logs</a>
+{% endblock %}

--- a/app/templates/debug_log.html
+++ b/app/templates/debug_log.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Debug Logs</h1>
+<form method="get" class="mb-4">
+  <label class="mr-2">Show:
+    <select name="show" onchange="this.form.submit()">
+      <option value="debug" {% if show != 'all' %}selected{% endif %}>Debug Only</option>
+      <option value="all" {% if show == 'all' %}selected{% endif %}>All Logs</option>
+    </select>
+  </label>
+  <label class="mr-2">Device:
+    <select name="device_id" onchange="this.form.submit()">
+      <option value="">All</option>
+      {% for d in devices %}
+      <option value="{{ d.id }}" {% if device_id and d.id == device_id %}selected{% endif %}>{{ d.hostname }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label>User:
+    <select name="user_id" onchange="this.form.submit()">
+      <option value="">All</option>
+      {% for u in users %}
+      <option value="{{ u.id }}" {% if user_id and u.id == user_id %}selected{% endif %}>{{ u.email }}</option>
+      {% endfor %}
+    </select>
+  </label>
+</form>
+<table class="min-w-full bg-gray-800">
+  <thead>
+    <tr>
+      <th class="px-4 py-2 text-left">Timestamp</th>
+      <th class="px-4 py-2 text-left">Device</th>
+      <th class="px-4 py-2 text-left">User</th>
+      <th class="px-4 py-2 text-left">Action Type</th>
+      <th class="px-4 py-2 text-left">Summary</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for entry in logs %}
+    <tr class="border-t border-gray-700">
+      <td class="px-4 py-2">{{ entry.timestamp }}</td>
+      <td class="px-4 py-2">{{ entry.device.hostname if entry.device else '' }}</td>
+      <td class="px-4 py-2">{{ entry.user.email if entry.user else 'System' }}</td>
+      <td class="px-4 py-2">{{ entry.action_type }}</td>
+      <td class="px-4 py-2">{{ entry.details[:50] }}</td>
+      <td class="px-4 py-2"><a href="/admin/debug/{{ entry.id }}" class="text-blue-400 underline">View Full</a></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `/admin/debug` routes for viewing and filtering debug log entries
- add templates for debug log list and details
- log SSH and SNMP failures plus config diff views as debug entries
- expose debug logs link in navigation
- include new router in application

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684c9699f00c832483c7b273cc94eae0