### PR TITLE
Update README for remote access tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Start the FastAPI application using [uvicorn](https://www.uvicorn.org/):
 uvicorn app.main:app --reload
 ```
 
+`uvicorn` binds to `127.0.0.1` by default, so only the local machine can connect.
+To access the app from other computers, specify `--host 0.0.0.0` and optionally
+set the port:
+
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+```
+
 The `--reload` flag automatically restarts the server on code changes.
 
 Visit [http://localhost:8000](http://localhost:8000) in your browser. Log in with the credentials created by `seed_superuser.py`:
@@ -45,6 +53,12 @@ After logging in you can add devices, VLANs and manage configuration backups thr
 
 
 ## Troubleshooting
+
+### Can't access the app from another machine
+If the browser shows a *connection refused* error when visiting
+`http://<server-ip>:8000`, the server is likely only listening on `127.0.0.1`.
+Start it with `uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload` and
+ensure the port is allowed through any firewall.
 
 ### "No such file or directory" during `pip install`
 If you see an error like:


### PR DESCRIPTION
## Summary
- clarify how to run the FastAPI server on all interfaces
- add troubleshooting notes for "connection refused" errors when starting the server

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684c9c54d098832497a911a98b27e6eb