### PR TITLE
Enhance UI theme and add welcome pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Request, WebSocket
+from fastapi import FastAPI, Request, WebSocket, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
@@ -18,6 +18,8 @@ from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
 from app.websockets.editor import shell_ws
 from app.websockets.terminal import router as terminal_ws_router
+from app.routes.welcome import router as welcome_router
+from app.utils.auth import get_current_user
 from app.tasks import start_queue_worker
 
 app = FastAPI()
@@ -41,13 +43,18 @@ app.include_router(admin_router)
 app.include_router(audit_router)
 app.include_router(admin_debug_router)
 app.include_router(terminal_ws_router)
+app.include_router(welcome_router)
 
 
 @app.get("/")
-async def read_root(request: Request):
-    """Render the base template with a test message."""
-    context = {"request": request, "message": "Hello, CES"}
-    return templates.TemplateResponse("base.html", context)
+async def read_root(request: Request, current_user=Depends(get_current_user)):
+    """Render the home page with login link and welcome text."""
+    context = {
+        "request": request,
+        "message": "",
+        "current_user": current_user,
+    }
+    return templates.TemplateResponse("index.html", context)
 
 
 @app.websocket("/ws/editor")

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -9,6 +9,7 @@ from .configs import router as configs_router
 from .admin import router as admin_router
 from .audit import router as audit_router
 from .admin_debug import router as admin_debug_router
+from .welcome import router as welcome_router
 
 __all__ = [
     "auth_router",
@@ -22,4 +23,5 @@ __all__ = [
     "admin_router",
     "audit_router",
     "admin_debug_router",
+    "welcome_router",
 ]

--- a/app/routes/welcome.py
+++ b/app/routes/welcome.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Request, Depends
+from fastapi.templating import Jinja2Templates
+
+from app.utils.auth import get_current_user
+
+router = APIRouter()
+templates = Jinja2Templates(directory="app/templates")
+
+WELCOME_TEXT = {
+    "viewer": [
+        "Browse devices and view configuration history.",
+    ],
+    "user": [
+        "All viewer abilities", "Check switch port status",
+    ],
+    "editor": [
+        "All user abilities",
+        "Add or modify devices and VLANs",
+        "Push and pull configurations",
+    ],
+    "admin": [
+        "All editor abilities", "Manage system tunables",
+    ],
+    "superadmin": [
+        "All admin abilities",
+        "Manage credentials and view debug/audit logs",
+    ],
+}
+
+@router.get("/welcome/{role}")
+async def welcome_role(role: str, request: Request, current_user=Depends(get_current_user)):
+    text = WELCOME_TEXT.get(role, [])
+    context = {"request": request, "role": role, "text": text, "current_user": current_user}
+    return templates.TemplateResponse("welcome.html", context)

--- a/app/templates/audit_log.html
+++ b/app/templates/audit_log.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">Audit Log</h1>
-<table class="min-w-full bg-gray-800">
+<table class="min-w-full bg-black">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Timestamp</th>
@@ -14,7 +14,7 @@
   </thead>
   <tbody>
   {% for entry in logs %}
-    <tr class="border-t border-gray-700">
+    <tr class="border-t border-white">
       <td class="px-4 py-2">{{ entry.timestamp }}</td>
       <td class="px-4 py-2">{{ entry.user.email if entry.user else 'System' }}</td>
       <td class="px-4 py-2">{{ entry.device.hostname if entry.device else '' }}</td>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,10 +6,10 @@
     <title>CES Inventory</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
-<body class="bg-gray-900 text-gray-100">
-    <nav class="bg-gray-800 p-4 text-gray-200">
+<body class="bg-black text-white">
+    <nav class="bg-black p-4 text-white border-b border-white">
         <ul class="flex space-x-4">
-            <li><a href="#" class="hover:underline">Dashboard</a></li>
+            <li><a href="/" class="hover:underline">Home</a></li>
             <li><a href="/devices" class="hover:underline">Devices</a></li>
             <li><a href="/vlans" class="hover:underline">VLANs</a></li>
             {% if current_user and current_user.role == 'superadmin' %}
@@ -18,8 +18,14 @@
             <li><a href="/admin/audit" class="hover:underline">Audit Log</a></li>
             <li><a href="/admin/debug" class="hover:underline">Debug Logs</a></li>
             {% endif %}
+            {% if current_user %}
+            <li class="ml-auto"><a href="/auth/logout" class="hover:underline">Logout</a></li>
+            {% else %}
+            <li class="ml-auto"><a href="/auth/login" class="hover:underline">Login</a></li>
+            {% endif %}
         </ul>
     </nav>
+    <hr class="border-white">
     <div class="container mx-auto p-4">
         <p>{{ message }}</p>
         {% block content %}{% endblock %}

--- a/app/templates/config_diff.html
+++ b/app/templates/config_diff.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">Config Diff for {{ device.hostname }}</h1>
-<pre class="bg-gray-800 p-4 whitespace-pre-wrap overflow-x-auto">
+<pre class="bg-black p-4 whitespace-pre-wrap overflow-x-auto">
 {% for line in diff_lines %}
 <span class="{% if line.startswith('+') %}text-green-400{% elif line.startswith('-') %}text-red-400{% endif %}">{{ line }}</span>
 {% endfor %}

--- a/app/templates/config_list.html
+++ b/app/templates/config_list.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">Config Backups for {{ device.hostname }}</h1>
-<table class="min-w-full bg-gray-800">
+<table class="min-w-full bg-black">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Timestamp</th>
@@ -13,7 +13,7 @@
   </thead>
   <tbody>
   {% for backup in backups %}
-    <tr class="border-t border-gray-700">
+    <tr class="border-t border-white">
       <td class="px-4 py-2">{{ backup.created_at }}</td>
       <td class="px-4 py-2">{{ backup.source }}</td>
       <td class="px-4 py-2">

--- a/app/templates/debug_detail.html
+++ b/app/templates/debug_detail.html
@@ -8,6 +8,6 @@
   <strong>User:</strong> {{ log.user.email if log.user else 'System' }}<br>
   <strong>Action Type:</strong> {{ log.action_type }}
 </div>
-<pre class="bg-gray-800 p-4 whitespace-pre-wrap overflow-x-auto">{{ log.details }}</pre>
+<pre class="bg-black p-4 whitespace-pre-wrap overflow-x-auto">{{ log.details }}</pre>
 <a href="/admin/debug" class="underline">Back to Debug Logs</a>
 {% endblock %}

--- a/app/templates/debug_log.html
+++ b/app/templates/debug_log.html
@@ -26,7 +26,7 @@
     </select>
   </label>
 </form>
-<table class="min-w-full bg-gray-800">
+<table class="min-w-full bg-black">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Timestamp</th>
@@ -39,7 +39,7 @@
   </thead>
   <tbody>
   {% for entry in logs %}
-    <tr class="border-t border-gray-700">
+    <tr class="border-t border-white">
       <td class="px-4 py-2">{{ entry.timestamp }}</td>
       <td class="px-4 py-2">{{ entry.device.hostname if entry.device else '' }}</td>
       <td class="px-4 py-2">{{ entry.user.email if entry.user else 'System' }}</td>

--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -10,7 +10,7 @@
     <button type="submit" class="ml-2">🔄 Run Push Queue Now</button>
   </form>
 {% endif %}
-<table class="min-w-full bg-gray-800">
+<table class="min-w-full bg-black">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Hostname</th>
@@ -27,7 +27,7 @@
   </thead>
   <tbody>
   {% for device in devices %}
-    <tr class="border-t border-gray-700">
+    <tr class="border-t border-white">
       <td class="px-4 py-2">{{ device.hostname }}</td>
       <td class="px-4 py-2">{{ device.ip }}</td>
       <td class="px-4 py-2">{{ device.model or '' }}</td>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-2xl mb-4">Welcome to CES Inventory</h1>
+<p>This application lets you browse network devices and review configuration history.</p>
+<p class="mt-2">As a viewer you can:</p>
+<ul class="list-disc list-inside ml-4">
+  <li>See the list of registered devices</li>
+  <li>Browse saved configuration backups</li>
+  <li>Review audit information</li>
+</ul>
+<p class="mt-4">Log in to access additional features.</p>
+{% if not current_user %}
+<p class="mt-4"><a href="/auth/login" class="underline">Login</a></p>
+{% endif %}
+{% endblock %}

--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -5,7 +5,7 @@
 {% if error %}
   <p class="text-red-500 mb-4">{{ error }}</p>
 {% endif %}
-<table class="min-w-full bg-gray-800">
+<table class="min-w-full bg-black">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Port Name</th>
@@ -17,7 +17,7 @@
   </thead>
   <tbody>
   {% for port in ports %}
-    <tr class="border-t border-gray-700">
+    <tr class="border-t border-white">
       <td class="px-4 py-2">{{ port.name or port.descr }}</td>
       <td class="px-4 py-2">
         {% if port.oper_status == 'up' %}

--- a/app/templates/snmp_list.html
+++ b/app/templates/snmp_list.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="text-xl mb-4">SNMP Communities</h1>
 <a href="/admin/snmp/new" class="underline">Add SNMP Profile</a>
-<table class="min-w-full bg-gray-800 mt-4">
+<table class="min-w-full bg-black mt-4">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Name</th>
@@ -14,7 +14,7 @@
   </thead>
   <tbody>
   {% for profile in profiles %}
-    <tr class="border-t border-gray-700">
+    <tr class="border-t border-white">
       <td class="px-4 py-2">{{ profile.name }}</td>
       <td class="px-4 py-2">{{ profile.community_string }}</td>
       <td class="px-4 py-2">{{ profile.version }}</td>

--- a/app/templates/ssh_list.html
+++ b/app/templates/ssh_list.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="text-xl mb-4">SSH Credentials</h1>
 <a href="/admin/ssh/new" class="underline">Add SSH Credential</a>
-<table class="min-w-full bg-gray-800 mt-4">
+<table class="min-w-full bg-black mt-4">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Name</th>
@@ -13,7 +13,7 @@
   </thead>
   <tbody>
   {% for cred in creds %}
-    <tr class="border-t border-gray-700">
+    <tr class="border-t border-white">
       <td class="px-4 py-2">{{ cred.name }}</td>
       <td class="px-4 py-2">{{ cred.username }}</td>
       <td class="px-4 py-2">

--- a/app/templates/template_config_form.html
+++ b/app/templates/template_config_form.html
@@ -26,7 +26,7 @@
   {% if snippet %}
   <div>
     <label class="block">Rendered Config</label>
-    <pre class="bg-gray-800 p-2">{{ snippet }}</pre>
+    <pre class="bg-black p-2">{{ snippet }}</pre>
   </div>
   {% endif %}
   {% if message %}

--- a/app/templates/vlan_list.html
+++ b/app/templates/vlan_list.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="text-xl mb-4">VLANs</h1>
 <a href="/vlans/new" class="underline">Add VLAN</a>
-<table class="min-w-full bg-gray-800 mt-4">
+<table class="min-w-full bg-black mt-4">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Tag</th>
@@ -13,7 +13,7 @@
   </thead>
   <tbody>
   {% for vlan in vlans %}
-    <tr class="border-t border-gray-700">
+    <tr class="border-t border-white">
       <td class="px-4 py-2">{{ vlan.tag }}</td>
       <td class="px-4 py-2">{{ vlan.description or '' }}</td>
       <td class="px-4 py-2">

--- a/app/templates/welcome.html
+++ b/app/templates/welcome.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-2xl mb-4">Welcome {{ role|title }}</h1>
+<ul class="list-disc list-inside ml-4">
+{% for line in text %}
+  <li>{{ line }}</li>
+{% endfor %}
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- switch all templates to a black background and white text
- provide login links in the navigation bar
- create a homepage with a viewer guide
- add per‑role welcome pages
- include a new router for the welcome pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c9dad06c083249dde2dc05b89bfd8