### PR TITLE
Fix missing audit import for config diff route

### DIFF
--- a/app/routes/configs.py
+++ b/app/routes/configs.py
@@ -6,6 +6,7 @@ import difflib
 from app.utils.db_session import get_db
 from app.utils.auth import get_current_user
 from app.models.models import Device, ConfigBackup
+from app.utils.audit import log_audit
 
 templates = Jinja2Templates(directory="app/templates")
 


### PR DESCRIPTION
## Summary
- ensure `log_audit` is imported in `configs` routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb0e6a2348324b248d0bd4d154de4