### PR TITLE
Fix missing log_audit import

### DIFF
--- a/app/routes/configs.py
+++ b/app/routes/configs.py
@@ -6,6 +6,7 @@ import difflib
 from app.utils.db_session import get_db
 from app.utils.auth import get_current_user
 from app.models.models import Device, ConfigBackup
+from app.utils.audit import log_audit
 
 templates = Jinja2Templates(directory="app/templates")
 


### PR DESCRIPTION
## Summary
- import `log_audit` in `configs` routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684cb239c3e08324898a5653a33f48f4