### PR TITLE
Fix config pull command

### DIFF
--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -265,7 +265,8 @@ async def pull_device_config(
     output = ""
     try:
         async with asyncssh.connect(device.ip, **conn_kwargs) as conn:
-            result = await conn.run("echo test-config", check=False)
+            # Retrieve the device's running configuration
+            result = await conn.run("show running-config", check=False)
             output = result.stdout
     except Exception as exc:
         log_audit(db, current_user, "debug", device, f"SSH pull error: {exc}")


### PR DESCRIPTION
## Summary
- fix command for SSH config pulls to use `show running-config`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cb4925e8083248e11f29591e83228