### PR TITLE
Fix seed data IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ This application manages network devices, VLANs and configuration backups using 
    ```
    These commands create a SQLite database file named `ces_inventory.db` in the project directory.
 
-   **Note:** The sample devices created by `seed_data.py` use hostnames like
-   `SW10.x` as their IP addresses. These hostnames must resolve through DNS or
-   entries in `/etc/hosts`; otherwise operations such as "Pull Config" will fail
-   with a *Name or service not known* error. If no DNS records exist, edit the
-   devices in the UI or modify `seed_data.py` to specify real IP addresses.
+   **Note:** The sample devices created by `seed_data.py` use example IP
+   addresses in the `192.168.10.0/24` range. Adjust these addresses in
+   `seed_data.py` or modify the devices through the UI if they do not match your
+   environment.
 
 ## Running the server
 

--- a/seed_data.py
+++ b/seed_data.py
@@ -39,16 +39,16 @@ def main():
         # Seed sample switches if none exist
         if not db.query(Device).first():
             devices = [
-                ("SW10.1", "WS-C3560CX-12PC-S"),
-                ("SW10.2", "WS-C2960G-8TC-L"),
-                ("SW10.6", "WS-C2960C-12PC-L"),
-                ("SW10.10", "WS-C3850-48P-E"),
-                ("SW10.11", "WS-C3560CX-12PC-S"),
+                ("SW10.1", "192.168.10.1", "WS-C3560CX-12PC-S"),
+                ("SW10.2", "192.168.10.2", "WS-C2960G-8TC-L"),
+                ("SW10.6", "192.168.10.6", "WS-C2960C-12PC-L"),
+                ("SW10.10", "192.168.10.10", "WS-C3850-48P-E"),
+                ("SW10.11", "192.168.10.11", "WS-C3560CX-12PC-S"),
             ]
-            for hostname, model in devices:
+            for hostname, ip_address, model in devices:
                 device = Device(
                     hostname=hostname,
-                    ip=hostname,
+                    ip=ip_address,
                     model=model,
                     manufacturer="Cisco",
                     device_type_id=switch_type.id,


### PR DESCRIPTION
## Summary
- use real IP addresses instead of hostnames in `seed_data.py`
- update README note about seed device IP addresses

## Testing
- `python -m py_compile seed_data.py`

------
https://chatgpt.com/codex/tasks/task_e_684cba3d299083248dfd2000fff0b49c