### PR TITLE
Fix navbar device type list

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, Request, WebSocket, Depends
 from fastapi.staticfiles import StaticFiles
-from fastapi.templating import Jinja2Templates
+
 from starlette.middleware.sessions import SessionMiddleware
 
 from app.routes import (
@@ -25,23 +25,12 @@ from app.websockets.terminal import router as terminal_ws_router
 from app.routes.welcome import router as welcome_router, WELCOME_TEXT
 from app.utils.auth import get_current_user
 from app.tasks import start_queue_worker
-from app.utils.db_session import SessionLocal
-from app.models.models import DeviceType
+from app.utils.templates import templates
 
 app = FastAPI()
 start_queue_worker(app)
 
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
-templates = Jinja2Templates(directory="app/templates")
-
-# Provide device types for navbar dropdown
-def get_device_types():
-    db = SessionLocal()
-    types = db.query(DeviceType).all()
-    db.close()
-    return types
-
-templates.env.globals["get_device_types"] = get_device_types
 
 # Store login information in signed cookies
 app.add_middleware(SessionMiddleware, secret_key="change-me")

--- a/app/routes/admin_debug.py
+++ b/app/routes/admin_debug.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Request, Depends, HTTPException
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from sqlalchemy.orm import Session
 from typing import Optional
 
@@ -7,7 +7,7 @@ from app.utils.db_session import get_db
 from app.utils.auth import require_role
 from app.models.models import AuditLog, User, Device
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/admin_profiles.py
+++ b/app/routes/admin_profiles.py
@@ -1,13 +1,13 @@
 from fastapi import APIRouter, Request, Depends, HTTPException, Form
 from fastapi.responses import RedirectResponse
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from sqlalchemy.orm import Session
 
 from app.utils.db_session import get_db
 from app.utils.auth import require_role
 from app.models.models import SSHCredential, SNMPCommunity
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/audit.py
+++ b/app/routes/audit.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter, Request, Depends
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from sqlalchemy.orm import Session
 
 from app.utils.db_session import get_db
 from app.utils.auth import require_role
 from app.models.models import AuditLog, User, Device
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,13 +1,13 @@
 from fastapi import APIRouter, Request, Depends, Form, HTTPException
 from fastapi.responses import RedirectResponse
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from sqlalchemy.orm import Session
 
 from app.utils.db_session import get_db
 from app.utils import auth as auth_utils
 from app.models.models import User
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/configs.py
+++ b/app/routes/configs.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Request, Depends, HTTPException
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from sqlalchemy.orm import Session
 import difflib
 
@@ -8,7 +8,7 @@ from app.utils.auth import get_current_user
 from app.models.models import Device, ConfigBackup
 from app.utils.audit import log_audit
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/device_types.py
+++ b/app/routes/device_types.py
@@ -1,13 +1,13 @@
 from fastapi import APIRouter, Request, Depends, HTTPException, Form
 from fastapi.responses import RedirectResponse
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from sqlalchemy.orm import Session
 
 from app.utils.db_session import get_db
 from app.utils.auth import require_role
 from app.models.models import DeviceType
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -6,7 +6,7 @@ from fastapi import (
     Form,
 )
 from fastapi.responses import RedirectResponse
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from sqlalchemy.orm import Session
 
 from app.utils.db_session import get_db
@@ -28,7 +28,7 @@ from app.utils.ssh import build_conn_kwargs
 from puresnmp import Client, PyWrapper, V2C
 from puresnmp.exc import SnmpError
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/editor.py
+++ b/app/routes/editor.py
@@ -1,9 +1,9 @@
 from fastapi import APIRouter, Request, Depends
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from app.utils.auth import require_role
 
 router = APIRouter()
-templates = Jinja2Templates(directory="app/templates")
+
 
 
 @router.get("/editor")

--- a/app/routes/network.py
+++ b/app/routes/network.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter, Request, Depends, HTTPException
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from sqlalchemy.orm import Session
 
 from app.utils.db_session import get_db
 from app.utils.auth import get_current_user
 from app.models.models import Device
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/task_views.py
+++ b/app/routes/task_views.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter, Request, Depends, HTTPException
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from sqlalchemy.orm import Session
 
 from app.utils.db_session import get_db
 from app.utils.auth import get_current_user
 from app.models.models import ConfigBackup
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/tunables.py
+++ b/app/routes/tunables.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Request, Depends, Form
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 import subprocess
@@ -8,7 +8,7 @@ from app.utils.db_session import get_db
 from app.utils.auth import require_role
 from app.models.models import SystemTunable
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/user_management.py
+++ b/app/routes/user_management.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter, Request, Depends, HTTPException
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from sqlalchemy.orm import Session
 
 from app.utils.db_session import get_db
 from app.utils.auth import require_role
 from app.models.models import User
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/vlans.py
+++ b/app/routes/vlans.py
@@ -1,13 +1,13 @@
 from fastapi import APIRouter, Request, Depends, HTTPException, Form
 from fastapi.responses import RedirectResponse
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 from sqlalchemy.orm import Session
 
 from app.utils.db_session import get_db
 from app.utils.auth import require_role
 from app.models.models import VLAN
 
-templates = Jinja2Templates(directory="app/templates")
+
 
 router = APIRouter()
 

--- a/app/routes/welcome.py
+++ b/app/routes/welcome.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter, Request, Depends
-from fastapi.templating import Jinja2Templates
+from app.utils.templates import templates
 
 from app.utils.auth import get_current_user
 
 router = APIRouter()
-templates = Jinja2Templates(directory="app/templates")
+
 
 WELCOME_TEXT = {
     "viewer": [

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -1,0 +1,15 @@
+from fastapi.templating import Jinja2Templates
+from app.utils.db_session import SessionLocal
+from app.models.models import DeviceType
+
+templates = Jinja2Templates(directory="app/templates")
+
+
+def get_device_types():
+    db = SessionLocal()
+    types = db.query(DeviceType).all()
+    db.close()
+    return types
+
+# Make function available in Jinja templates
+templates.env.globals["get_device_types"] = get_device_types


### PR DESCRIPTION
## Summary
- centralize template handling with a common `templates` object
- update all route modules to use the shared templates

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684cba4feca083249e57da9ae1ba95fd