### PR TITLE
Add port config view and clean port status

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -93,6 +93,7 @@ class ConfigBackup(Base):
     source = Column(String, nullable=False)
     queued = Column(Boolean, default=False)
     status = Column(String, nullable=True)
+    port_name = Column(String, nullable=True)
 
     device = relationship("Device", back_populates="backups")
 

--- a/app/templates/port_config.html
+++ b/app/templates/port_config.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Port {{ port_name }} on {{ device.hostname }}</h1>
+{% if error %}
+<p class="text-red-500">{{ error }}</p>
+{% endif %}
+{% if message %}
+<p class="text-green-400">{{ message }}</p>
+{% endif %}
+{% if config %}
+<h2 class="text-lg mt-2">Current Config</h2>
+<pre class="bg-black p-2 whitespace-pre-wrap overflow-auto">{{ config }}</pre>
+{% endif %}
+{% if prev_config %}
+<h2 class="text-lg mt-4">Previous Config</h2>
+<pre class="bg-black p-2 whitespace-pre-wrap overflow-auto">{{ prev_config }}</pre>
+{% endif %}
+<h2 class="text-lg mt-4">Stage Change</h2>
+<form method="post" class="space-y-4">
+  <textarea name="config_text" rows="5" class="w-full p-2 text-black" required></textarea>
+  <div>
+    <button type="submit" class="bg-blue-600 px-4 py-2">Queue Change</button>
+    <a href="/devices/{{ device.id }}/ports" class="ml-2 underline">Back</a>
+  </div>
+</form>
+{% endblock %}

--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -13,6 +13,7 @@
       <th class="px-4 py-2 text-left">Admin State</th>
       <th class="px-4 py-2 text-left">Speed</th>
       <th class="px-4 py-2 text-left">Description</th>
+      <th class="px-4 py-2 text-left">Actions</th>
     </tr>
   </thead>
   <tbody>
@@ -27,8 +28,11 @@
         {% endif %}
       </td>
       <td class="px-4 py-2">{{ port.admin_status }}</td>
-      <td class="px-4 py-2">{{ port.speed }}</td>
+      <td class="px-4 py-2">{{ port.speed or '' }} Mbps</td>
       <td class="px-4 py-2">{{ port.alias or '' }}</td>
+      <td class="px-4 py-2">
+        <a href="/devices/{{ device.id }}/ports/{{ port.name }}/config" class="text-blue-400 underline">Config</a>
+      </td>
     </tr>
   {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- decode SNMP values so port names & descriptions no longer show byte strings
- display port speeds in Mbps
- add a column on the port status page with a link to per-port configuration
- implement per-port configuration view with ability to stage changes
- store port name in config backups

## Testing
- `python -m py_compile app/routes/devices.py app/models/models.py`

------
https://chatgpt.com/codex/tasks/task_e_684cbe6176188324bb6f7af8b06f9ef0