### PR TITLE
Add switch view above port table

### DIFF
--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -5,6 +5,16 @@
 {% if error %}
   <p class="text-red-500 mb-4">{{ error }}</p>
 {% endif %}
+<div class="grid grid-cols-8 gap-1 mb-4">
+  {% for port in ports %}
+    <div
+      class="w-8 h-8 flex items-center justify-center text-xs text-white {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
+      title="{{ port.name or port.descr }}"
+    >
+      {{ loop.index }}
+    </div>
+  {% endfor %}
+</div>
 <table class="min-w-full bg-black">
   <thead>
     <tr>


### PR DESCRIPTION
## Summary
- show a grid of port indicators before the port stats table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cc1576e088324bdaa8e978cb137e2