### PR TITLE
Add switch view above port table

### DIFF
--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -538,6 +538,68 @@ async def _gather_snmp_table(client: PyWrapper, oid: str) -> dict:
     return data
 
 
+def _layout_ports(ports: list[dict]) -> list[list[dict]]:
+    """Return port rows for switch view based on port count."""
+    n = len(ports)
+
+    # 8 ports - two blocks of four on one line
+    if n == 8:
+        return [ports]
+
+    # 10 ports - 4/4 on first line, 2 on second
+    if n == 10:
+        return [ports[:8], ports[8:]]
+
+    # 12-23 ports - blocks of 6 with extras handled specially
+    if 12 <= n < 24:
+        rows: list[list[dict]] = []
+        idx = 0
+        while idx + 6 <= n:
+            rows.append(ports[idx : idx + 6])
+            idx += 6
+
+        remainder = n - idx
+        extras = ports[idx:]
+
+        if remainder == 2:
+            if rows:
+                rows[-1].extend(extras)
+            else:
+                rows.append(extras)
+        elif remainder == 4:
+            # split two ports between the last two rows
+            if len(rows) >= 2:
+                rows[-2].extend(extras[:2])
+                rows[-1].extend(extras[2:])
+            elif len(rows) == 1:
+                rows.append(extras[:2])
+                rows[0].extend(extras[2:])
+        elif remainder:
+            rows.append(extras)
+        return rows
+
+    # 24 or more ports - two lines of 12 with limited extras
+    if n >= 24:
+        row1 = ports[:12]
+        row2 = ports[12:24]
+        rows = [row1, row2]
+
+        extras = ports[24:]
+        if len(extras) == 2:
+            rows.append(extras)
+        elif len(extras) == 4:
+            rows[0].extend(extras[:2])
+            rows[1].extend(extras[2:])
+        elif extras:
+            # generic handling for larger counts
+            for i in range(0, len(extras), 12):
+                rows.append(extras[i : i + 12])
+        return rows
+
+    # default fallback
+    return [ports]
+
+
 @router.get("/devices/{device_id}/ports")
 async def port_status(
     device_id: int,
@@ -610,6 +672,7 @@ async def port_status(
         "request": request,
         "device": device,
         "ports": ports,
+        "port_rows": _layout_ports(ports),
         "error": None,
         "current_user": current_user,
     }

--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -5,6 +5,21 @@
 {% if error %}
   <p class="text-red-500 mb-4">{{ error }}</p>
 {% endif %}
+<div class="space-y-1 mb-4">
+  {% for row in port_rows %}
+  <div class="grid grid-cols-{{ row|length }} gap-1 justify-center">
+    {% for port in row %}
+      <div
+        class="w-20 h-12 flex flex-col items-center justify-center text-xs text-white {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
+        title="{{ port.descr or port.name }}"
+      >
+        <span>{{ port.name }}</span>
+        <span>{{ port.speed }}{% if port.speed %}M{% endif %}</span>
+      </div>
+    {% endfor %}
+  </div>
+  {% endfor %}
+</div>
 <table class="min-w-full bg-black">
   <thead>
     <tr>


### PR DESCRIPTION
## Summary
- group ports into rows for switch-like view
- show port name and speed indicators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cc1576e088324bdaa8e978cb137e2