### PR TITLE
Fix missing loop terminator in port template

### DIFF
--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -18,6 +18,8 @@
       </div>
     {% endfor %}
   </div>
+  {% endfor %}
+</div>
 <div class="grid grid-cols-8 gap-1 mb-4">
   {% for port in ports %}
     <div


### PR DESCRIPTION
## Summary
- fix missing `{% endfor %}` in `port_status.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc49cd4748324b232300d7a600762