### PR TITLE
Improve port status display

### DIFF
--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h1 class="text-xl mb-4">Port Status for {{ device.hostname }}</h1>
+<h1 class="text-xl mb-2">Port Status for {{ device.hostname }}</h1>
+<a href="/devices" class="underline inline-block mb-4">Back to Devices</a>
 {% if error %}
   <p class="text-red-500 mb-4">{{ error }}</p>
 {% endif %}
@@ -20,16 +21,21 @@
   </div>
   {% endfor %}
 </div>
-<div class="grid grid-cols-8 gap-1 mb-4">
-  {% for port in ports %}
+{% if virtual_ports %}
+<hr class="my-4">
+<h2 class="text-lg mb-2">Virtual Ports</h2>
+<div class="flex flex-wrap gap-1 mb-4">
+  {% for port in virtual_ports %}
     <div
-      class="w-8 h-8 flex items-center justify-center text-xs text-white {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
-      title="{{ port.name or port.descr }}"
+      class="w-20 h-12 flex flex-col items-center justify-center text-xs text-white {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
+      title="{{ port.descr or port.name }}"
     >
-      {{ loop.index }}
+      <span>{{ port.name }}</span>
+      <span>{{ port.speed }}{% if port.speed %}M{% endif %}</span>
     </div>
   {% endfor %}
 </div>
+{% endif %}
 <table class="min-w-full bg-black">
   <thead>
     <tr>


### PR DESCRIPTION
## Summary
- add back button on port status page
- remove outdated port number grid
- split physical and virtual ports in port status view

## Testing
- `python -m py_compile app/routes/devices.py`

------
https://chatgpt.com/codex/tasks/task_e_684cc5c4ffa48324849015915694c60c