### PR TITLE
Organize port view in panes

### DIFF
--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -6,18 +6,22 @@
 {% if error %}
   <p class="text-red-500 mb-4">{{ error }}</p>
 {% endif %}
-<div class="space-y-1 mb-4">
-  {% for row in port_rows %}
-  <div class="grid grid-cols-{{ row|length }} gap-1 justify-center">
-    {% for port in row %}
-      <div
-        id="port-{{ port.name|replace('/', '-') }}"
-        class="w-20 h-12 flex flex-col items-center justify-center text-xs text-white {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
-        title="{{ port.descr or port.name }}"
-      >
-        <span>{{ port.name }}</span>
-        <span class="port-rate">--</span>
-      </div>
+<div class="flex flex-wrap gap-4 mb-4">
+  {% for pane in port_panes %}
+  <div class="space-y-0.5">
+    {% for row in pane %}
+    <div class="grid grid-cols-3 gap-0.5 justify-center">
+      {% for port in row %}
+        <div
+          id="port-{{ port.name|replace('/', '-') }}"
+          class="w-20 h-12 flex flex-col items-center justify-center text-xs text-white rounded-md {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
+          title="{{ port.descr or port.name }}"
+        >
+          <span>{{ port.name }}</span>
+          <span class="port-rate">--</span>
+        </div>
+      {% endfor %}
+    </div>
     {% endfor %}
   </div>
   {% endfor %}


### PR DESCRIPTION
## Summary
- reorganize physical interfaces into panes of six
- display odd-numbered ports on top and even on bottom
- soften port box corners and tighten grid spacing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ccb6833dc83249e0e9baf99bf3d4c