### PR TITLE
Fix port status grid

### DIFF
--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -544,20 +544,16 @@ async def _gather_snmp_table(client: PyWrapper, oid: str) -> dict:
 
 
 def _layout_ports(ports: list[dict]) -> list[list[list[dict]]]:
-    """Return port panes with odd/even rows for switch view."""
+    """Return port panes of six interfaces arranged two per row."""
     panes: list[list[list[dict]]] = []
     idx = 0
     n = len(ports)
     while idx < n:
         chunk = ports[idx : idx + 6]
-        odd_row: list[dict] = []
-        even_row: list[dict] = []
-        for pos, port in enumerate(chunk):
-            if pos % 2 == 0:
-                odd_row.append(port)
-            else:
-                even_row.append(port)
-        panes.append([odd_row, even_row])
+        rows: list[list[dict]] = []
+        for i in range(0, len(chunk), 2):
+            rows.append(chunk[i : i + 2])
+        panes.append(rows)
         idx += 6
     return panes
 

--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -10,11 +10,11 @@
   {% for pane in port_panes %}
   <div class="space-y-0.5">
     {% for row in pane %}
-    <div class="grid grid-cols-3 gap-0.5 justify-center">
+    <div class="grid grid-cols-2 gap-0.5 justify-center">
       {% for port in row %}
         <div
           id="port-{{ port.name|replace('/', '-') }}"
-          class="w-40 h-24 flex flex-col items-center justify-center text-xs text-white rounded-md {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
+          class="w-20 h-12 flex flex-col items-center justify-center text-xs text-white rounded-md {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
           title="{{ port.descr or port.name }}"
         >
           <span>{{ port.name }}</span>
@@ -38,7 +38,7 @@
   {% for port in virtual_ports %}
     <div
       id="port-{{ port.name|replace('/', '-') }}"
-      class="w-40 h-24 flex flex-col items-center justify-center text-xs text-white {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
+      class="w-20 h-12 flex flex-col items-center justify-center text-xs text-white {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
       title="{{ port.descr or port.name }}"
     >
       <span>{{ port.name }}</span>


### PR DESCRIPTION
## Summary
- adjust `_layout_ports` to arrange two interfaces per row
- make port status panes show 2 interfaces per row and smaller boxes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cce7e5554832492a8f9bd56e20b0c