### PR TITLE
Improve port status pane layout

### DIFF
--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -544,17 +544,26 @@ async def _gather_snmp_table(client: PyWrapper, oid: str) -> dict:
 
 
 def _layout_ports(ports: list[dict]) -> list[list[list[dict]]]:
-    """Return port panes of six interfaces arranged two per row."""
+    """Return port panes of six interfaces with odd/even layout.
+
+    Each pane contains up to six interfaces displayed across two rows.  The
+    first row shows the odd-numbered ports from the chunk of six while the
+    second row shows the even-numbered ports.  This mirrors the typical switch
+    layout where ports increment left to right and odd numbers appear above the
+    corresponding even numbers.
+    """
+
     panes: list[list[list[dict]]] = []
     idx = 0
     n = len(ports)
     while idx < n:
         chunk = ports[idx : idx + 6]
-        rows: list[list[dict]] = []
-        for i in range(0, len(chunk), 2):
-            rows.append(chunk[i : i + 2])
-        panes.append(rows)
+        # Arrange odd numbered interfaces on the top row and even on the bottom
+        odd_row = chunk[0::2]
+        even_row = chunk[1::2]
+        panes.append([odd_row, even_row])
         idx += 6
+
     return panes
 
 

--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -6,11 +6,11 @@
 {% if error %}
   <p class="text-red-500 mb-4">{{ error }}</p>
 {% endif %}
-<div class="grid grid-cols-2 gap-4 mb-4">
+<div class="grid grid-cols-2 gap-4 mb-4 justify-center">
   {% for pane in port_panes %}
-  <div class="space-y-0.5">
+  <div class="space-y-0.5 w-1/3">
     {% for row in pane %}
-    <div class="grid grid-cols-2 gap-0.5 justify-center">
+    <div class="grid grid-cols-3 gap-0.5 justify-center">
       {% for port in row %}
         <div
           id="port-{{ port.name|replace('/', '-') }}"


### PR DESCRIPTION
## Summary
- arrange ports in each pane with odd numbers above even numbers
- adjust port pane width and grid layout

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cd01bc32c8324b1e2ce2c8a448946