### PR TITLE
Enlarge port status panes

### DIFF
--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -6,15 +6,16 @@
 {% if error %}
   <p class="text-red-500 mb-4">{{ error }}</p>
 {% endif %}
-<div class="grid grid-cols-2 gap-4 mb-4 justify-center">
+<div class="grid grid-cols-2 gap-4 mb-4 justify-center mx-auto">
   {% for pane in port_panes %}
-  <div class="space-y-0.5 w-1/3">
+  <div class="space-y-0.5" style="width: 43%;">
     {% for row in pane %}
     <div class="grid grid-cols-3 gap-0.5 justify-center">
       {% for port in row %}
         <div
           id="port-{{ port.name|replace('/', '-') }}"
-          class="w-20 h-12 flex flex-col items-center justify-center text-xs text-white rounded-md {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
+          class="flex flex-col items-center justify-center text-xs text-white rounded-md {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
+          style="width:6.5rem;height:3.9rem;"
           title="{{ port.descr or port.name }}"
         >
           <span>{{ port.name }}</span>
@@ -34,11 +35,12 @@
 {% if virtual_ports %}
 <hr class="my-4">
 <h2 class="text-lg mb-2">Virtual Ports</h2>
-<div class="flex flex-wrap gap-1 mb-4">
+<div class="flex flex-wrap gap-1 mb-4 justify-center">
   {% for port in virtual_ports %}
     <div
       id="port-{{ port.name|replace('/', '-') }}"
-      class="w-20 h-12 flex flex-col items-center justify-center text-xs text-white {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
+      class="flex flex-col items-center justify-center text-xs text-white {% if port.oper_status == 'up' %}bg-green-600{% else %}bg-red-600{% endif %}"
+      style="width:6.5rem;height:3.9rem;"
       title="{{ port.descr or port.name }}"
     >
       <span>{{ port.name }}</span>


### PR DESCRIPTION
## Summary
- enlarge panes in `port_status.html`
- enlarge port boxes and center panes on the page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cd3b856d48324b4fe6c7c49a48edf