### PR TITLE
Add 'add as template' for port configs

### DIFF
--- a/app/routes/port_config_templates.py
+++ b/app/routes/port_config_templates.py
@@ -18,8 +18,22 @@ async def list_port_configs(request: Request, db: Session = Depends(get_db), cur
 
 
 @router.get("/network/port-configs/new")
-async def new_port_config_form(request: Request, current_user=Depends(require_role("editor"))):
-    context = {"request": request, "template": None, "form_title": "New Port Config", "error": None, "current_user": current_user}
+async def new_port_config_form(
+    request: Request,
+    config_text: str | None = None,
+    name: str | None = None,
+    current_user=Depends(require_role("editor")),
+):
+    template_data = None
+    if config_text is not None or name is not None:
+        template_data = {"name": name or "", "config_text": config_text or ""}
+    context = {
+        "request": request,
+        "template": template_data,
+        "form_title": "New Port Config",
+        "error": None,
+        "current_user": current_user,
+    }
     return templates.TemplateResponse("port_config_template_form.html", context)
 
 

--- a/app/templates/port_config.html
+++ b/app/templates/port_config.html
@@ -9,11 +9,25 @@
 <p class="text-green-400">{{ message }}</p>
 {% endif %}
 {% if config %}
-<h2 class="text-lg mt-2">Current Config</h2>
+<h2 class="text-lg mt-2 flex items-center">
+  Current Config
+  <a
+    href="/network/port-configs/new?config_text={{ config|urlencode }}"
+    class="ml-2 underline text-sm text-blue-400"
+    >Add as Template</a
+  >
+</h2>
 <pre class="bg-black p-2 whitespace-pre-wrap overflow-auto">{{ config }}</pre>
 {% endif %}
 {% if prev_config %}
-<h2 class="text-lg mt-4">Previous Config</h2>
+<h2 class="text-lg mt-4 flex items-center">
+  Previous Config
+  <a
+    href="/network/port-configs/new?config_text={{ prev_config|urlencode }}"
+    class="ml-2 underline text-sm text-blue-400"
+    >Add as Template</a
+  >
+</h2>
 <pre class="bg-black p-2 whitespace-pre-wrap overflow-auto">{{ prev_config }}</pre>
 {% endif %}
 <h2 class="text-lg mt-4">Stage Change</h2>


### PR DESCRIPTION
## Summary
- allow port config template form to accept default config text
- add links on current/previous port configs to create templates prefilled

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cdba9e0dc832483354e092daa5a60