### PR TITLE
Add CSV upload function to Tasks

### DIFF
--- a/app/routes/task_views.py
+++ b/app/routes/task_views.py
@@ -3,13 +3,58 @@ from app.utils.templates import templates
 from sqlalchemy.orm import Session
 
 from app.utils.db_session import get_db
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, Response
+from fastapi import UploadFile, File, Form
 from app.utils.auth import get_current_user, require_role
-from app.models.models import ConfigBackup, Device
+from app.models.models import (
+    ConfigBackup,
+    Device,
+    VLAN,
+    DeviceType,
+    SSHCredential,
+    SNMPCommunity,
+    PortConfigTemplate,
+)
+import csv
+import io
 
 
 
 router = APIRouter()
+
+# Map user-facing table names to SQLAlchemy models and fields for CSV upload
+CSV_TABLES = {
+    "devices": {
+        "model": Device,
+        "fields": [
+            "hostname",
+            "ip",
+            "mac",
+            "model",
+            "manufacturer",
+            "device_type_id",
+            "location",
+            "status",
+            "vlan_id",
+            "ssh_credential_id",
+            "snmp_community_id",
+        ],
+    },
+    "vlans": {"model": VLAN, "fields": ["tag", "description"]},
+    "device_types": {"model": DeviceType, "fields": ["name", "manufacturer"]},
+    "ssh_credentials": {
+        "model": SSHCredential,
+        "fields": ["name", "username", "password", "private_key"],
+    },
+    "snmp_communities": {
+        "model": SNMPCommunity,
+        "fields": ["name", "community_string", "version"],
+    },
+    "port_config_templates": {
+        "model": PortConfigTemplate,
+        "fields": ["name", "config_text"],
+    },
+}
 
 
 @router.get("/tasks")
@@ -22,11 +67,13 @@ async def list_tasks(
         raise HTTPException(status_code=401, detail="Not authenticated")
     queued = db.query(ConfigBackup).filter(ConfigBackup.queued == True).all()
     devices = db.query(Device).all()
+    message = request.query_params.get("message")
     context = {
         "request": request,
         "queued": queued,
         "devices": devices,
         "current_user": current_user,
+        "message": message,
     }
     return templates.TemplateResponse("tasks.html", context)
 
@@ -41,3 +88,39 @@ async def live_session(
     if not device:
         raise HTTPException(status_code=404, detail="Device not found")
     return RedirectResponse(url=f"/devices/{device_id}/terminal")
+
+
+@router.get("/tasks/download-template/{table_name}")
+async def download_template(table_name: str):
+    table = CSV_TABLES.get(table_name)
+    if not table:
+        raise HTTPException(status_code=404, detail="Invalid table")
+    header = ",".join(table["fields"]) + "\n"
+    return Response(
+        content=header,
+        media_type="text/csv",
+        headers={"Content-Disposition": f"attachment; filename={table_name}_template.csv"},
+    )
+
+
+@router.post("/tasks/upload-csv")
+async def upload_csv(
+    table_name: str = Form(...),
+    csv_file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("editor")),
+):
+    table = CSV_TABLES.get(table_name)
+    if not table:
+        raise HTTPException(status_code=400, detail="Invalid table")
+
+    content = await csv_file.read()
+    reader = csv.DictReader(io.StringIO(content.decode()))
+    model = table["model"]
+    fields = table["fields"]
+    for row in reader:
+        data = {field: row.get(field) or None for field in fields}
+        record = model(**data)
+        db.add(record)
+    db.commit()
+    return RedirectResponse(url="/tasks?message=CSV+uploaded", status_code=302)

--- a/app/templates/tasks.html
+++ b/app/templates/tasks.html
@@ -32,4 +32,36 @@
   </select>
   <button type="submit" class="bg-blue-600 px-3 py-1">Connect</button>
 </form>
+
+<hr class="my-4">
+<h2 class="text-lg mb-2">Upload CSV</h2>
+<form method="post" action="/tasks/upload-csv" enctype="multipart/form-data" class="space-y-2">
+  <div>
+    <label class="block">Table</label>
+    <select name="table_name" class="p-1 text-black">
+      <option value="devices">Devices</option>
+      <option value="vlans">VLANs</option>
+      <option value="device_types">Device Types</option>
+      <option value="ssh_credentials">SSH Credentials</option>
+      <option value="snmp_communities">SNMP Communities</option>
+      <option value="port_config_templates">Port Config Templates</option>
+    </select>
+    <a href="#" id="download-template" class="ml-2 underline text-blue-400">Download CSV template</a>
+  </div>
+  <div>
+    <input type="file" name="csv_file" accept=".csv" class="text-black" required />
+  </div>
+  <button type="submit" class="bg-blue-600 px-3 py-1">Upload</button>
+</form>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ super() }}
+<script>
+document.getElementById('download-template').addEventListener('click', function(e) {
+  e.preventDefault();
+  const table = document.querySelector('select[name="table_name"]').value;
+  window.location.href = `/tasks/download-template/${table}`;
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add CSV upload and template download routes
- extend tasks page with table selector, template download, and file upload
- return status messages for uploads

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684cdec677a0832498b61eb5e347bbef