### PR TITLE
Add duplicate tracking and asset tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Visit [http://localhost:8000](http://localhost:8000) in your browser. Log in wit
 - **Password:** `C0pperpa!r`
 
 After logging in you can add devices, VLANs and manage configuration backups through the web interface.
+The **Devices** menu also includes a *Duplicate Checker* page to locate records sharing the same IP, MAC or asset tag and to list devices missing these values.
 If the login form reports **Invalid credentials**, run `python seed_superuser.py` again to ensure the password is stored correctly.
 
 

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -60,8 +60,9 @@ class Device(Base):
 
     id = Column(Integer, primary_key=True)
     hostname = Column(String, unique=True, nullable=False)
-    ip = Column(String, unique=True, nullable=False)
+    ip = Column(String, nullable=False)
     mac = Column(String, nullable=True)
+    asset_tag = Column(String, nullable=True)
     model = Column(String, nullable=True)
     manufacturer = Column(String, nullable=False)
     device_type_id = Column(Integer, ForeignKey("device_types.id"), nullable=False)

--- a/app/static/dark.css
+++ b/app/static/dark.css
@@ -39,6 +39,10 @@ textarea {
   background-color: #343a40;
 }
 
+.duplicate {
+  background-color: #7f1d1d;
+}
+
 .navbar .dropdown:hover .dropdown-menu {
   display: block;
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,6 +25,7 @@
                 <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Devices</a>
                 <ul class="dropdown-menu">
                   <li><a class="dropdown-item" href="/devices">All Devices</a></li>
+                  <li><a class="dropdown-item" href="/devices/duplicates">Duplicate Checker</a></li>
                   {% for dtype in get_device_types() %}
                   <li><a class="dropdown-item" href="/devices/type/{{ dtype.id }}">{{ dtype.name }}</a></li>
                   {% endfor %}

--- a/app/templates/device_duplicates.html
+++ b/app/templates/device_duplicates.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">Duplicate Report</h1>
+<h2 class="text-lg mt-4">Duplicate IP Addresses</h2>
+<ul class="list-disc ml-6">
+  {% for ip, devs in ip_dupes.items() %}
+  <li>{{ ip }}:
+    {% for d in devs %}
+    <a href="/devices/{{ d.id }}/edit" class="underline">{{ d.hostname }}</a>{% if not loop.last %}, {% endif %}
+    {% endfor %}
+  </li>
+  {% else %}
+  <li>No duplicates</li>
+  {% endfor %}
+</ul>
+<h2 class="text-lg mt-4">Duplicate MAC Addresses</h2>
+<ul class="list-disc ml-6">
+  {% for mac, devs in mac_dupes.items() %}
+  <li>{{ mac }}:
+    {% for d in devs %}
+    <a href="/devices/{{ d.id }}/edit" class="underline">{{ d.hostname }}</a>{% if not loop.last %}, {% endif %}
+    {% endfor %}
+  </li>
+  {% else %}
+  <li>No duplicates</li>
+  {% endfor %}
+</ul>
+<h2 class="text-lg mt-4">Duplicate Asset Tags</h2>
+<ul class="list-disc ml-6">
+  {% for tag, devs in tag_dupes.items() %}
+  <li>{{ tag }}:
+    {% for d in devs %}
+    <a href="/devices/{{ d.id }}/edit" class="underline">{{ d.hostname }}</a>{% if not loop.last %}, {% endif %}
+    {% endfor %}
+  </li>
+  {% else %}
+  <li>No duplicates</li>
+  {% endfor %}
+</ul>
+<h2 class="text-lg mt-4">Missing Fields</h2>
+<ul class="list-disc ml-6">
+  <li>Missing IP:
+    {% for d in missing.ip %}<a href="/devices/{{ d.id }}/edit" class="underline">{{ d.hostname }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+    {% if not missing.ip %}None{% endif %}
+  </li>
+  <li>Missing MAC:
+    {% for d in missing.mac %}<a href="/devices/{{ d.id }}/edit" class="underline">{{ d.hostname }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+    {% if not missing.mac %}None{% endif %}
+  </li>
+  <li>Missing Asset Tag:
+    {% for d in missing.asset_tag %}<a href="/devices/{{ d.id }}/edit" class="underline">{{ d.hostname }}</a>{% if not loop.last %}, {% endif %}{% endfor %}
+    {% if not missing.asset_tag %}None{% endif %}
+  </li>
+</ul>
+{% endblock %}

--- a/app/templates/device_form.html
+++ b/app/templates/device_form.html
@@ -16,6 +16,10 @@
     <input type="text" name="mac" value="{{ device.mac if device else '' }}" class="w-full p-2 text-black" />
   </div>
   <div>
+    <label class="block">Asset Tag</label>
+    <input type="text" name="asset_tag" value="{{ device.asset_tag if device else '' }}" class="w-full p-2 text-black" />
+  </div>
+  <div>
     <label class="block">Model</label>
     <input type="text" name="model" value="{{ device.model if device else '' }}" class="w-full p-2 text-black" />
   </div>

--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -17,6 +17,8 @@
       <th class="px-2"><input type="checkbox" id="select-all"></th>
       <th class="px-4 py-2 text-left">Hostname</th>
       <th class="px-4 py-2 text-left">IP</th>
+      <th class="px-4 py-2 text-left">MAC</th>
+      <th class="px-4 py-2 text-left">Asset Tag</th>
       <th class="px-4 py-2 text-left">Model</th>
       <th class="px-4 py-2 text-left">Manufacturer</th>
       <th class="px-4 py-2 text-left">Type</th>
@@ -34,7 +36,9 @@
     <tr class="border-t border-white">
       <td class="px-2"><input type="checkbox" name="selected" value="{{ device.id }}"></td>
       <td class="px-4 py-2">{{ device.hostname }}</td>
-      <td class="px-4 py-2">{{ device.ip }}</td>
+      <td class="px-4 py-2 {% if device.ip and duplicate_ips.get(device.ip) %}duplicate{% endif %}" title="{{ duplicate_ips.get(device.ip)|join(', ') if duplicate_ips.get(device.ip) }}">{{ device.ip }}</td>
+      <td class="px-4 py-2 {% if device.mac and duplicate_macs.get(device.mac) %}duplicate{% endif %}" title="{{ duplicate_macs.get(device.mac)|join(', ') if duplicate_macs.get(device.mac) }}">{{ device.mac or '' }}</td>
+      <td class="px-4 py-2 {% if device.asset_tag and duplicate_tags.get(device.asset_tag) %}duplicate{% endif %}" title="{{ duplicate_tags.get(device.asset_tag)|join(', ') if duplicate_tags.get(device.asset_tag) }}">{{ device.asset_tag or '' }}</td>
       <td class="px-4 py-2">{{ device.model or '' }}</td>
       <td class="px-4 py-2">{{ device.manufacturer }}</td>
       <td class="px-4 py-2">{{ device.device_type.name if device.device_type else '' }}</td>

--- a/seed_data.py
+++ b/seed_data.py
@@ -39,16 +39,17 @@ def main():
         # Seed sample switches if none exist
         if not db.query(Device).first():
             devices = [
-                ("SW10.1", "192.168.10.1", "WS-C3560CX-12PC-S"),
-                ("SW10.2", "192.168.10.2", "WS-C2960G-8TC-L"),
-                ("SW10.6", "192.168.10.6", "WS-C2960C-12PC-L"),
-                ("SW10.10", "192.168.10.10", "WS-C3850-48P-E"),
-                ("SW10.11", "192.168.10.11", "WS-C3560CX-12PC-S"),
+                ("SW10.1", "192.168.10.1", "WS-C3560CX-12PC-S", "AT-1001"),
+                ("SW10.2", "192.168.10.2", "WS-C2960G-8TC-L", "AT-1002"),
+                ("SW10.6", "192.168.10.6", "WS-C2960C-12PC-L", "AT-1003"),
+                ("SW10.10", "192.168.10.10", "WS-C3850-48P-E", "AT-1004"),
+                ("SW10.11", "192.168.10.11", "WS-C3560CX-12PC-S", "AT-1005"),
             ]
-            for hostname, ip_address, model in devices:
+            for hostname, ip_address, model, atag in devices:
                 device = Device(
                     hostname=hostname,
                     ip=ip_address,
+                    asset_tag=atag,
                     model=model,
                     manufacturer="Cisco",
                     device_type_id=switch_type.id,


### PR DESCRIPTION
## Summary
- track duplicate IP, MAC and asset tags
- add asset tag field to devices and forms
- highlight duplicates in device list
- include duplicate checker page and navigation
- style duplicates in dark theme
- update sample data and docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ce2cf94a48324b284e0bc5702d238