### PR TITLE
Add Google Sheets integration for tables

### DIFF
--- a/app/templates/google_sheets.html
+++ b/app/templates/google_sheets.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Google Sheets Integration</h1>
+
+<form method="post" action="/tasks/google-sheets-config" class="space-y-2 mb-4">
+  <div>
+    <label class="block">Service Account JSON Path</label>
+    <input type="text" name="service_account_json" value="{{ config.creds }}" class="text-black w-96">
+  </div>
+  <div>
+    <label class="block">Spreadsheet ID</label>
+    <input type="text" name="spreadsheet_id" value="{{ config.sheet_id }}" class="text-black w-96">
+  </div>
+  <button type="submit" class="bg-blue-600 px-3 py-1">Save</button>
+</form>
+
+<hr class="my-4">
+<h2 class="text-lg mb-2">Export Table to Sheets</h2>
+<form method="post" action="/tasks/export-google" class="space-y-2 mb-4">
+  <select name="table_name" class="p-1 text-black">
+    <option value="devices">Devices</option>
+    <option value="vlans">VLANs</option>
+    <option value="device_types">Device Types</option>
+    <option value="ssh_credentials">SSH Credentials</option>
+    <option value="snmp_communities">SNMP Communities</option>
+    <option value="port_config_templates">Port Config Templates</option>
+  </select>
+  <button type="submit" class="bg-blue-600 px-3 py-1">Export</button>
+</form>
+
+<hr class="my-4">
+<h2 class="text-lg mb-2">Import Table from Sheets</h2>
+<form method="post" action="/tasks/import-google" class="space-y-2 mb-4">
+  <select name="table_name" class="p-1 text-black">
+    <option value="devices">Devices</option>
+    <option value="vlans">VLANs</option>
+    <option value="device_types">Device Types</option>
+    <option value="ssh_credentials">SSH Credentials</option>
+    <option value="snmp_communities">SNMP Communities</option>
+    <option value="port_config_templates">Port Config Templates</option>
+  </select>
+  <button type="submit" class="bg-blue-600 px-3 py-1">Import</button>
+</form>
+{% endblock %}

--- a/app/templates/tasks.html
+++ b/app/templates/tasks.html
@@ -53,6 +53,10 @@
   </div>
   <button type="submit" class="bg-blue-600 px-3 py-1">Upload</button>
 </form>
+
+<hr class="my-4">
+<h2 class="text-lg mb-2">Google Sheets</h2>
+<a href="/tasks/google-sheets" class="underline">Configure Google Sheets Integration</a>
 {% endblock %}
 
 {% block extra_scripts %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ itsdangerous
 bcrypt
 puresnmp
 websockets
+gspread
+google-auth

--- a/seed_tunables.py
+++ b/seed_tunables.py
@@ -34,6 +34,22 @@ def main():
                 options="v1,v2c,v3",
                 description="SNMP protocol version used for device queries",
             ),
+            SystemTunable(
+                name="Google Service Account JSON",
+                value="service_account.json",
+                function="Google Sheets",
+                file_type="application",
+                data_type="text",
+                description="Path to service account credentials",
+            ),
+            SystemTunable(
+                name="Google Spreadsheet ID",
+                value="",
+                function="Google Sheets",
+                file_type="application",
+                data_type="text",
+                description="Target spreadsheet ID",
+            ),
         ]
         db.add_all(samples)
         db.commit()


### PR DESCRIPTION
## Summary
- allow configuring Google Sheets credentials via new task page
- export/import database tables to/from Google Sheets
- add links from Tasks page
- seed default tunables for Google Sheets
- include gspread dependencies

## Testing
- `python -m py_compile app/routes/task_views.py seed_tunables.py`

------
https://chatgpt.com/codex/tasks/task_e_684cebe85254832489d406ee76b96ef9