### PR TITLE
Improve navigation and add back button

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -42,6 +42,15 @@
                   <li><a class="dropdown-item" href="/network/port-configs">Port Configs</a></li>
                 </ul>
               </li>
+              {% if current_user and current_user.role in ['admin','superadmin'] %}
+              <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Tags</a>
+                <ul class="dropdown-menu">
+                  <li><a class="dropdown-item" href="/tasks/edit-tags">Edit Tags</a></li>
+                  <li><a class="dropdown-item" href="/tasks/google-sheets">Google Sheets</a></li>
+                </ul>
+              </li>
+              {% endif %}
               <li class="nav-item">
                 <a class="nav-link" href="/tasks">Tasks</a>
               </li>
@@ -85,6 +94,7 @@
       </nav>
     </header>
     <div class="container mt-4">
+      <a href="javascript:history.back()" class="text-blue-400 underline">&laquo; Back</a>
       <p>{{ message }}</p>
       {% block content %}{% endblock %}
     </div>

--- a/app/templates/tasks.html
+++ b/app/templates/tasks.html
@@ -54,12 +54,7 @@
   <button type="submit" class="bg-blue-600 px-3 py-1">Upload</button>
 </form>
 
-<hr class="my-4">
-<h2 class="text-lg mb-2">Google Sheets</h2>
-<a href="/tasks/google-sheets" class="underline">Configure Google Sheets Integration</a>
-<hr class="my-4">
-<h2 class="text-lg mb-2">Tag Editor</h2>
-<a href="/tasks/edit-tags" class="underline">Edit Device Tags</a>
+
 {% endblock %}
 
 {% block extra_scripts %}


### PR DESCRIPTION
## Summary
- add Tags dropdown to navbar with links to Tag Editor and Google Sheets
- move Google and tag options out of tasks page
- provide a universal back link on all pages

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684cf09a99b48324aed78b519aeeabfc