### PR TITLE
Move duplicate checker and tag editing under Tasks menu

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,7 +25,6 @@
                 <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Devices</a>
                 <ul class="dropdown-menu">
                   <li><a class="dropdown-item" href="/devices">All Devices</a></li>
-                  <li><a class="dropdown-item" href="/devices/duplicates">Duplicate Checker</a></li>
                   {% for dtype in get_device_types() %}
                   <li><a class="dropdown-item" href="/devices/type/{{ dtype.id }}">{{ dtype.name }}</a></li>
                   {% endfor %}
@@ -42,17 +41,16 @@
                   <li><a class="dropdown-item" href="/network/port-configs">Port Configs</a></li>
                 </ul>
               </li>
-              {% if current_user and current_user.role in ['admin','superadmin'] %}
               <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Tags</a>
+                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Tasks</a>
                 <ul class="dropdown-menu">
+                  <li><a class="dropdown-item" href="/tasks">Task Queue</a></li>
+                  <li><a class="dropdown-item" href="/devices/duplicates">Duplicate Checker</a></li>
+                  {% if current_user and current_user.role in ['admin','superadmin'] %}
                   <li><a class="dropdown-item" href="/tasks/edit-tags">Edit Tags</a></li>
                   <li><a class="dropdown-item" href="/tasks/google-sheets">Google Sheets</a></li>
+                  {% endif %}
                 </ul>
-              </li>
-              {% endif %}
-              <li class="nav-item">
-                <a class="nav-link" href="/tasks">Tasks</a>
               </li>
             </ul>
             <div class="d-flex align-items-center">

--- a/app/templates/tag_edit.html
+++ b/app/templates/tag_edit.html
@@ -15,7 +15,7 @@
     <tr class="border-t border-gray-700">
       <td class="px-4 py-2">{{ dev.hostname }}</td>
       <td class="px-4 py-2">
-        <input type="text" name="tags_{{ dev.id }}" value="{{ ', '.join([t.name for t in dev.tags if t.name not in ['complete','incomplete']]) }}" class="w-full p-2 text-black" />
+        <input type="text" name="tags_{{ dev.id }}" value="{{ dev.tags | rejectattr('name', 'in', ['complete','incomplete']) | map(attribute='name') | join(', ') }}" class="w-full p-2 text-black" />
       </td>
     </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- update navigation to include a Tasks dropdown
- move Duplicate Checker and tag-related links into the new dropdown
- fix the tag editing template expression that was causing a Jinja error

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d2edf95548324877c33b81d8e3a5b