### PR TITLE
Fix tag rendering in device list

### DIFF
--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -52,7 +52,7 @@
       <td class="px-4 py-2">{{ device.vlan.tag if device.vlan else '' }}</td>
       <td class="px-4 py-2">{{ device.ssh_credential.name if device.ssh_credential else '' }}</td>
       <td class="px-4 py-2">{{ device.snmp_community.name if device.snmp_community else '' }}</td>
-      <td class="px-4 py-2">{{ ', '.join([t.name for t in device.tags]) }}</td>
+      <td class="px-4 py-2">{{ device.tags | map(attribute='name') | join(', ') }}</td>
     </tr>
     {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
     <tr class="border-b border-gray-700">


### PR DESCRIPTION
## Summary
- fix the Jinja2 syntax used to display tag names on the device list page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d36166e1c8324b08baab4f4f9c771