### PR TITLE
Add dotenv-based configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/__pycache__/
 *.pyc
 ces_inventory.db
+
+.env

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,2 @@
+from dotenv import load_dotenv
+load_dotenv()

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Request, WebSocket, Depends
 from fastapi.staticfiles import StaticFiles
 
 from starlette.middleware.sessions import SessionMiddleware
+import os
 
 from app.routes import (
     auth_router,
@@ -35,7 +36,10 @@ start_queue_worker(app)
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 # Store login information in signed cookies
-app.add_middleware(SessionMiddleware, secret_key="change-me")
+app.add_middleware(
+    SessionMiddleware,
+    secret_key=os.environ.get("SECRET_KEY", "change-me"),
+)
 
 app.include_router(auth_router, prefix="/auth")
 app.include_router(devices_router)

--- a/app/routes/admin_profiles.py
+++ b/app/routes/admin_profiles.py
@@ -6,6 +6,9 @@ from sqlalchemy.orm import Session
 from app.utils.db_session import get_db
 from app.utils.auth import require_role
 from app.models.models import SSHCredential, SNMPCommunity
+import os
+
+DEFAULT_SNMP_VERSION = os.environ.get("DEFAULT_SNMP_VERSION", "2c")
 
 
 
@@ -162,7 +165,7 @@ async def create_snmp_profile(
     request: Request,
     name: str = Form(...),
     community_string: str = Form(...),
-    version: str = Form("2c"),
+    version: str = Form(DEFAULT_SNMP_VERSION),
     db: Session = Depends(get_db),
     current_user=Depends(require_role("superadmin")),
 ):
@@ -176,7 +179,7 @@ async def create_snmp_profile(
         }
         return templates.TemplateResponse("snmp_form.html", context)
 
-    profile = SNMPCommunity(name=name, community_string=community_string, version=version or "2c")
+    profile = SNMPCommunity(name=name, community_string=community_string, version=version or DEFAULT_SNMP_VERSION)
     db.add(profile)
     db.commit()
     return RedirectResponse(url="/admin/snmp", status_code=302)
@@ -202,7 +205,7 @@ async def update_snmp_profile(
     request: Request,
     name: str = Form(...),
     community_string: str = Form(...),
-    version: str = Form("2c"),
+    version: str = Form(DEFAULT_SNMP_VERSION),
     db: Session = Depends(get_db),
     current_user=Depends(require_role("superadmin")),
 ):
@@ -225,7 +228,7 @@ async def update_snmp_profile(
 
     profile.name = name
     profile.community_string = community_string
-    profile.version = version or "2c"
+    profile.version = version or DEFAULT_SNMP_VERSION
     db.commit()
     return RedirectResponse(url="/admin/snmp", status_code=302)
 

--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -38,7 +38,8 @@ router = APIRouter()
 
 # Basic status options for dropdown menus
 STATUS_OPTIONS = ["active", "inactive", "maintenance"]
-MAX_BACKUPS = 10
+import os
+MAX_BACKUPS = int(os.environ.get("MAX_BACKUPS", "10"))
 # Available configuration templates for push-config form
 TEMPLATE_OPTIONS = [
     "Trunk Port",

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -7,8 +7,9 @@ from app.utils.ssh import build_conn_kwargs
 from app.utils.db_session import SessionLocal
 from app.models.models import ConfigBackup
 from app.utils.audit import log_audit
+import os
 
-QUEUE_INTERVAL = 60  # seconds
+QUEUE_INTERVAL = int(os.environ.get("QUEUE_INTERVAL", "60"))
 
 async def run_push_queue_once():
     db = SessionLocal()

--- a/app/utils/db_session.py
+++ b/app/utils/db_session.py
@@ -1,12 +1,13 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+import os
 
 from app.utils.database import Base
 
 # Import models so that Base.metadata is aware of them before creating tables
 from app import models  # noqa: F401
 
-DATABASE_URL = "sqlite:///ces_inventory.db"
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///ces_inventory.db")
 
 engine = create_engine(
     DATABASE_URL, connect_args={"check_same_thread": False}

--- a/app/websockets/terminal.py
+++ b/app/websockets/terminal.py
@@ -5,6 +5,7 @@ import asyncssh
 import asyncio
 import time
 import logging
+import os
 
 from app.utils.ssh import build_conn_kwargs
 
@@ -13,6 +14,7 @@ from app.models.models import Device, User
 from app.utils.auth import ROLE_HIERARCHY
 
 router = APIRouter()
+INACTIVITY_TIMEOUT = int(os.environ.get("SSH_TIMEOUT", "900"))
 
 
 @router.websocket("/ws/terminal/{device_id}")
@@ -79,7 +81,7 @@ async def terminal_ws(websocket: WebSocket, device_id: int):
                     try:
                         while True:
                             await asyncio.sleep(30)
-                            if time.monotonic() - last_msg > 900:
+                            if time.monotonic() - last_msg > INACTIVITY_TIMEOUT:
                                 try:
                                     await websocket.send_text("\u26A0\uFE0F Session expired due to inactivity")
                                 except Exception:


### PR DESCRIPTION
## Summary
- ignore `.env`
- load environment vars on package import
- read secret key from env
- configure database via `DATABASE_URL`
- make queue worker and inactivity timeout configurable
- default SNMP version configurable
- allow environment override for max backups

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d373355388324b8df907e0f25723e