### PR TITLE
Add Gunicorn for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,32 @@ The **Devices** menu also includes a *Duplicate Checker* page to locate records 
 If the login form reports **Invalid credentials**, run `python seed_superuser.py` again to ensure the password is stored correctly.
 
 
+## Production deployment
+
+For production environments it is recommended to run the app under
+[Gunicorn](https://gunicorn.org/) using Uvicorn workers. Gunicorn manages
+multiple worker processes while Uvicorn handles the ASGI interface.
+
+Start the server with reasonable defaults using the provided `start.sh` script:
+
+```bash
+./start.sh
+```
+
+This script loads variables from `.env` if present and executes:
+
+```bash
+gunicorn app.main:app \
+    --worker-class uvicorn.workers.UvicornWorker \
+    --workers ${WORKERS:-4} \
+    --timeout ${TIMEOUT:-120} \
+    --bind 0.0.0.0:${PORT:-8000}
+```
+
+Adjust `WORKERS`, `TIMEOUT` and `PORT` as needed. The server listens on
+`0.0.0.0` so it can be proxied by a web server such as Nginx.
+
+
 ## Troubleshooting
 
 ### Can't access the app from another machine

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ websockets
 gspread
 google-auth
 psycopg2-binary
+gunicorn

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Start Gunicorn with Uvicorn workers for production
+set -e
+
+# Load environment variables from .env if present
+if [ -f .env ]; then
+    set -a
+    . .env
+    set +a
+fi
+
+exec gunicorn app.main:app \
+    --worker-class uvicorn.workers.UvicornWorker \
+    --workers "${WORKERS:-4}" \
+    --timeout "${TIMEOUT:-120}" \
+    --bind "0.0.0.0:${PORT:-8000}"
+


### PR DESCRIPTION
## Summary
- configure Gunicorn with uvicorn workers
- add a `start.sh` helper script to launch Gunicorn
- document production deployment steps
- include Gunicorn in project requirements

## Testing
- `pip install -r requirements.txt`
- `./start.sh & sleep 5; pkill -f gunicorn`

------
https://chatgpt.com/codex/tasks/task_e_684d3a7d81c08324ab2138f503e05e76