### PR TITLE
Auto seed database with start.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This application manages network devices, VLANs and configuration backups using 
    ```bash
    pip install -r requirements.txt
    ```
-4. **Seed the database** with default values. This will create a superuser, system settings, and some sample devices:
+4. **Seed the database** with default values. This will create a superuser, system settings, and some sample devices. The `start.sh` script will automatically run these seed commands unless `AUTO_SEED` is disabled, but you can also run them manually:
    ```bash
    python seed_tunables.py
    python seed_superuser.py
@@ -79,7 +79,7 @@ Start the server with reasonable defaults using the provided `start.sh` script:
 ./start.sh
 ```
 
-This script loads variables from `.env` if present and executes:
+This script loads variables from `.env` if present, automatically runs the seed scripts (unless `AUTO_SEED=0` or `false`) and then executes:
 
 ```bash
 gunicorn app.main:app \
@@ -88,6 +88,8 @@ gunicorn app.main:app \
     --timeout ${TIMEOUT:-120} \
     --bind 0.0.0.0:${PORT:-8000}
 ```
+
+Set the `AUTO_SEED` environment variable to `0` or `false` to skip the automatic seeding step if the database is already populated.
 
 Adjust `WORKERS`, `TIMEOUT` and `PORT` as needed. The server listens on
 `0.0.0.0` so it can be proxied by a web server such as Nginx.

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,12 @@ if [ -f .env ]; then
     set +a
 fi
 
+if [ "${AUTO_SEED:-1}" != "0" ] && [ "${AUTO_SEED}" != "false" ]; then
+    python seed_tunables.py
+    python seed_superuser.py
+    python seed_data.py
+fi
+
 exec gunicorn app.main:app \
     --worker-class uvicorn.workers.UvicornWorker \
     --workers "${WORKERS:-4}" \


### PR DESCRIPTION
## Summary
- run database seed scripts from `start.sh` unless `AUTO_SEED=0`
- document automatic seeding in the README

## Testing
- `pip install -r requirements.txt`
- `AUTO_SEED=1 WORKERS=1 PORT=8001 ./start.sh` *(verified DB seeded)*
- `AUTO_SEED=1 WORKERS=1 PORT=8001 ./start.sh` again *(idempotent)*
- `AUTO_SEED=0 WORKERS=1 PORT=8001 ./start.sh` *(no seeding)*

------
https://chatgpt.com/codex/tasks/task_e_684d40096b288324883006c2b5695b9a