### PR TITLE
Handle missing Postgres with SQLite fallback

### DIFF
--- a/app/utils/db_session.py
+++ b/app/utils/db_session.py
@@ -7,17 +7,31 @@ from app.utils.database import Base
 # Import models so that Base.metadata is aware of them before creating tables
 from app import models  # noqa: F401
 
-DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///ces_inventory.db")
+DEFAULT_SQLITE = "sqlite:///ces_inventory.db"
+DATABASE_URL = os.environ.get("DATABASE_URL", DEFAULT_SQLITE)
 
 # Use special connection args only for SQLite
 connect_args = {}
 if DATABASE_URL.startswith("sqlite"):
     connect_args["check_same_thread"] = False
 
-engine = create_engine(
-    DATABASE_URL,
-    connect_args=connect_args,
-)
+try:
+    engine = create_engine(
+        DATABASE_URL,
+        connect_args=connect_args,
+    )
+    # Attempt to connect so connection issues surface immediately
+    with engine.connect() as _:
+        pass
+except Exception as exc:
+    if DATABASE_URL != DEFAULT_SQLITE:
+        print(f"Warning: Could not connect to database at {DATABASE_URL}: {exc}")
+        print("Falling back to local SQLite database.")
+        DATABASE_URL = DEFAULT_SQLITE
+        connect_args = {"check_same_thread": False}
+        engine = create_engine(DATABASE_URL, connect_args=connect_args)
+    else:
+        raise
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
## Summary
- fallback to local SQLite DB if the `DATABASE_URL` connection fails

## Testing
- `./start.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d5155d2888324be1844300c84f989