### PR TITLE
Enforce PostgreSQL usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 **/__pycache__/
 *.pyc
-ces_inventory.db
 
 .env

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Master IP App
 
-This application manages network devices, VLANs and configuration backups using [FastAPI](https://fastapi.tiangolo.com/). By default it stores data in a local SQLite database and provides a simple web interface. Production deployments can point SQLAlchemy at a PostgreSQL server by setting a `DATABASE_URL` environment variable.
+This application manages network devices, VLANs and configuration backups using [FastAPI](https://fastapi.tiangolo.com/). All data is stored in a PostgreSQL database specified via the `DATABASE_URL` environment variable. SQLite is not supported.
 
 ## Prerequisites
 
 - **Python 3.10+** (any recent Python 3 version should work)
+- **PostgreSQL 12+** installed and running
 - (Optional) [virtualenv](https://docs.python.org/3/library/venv.html) for an isolated environment
 
 ## Setup
@@ -25,9 +26,7 @@ This application manages network devices, VLANs and configuration backups using 
    python seed_superuser.py
    python seed_data.py
    ```
-   These commands create a SQLite database file named `ces_inventory.db` in the project directory unless a `DATABASE_URL` is provided.
-
-   If you want to use PostgreSQL, create a `.env` file and set a connection string, for example:
+   Before running these scripts, create a `.env` file with a PostgreSQL connection string, for example:
 
    ```bash
    echo "DATABASE_URL=postgresql://postgres:postgres@localhost:5432/master_ip_db" > .env

--- a/app/utils/db_session.py
+++ b/app/utils/db_session.py
@@ -7,17 +7,14 @@ from app.utils.database import Base
 # Import models so that Base.metadata is aware of them before creating tables
 from app import models  # noqa: F401
 
-DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///ces_inventory.db")
+DATABASE_URL = os.environ.get("DATABASE_URL")
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL environment variable is required and must point to a PostgreSQL database")
 
-# Use special connection args only for SQLite
-connect_args = {}
-if DATABASE_URL.startswith("sqlite"):
-    connect_args["check_same_thread"] = False
+if not DATABASE_URL.startswith("postgresql"):
+    raise RuntimeError("Only PostgreSQL is supported. DATABASE_URL must begin with 'postgresql'.")
 
-engine = create_engine(
-    DATABASE_URL,
-    connect_args=connect_args,
-)
+engine = create_engine(DATABASE_URL)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
## Summary
- make `db_session` require a PostgreSQL `DATABASE_URL`
- drop SQLite references from README
- document PostgreSQL as a prerequisite
- clean up `.gitignore`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684d5295818c8324a7bedae854cf04ec