### PR TITLE
Make IP search results link to device pages

### DIFF
--- a/app/templates/ip_search.html
+++ b/app/templates/ip_search.html
@@ -10,7 +10,7 @@
 <h2 class="text-lg mb-2">Results for '{{ ip }}'</h2>
 <ul class="list-disc list-inside ml-4">
   {% for device in results %}
-  <li>{{ device.hostname }} ({{ device.ip }})</li>
+  <li><a href="/devices/{{ device.id }}/edit" class="underline">{{ device.hostname }} ({{ device.ip }})</a></li>
   {% else %}
   <li>No devices found.</li>
   {% endfor %}


### PR DESCRIPTION
## Summary
- add links in IP search results so each device navigates to its edit page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d5515f968832494df5eec8b063460