### PR TITLE
Add automatic attribute tags for devices

### DIFF
--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -22,7 +22,7 @@ from app.models.models import (
     PortConfigTemplate,
 )
 from app.utils.audit import log_audit
-from app.utils.tags import update_device_complete_tag
+from app.utils.tags import update_device_complete_tag, update_device_attribute_tags
 from app.models.models import DeviceEditLog
 
 import asyncssh
@@ -267,6 +267,7 @@ async def create_device(
     )
     db.add(device)
     update_device_complete_tag(db, device)
+    update_device_attribute_tags(db, device)
     db.commit()
     db.add(DeviceEditLog(device_id=device.id, user_id=current_user.id, changes="created"))
     db.commit()
@@ -364,6 +365,7 @@ async def update_device(
 
     device.updated_at = datetime.utcnow()
     update_device_complete_tag(db, device)
+    update_device_attribute_tags(db, device, old)
     db.commit()
 
     changes = []

--- a/app/routes/task_views.py
+++ b/app/routes/task_views.py
@@ -22,7 +22,10 @@ import io
 import urllib.parse
 import gspread
 from google.oauth2.service_account import Credentials
-from app.utils.tags import update_device_complete_tag
+from app.utils.tags import (
+    update_device_complete_tag,
+    update_device_attribute_tags,
+)
 
 
 
@@ -275,6 +278,7 @@ async def save_tags(
                 dev.tags.remove(t)
         dev.tags.extend(manual)
         update_device_complete_tag(db, dev)
+        update_device_attribute_tags(db, dev)
     db.commit()
     return RedirectResponse(url="/tasks/edit-tags", status_code=302)
 

--- a/app/utils/tags.py
+++ b/app/utils/tags.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
 
-from app.models.models import Device, Tag
+from app.models.models import Device, Tag, DeviceType, Location
 
 
 def update_device_complete_tag(db: Session, device: Device) -> None:
@@ -36,3 +36,55 @@ def update_device_complete_tag(db: Session, device: Device) -> None:
         device.tags.append(complete)
     else:
         device.tags.append(incomplete)
+
+
+def _ensure_tag(db: Session, name: str) -> Tag:
+    tag = db.query(Tag).filter(Tag.name == name).first()
+    if not tag:
+        tag = Tag(name=name)
+        db.add(tag)
+        db.flush()
+    return tag
+
+
+def update_device_attribute_tags(
+    db: Session, device: Device, old: dict | None = None
+) -> None:
+    """Sync manufacturer, device type and location tags for a device."""
+    old = old or {}
+
+    def remove_tag(name: str | None) -> None:
+        if not name:
+            return
+        tag = db.query(Tag).filter(Tag.name == name).first()
+        if tag and tag in device.tags:
+            device.tags.remove(tag)
+
+    # Remove outdated tags if values changed
+    if old.get("manufacturer") and old["manufacturer"] != device.manufacturer:
+        remove_tag(old["manufacturer"])
+
+    if old.get("device_type_id") and old["device_type_id"] != device.device_type_id:
+        dt = db.query(DeviceType).filter(DeviceType.id == old["device_type_id"]).first()
+        if dt:
+            remove_tag(dt.name)
+
+    if old.get("location_id") and old["location_id"] != device.location_id:
+        loc = db.query(Location).filter(Location.id == old["location_id"]).first()
+        if loc:
+            remove_tag(loc.name)
+
+    # Ensure current tags
+    manu_tag = _ensure_tag(db, device.manufacturer)
+    if manu_tag not in device.tags:
+        device.tags.append(manu_tag)
+
+    if device.device_type:
+        dtype_tag = _ensure_tag(db, device.device_type.name)
+        if dtype_tag not in device.tags:
+            device.tags.append(dtype_tag)
+
+    if device.location_ref:
+        loc_tag = _ensure_tag(db, device.location_ref.name)
+        if loc_tag not in device.tags:
+            device.tags.append(loc_tag)


### PR DESCRIPTION
## Summary
- tag devices automatically with manufacturer, type, and location
- keep attribute tags in sync on update and manual tag edits

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6387e1288324afb620ce129716b5