### PR TITLE
Add user detail page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from app.routes import (
     port_config_templates_router,
     task_views_router,
     user_management_router,
+    user_pages_router,
     locations_router,
 )
 from app.routes.tunables import router as tunables_router
@@ -59,6 +60,7 @@ app.include_router(network_router)
 app.include_router(port_config_templates_router)
 app.include_router(task_views_router)
 app.include_router(user_management_router)
+app.include_router(user_pages_router)
 app.include_router(locations_router)
 
 

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -15,6 +15,7 @@ from .network import router as network_router
 from .port_config_templates import router as port_config_templates_router
 from .task_views import router as task_views_router
 from .user_management import router as user_management_router
+from .user_pages import router as user_pages_router
 from .locations import router as locations_router
 
 __all__ = [
@@ -35,5 +36,6 @@ __all__ = [
     "port_config_templates_router",
     "task_views_router",
     "user_management_router",
+    "user_pages_router",
     "locations_router",
 ]

--- a/app/routes/user_pages.py
+++ b/app/routes/user_pages.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Request, Depends, HTTPException
+from app.utils.templates import templates
+from sqlalchemy.orm import Session
+
+from app.utils.db_session import get_db
+from app.utils.auth import get_current_user, require_role, ROLE_HIERARCHY
+from app.models.models import User
+
+router = APIRouter()
+
+@router.get('/users/me')
+async def my_profile(request: Request, current_user: User = Depends(require_role("viewer"))):
+    """Display the currently logged-in user's details."""
+    context = {"request": request, "user": current_user, "current_user": current_user}
+    return templates.TemplateResponse("user_detail.html", context)
+
+
+@router.get('/users/{user_id}')
+async def user_detail(user_id: int, request: Request, db: Session = Depends(get_db), current_user: User = Depends(require_role("viewer"))):
+    """Display details for a specific user."""
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if current_user.id != user.id and ROLE_HIERARCHY.index(current_user.role) < ROLE_HIERARCHY.index("admin"):
+        raise HTTPException(status_code=403, detail="Insufficient role")
+
+    context = {"request": request, "user": user, "current_user": current_user}
+    return templates.TemplateResponse("user_detail.html", context)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -57,6 +57,7 @@
               {% if current_user %}
                 <span class="navbar-text me-2">Logged in as {{ current_user.email }}</span>
                 <a class="btn btn-sm btn-outline-light me-2" href="/dashboard">Dashboard</a>
+                <a class="btn btn-sm btn-outline-light me-2" href="/users/me">My Profile</a>
                 {% if current_user.role in ['admin','superadmin'] %}
                 <div class="btn-group me-2">
                   <button type="button" class="btn btn-sm btn-outline-light dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">

--- a/app/templates/user_detail.html
+++ b/app/templates/user_detail.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">User Details</h1>
+<table class="min-w-full bg-black">
+  <tbody>
+    <tr class="border-t border-gray-700">
+      <th class="px-4 py-2 text-left">Email</th>
+      <td class="px-4 py-2">{{ user.email }}</td>
+    </tr>
+    <tr class="border-t border-gray-700">
+      <th class="px-4 py-2 text-left">Role</th>
+      <td class="px-4 py-2">{{ user.role }}</td>
+    </tr>
+    <tr class="border-t border-gray-700">
+      <th class="px-4 py-2 text-left">Active</th>
+      <td class="px-4 py-2">{{ 'Yes' if user.is_active else 'No' }}</td>
+    </tr>
+    <tr class="border-t border-gray-700">
+      <th class="px-4 py-2 text-left">Created At</th>
+      <td class="px-4 py-2">{{ user.created_at }}</td>
+    </tr>
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/users/me` and `/users/{user_id}` routes
- include user pages in router exports and app
- add profile link to base template navigation
- create new `user_detail.html` template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d67b2d7f4832499f63f8bbc051b77