### PR TITLE
Add wait-for-db startup check

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,9 @@ if [ -f .env ]; then
     set +a
 fi
 
+# Wait for the database to become available
+python wait_for_db.py
+
 if [ "${AUTO_SEED:-1}" != "0" ] && [ "${AUTO_SEED}" != "false" ]; then
     python seed_tunables.py
     python seed_superuser.py

--- a/wait_for_db.py
+++ b/wait_for_db.py
@@ -1,0 +1,24 @@
+import os
+import time
+import psycopg2
+
+DB_URL = os.environ.get("DATABASE_URL")
+if not DB_URL:
+    raise RuntimeError("DATABASE_URL environment variable not set")
+
+max_attempts = int(os.environ.get("DB_WAIT_ATTEMPTS", 30))
+delay = int(os.environ.get("DB_WAIT_DELAY", 2))
+
+for attempt in range(1, max_attempts + 1):
+    try:
+        conn = psycopg2.connect(DB_URL)
+        conn.close()
+        print("Database is ready")
+        break
+    except Exception as exc:
+        print(f"Attempt {attempt}/{max_attempts} - waiting for database...")
+        time.sleep(delay)
+else:
+    print("Could not connect to database. Exiting.")
+    raise SystemExit(1)
+


### PR DESCRIPTION
## Summary
- add a Python helper that waits for DB readiness
- call the helper in `start.sh`

## Testing
- `python -m py_compile wait_for_db.py app/utils/db_session.py`

------
https://chatgpt.com/codex/tasks/task_e_684d6e606c448324ac30695fa5caff0e