### PR TITLE
Add not authorised page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI, Request, WebSocket, Depends
+from fastapi import FastAPI, Request, WebSocket, Depends, HTTPException
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import JSONResponse
 
 from starlette.middleware.sessions import SessionMiddleware
 import os
@@ -62,6 +63,17 @@ app.include_router(task_views_router)
 app.include_router(user_management_router)
 app.include_router(user_pages_router)
 app.include_router(locations_router)
+
+
+@app.exception_handler(HTTPException)
+async def unauthorized_handler(request: Request, exc: HTTPException):
+    """Show a friendly page when authentication is required."""
+    if exc.status_code == 401:
+        context = {"request": request}
+        return templates.TemplateResponse(
+            "not_authorised.html", context, status_code=exc.status_code
+        )
+    return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
 
 
 @app.get("/")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,6 +10,7 @@
   </head>
   <body>
     <header>
+      {% block nav %}
       <nav class="navbar navbar-dark navbar-expand-lg bg-dark">
         <div class="container">
           <a class="navbar-brand" href="/">CES Inventory</a>
@@ -91,6 +92,7 @@
           </div>
         </div>
       </nav>
+      {% endblock %}
     </header>
     <div class="container mt-4">
       <a href="javascript:history.back()" class="text-blue-400 underline">&laquo; Back</a>

--- a/app/templates/not_authorised.html
+++ b/app/templates/not_authorised.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block nav %}
+<nav class="navbar navbar-dark navbar-expand-lg bg-dark">
+  <div class="container">
+    <a class="navbar-brand" href="/">CES Inventory</a>
+    <div class="d-flex">
+      <a href="/auth/login" class="btn btn-sm btn-outline-light">Login</a>
+    </div>
+  </div>
+</nav>
+{% endblock %}
+
+{% block content %}
+<div class="max-w-lg mx-auto mt-10 text-center">
+  <h1 class="text-2xl mb-4">Not Authorised</h1>
+  <p>You must be logged in to use the system.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- support overriding navbar with a template block
- display a new not authorised page when a 401 is raised

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d74b006788324a95b0de15bd39ab2