### PR TITLE
Add Netbird SSH connection support

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -61,6 +61,7 @@
                   <li><a class="dropdown-item" href="/ssh/config-check">Config Check</a></li>
                   <li><a class="dropdown-item" href="/ssh/port-search">Port Search</a></li>
                   <li><a class="dropdown-item" href="/ssh/bulk-port-update">Bulk Port Update</a></li>
+                  <li><a class="dropdown-item" href="/ssh/netbird-connect">Initiate Netbird Connection</a></li>
                 </ul>
               </li>
             </ul>

--- a/app/templates/ssh_menu.html
+++ b/app/templates/ssh_menu.html
@@ -8,5 +8,6 @@
   <li><a class="underline text-blue-400" href="/ssh/config-check">Config Check</a></li>
   <li><a class="underline text-blue-400" href="/ssh/port-search">Port Search</a></li>
   <li><a class="underline text-blue-400" href="/ssh/bulk-port-update">Bulk Port Update</a></li>
+  <li><a class="underline text-blue-400" href="/ssh/netbird-connect">Initiate Netbird Connection</a></li>
 </ul>
 {% endblock %}

--- a/app/templates/ssh_netbird.html
+++ b/app/templates/ssh_netbird.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Initiate Netbird Connection</h1>
+{% if error %}<p class="text-red-500">{{ error }}</p>{% endif %}
+{% if message %}<p class="text-green-600">{{ message }}</p>{% endif %}
+<form method="post" class="space-y-4">
+  <div>
+    <label class="block">Peer</label>
+    <select name="peer_id" class="p-2 text-black">
+      {% for peer in peers %}
+      <option value="{{ peer.id }}">{{ peer.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <button type="submit" class="bg-blue-600 px-4 py-2">Connect</button>
+</form>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ gspread
 google-auth
 psycopg2-binary
 gunicorn
+requests

--- a/seed_tunables.py
+++ b/seed_tunables.py
@@ -50,6 +50,22 @@ def main():
                 data_type="text",
                 description="Target spreadsheet ID",
             ),
+            SystemTunable(
+                name="Netbird API URL",
+                value="https://api.netbird.io/api",
+                function="Netbird",
+                file_type="application",
+                data_type="text",
+                description="Base URL of the Netbird API",
+            ),
+            SystemTunable(
+                name="Netbird API Token",
+                value="",
+                function="Netbird",
+                file_type="application",
+                data_type="text",
+                description="Bearer token for Netbird API access",
+            ),
         ]
         db.add_all(samples)
         db.commit()


### PR DESCRIPTION
## Summary
- expose Netbird configuration via system tunables
- add Netbird API helper in SSH tasks
- list peers and initiate connections through new routes
- show link to Netbird connection page in SSH menus
- include `requests` library

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d7911062483248d4424802c42e0cb