### PR TITLE
Fix import error from missing router

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,7 +19,6 @@ from app.routes import (
     network_router,
     port_config_templates_router,
     task_views_router,
-    user_management_router,
     user_pages_router,
     locations_router,
     ssh_tasks_router,
@@ -63,7 +62,6 @@ app.include_router(device_types_router)
 app.include_router(network_router)
 app.include_router(port_config_templates_router)
 app.include_router(task_views_router)
-app.include_router(user_management_router)
 app.include_router(user_pages_router)
 app.include_router(locations_router)
 app.include_router(ssh_tasks_router)


### PR DESCRIPTION
## Summary
- remove reference to `user_management_router` in main app

## Testing
- `python -m py_compile app/main.py app/routes/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684d8297e4b083248e89228fac702cb0