### PR TITLE
Update navigation with Inventory submenu

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.routes import (
     ip_bans_router,
     user_ssh_router,
     login_events_router,
+    inventory_router,
 )
 from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
@@ -69,6 +70,7 @@ app.include_router(ssh_tasks_router)
 app.include_router(ip_bans_router)
 app.include_router(user_ssh_router)
 app.include_router(login_events_router)
+app.include_router(inventory_router)
 
 
 @app.exception_handler(HTTPException)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -21,6 +21,7 @@ from .ssh_tasks import router as ssh_tasks_router
 from .ip_bans import router as ip_bans_router
 from .user_ssh import router as user_ssh_router
 from .login_events import router as login_events_router
+from .inventory import router as inventory_router
 
 __all__ = [
     "auth_router",
@@ -46,4 +47,5 @@ __all__ = [
     "ip_bans_router",
     "user_ssh_router",
     "login_events_router",
+    "inventory_router",
 ]

--- a/app/routes/inventory.py
+++ b/app/routes/inventory.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Request, Depends
+from app.utils.templates import templates
+from app.utils.auth import require_role
+
+router = APIRouter()
+
+@router.get('/inventory/audit')
+async def inventory_audit(request: Request, current_user=Depends(require_role("viewer"))):
+    """Placeholder page for audit information."""
+    context = {"request": request, "current_user": current_user}
+    return templates.TemplateResponse('inventory_audit.html', context)
+
+@router.get('/inventory/trailers')
+async def inventory_trailers(request: Request, current_user=Depends(require_role("viewer"))):
+    """Placeholder page for trailer inventory."""
+    context = {"request": request, "current_user": current_user}
+    return templates.TemplateResponse('inventory_trailer.html', context)
+
+@router.get('/inventory/sites')
+async def inventory_sites(request: Request, current_user=Depends(require_role("viewer"))):
+    """Placeholder page for site inventory."""
+    context = {"request": request, "current_user": current_user}
+    return templates.TemplateResponse('inventory_site.html', context)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -23,15 +23,20 @@
                 <a class="nav-link" href="/">Home</a>
               </li>
               <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Devices</a>
+                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Inventory</a>
                 <ul class="dropdown-menu">
-                  <li><a class="dropdown-item" href="/devices">All Devices</a></li>
-                  {% for dtype in get_device_types() %}
-                  <li><a class="dropdown-item" href="/devices/type/{{ dtype.id }}">{{ dtype.name }}</a></li>
-                  {% endfor %}
-                  {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
-                  <li><a class="dropdown-item" href="/devices/new">Add Device</a></li>
-                  {% endif %}
+                  <li class="dropend">
+                    <a class="dropdown-item dropdown-toggle" href="#" data-bs-toggle="dropdown" aria-expanded="false">Devices</a>
+                    <ul class="dropdown-menu">
+                      <li><a class="dropdown-item" href="/devices">All Devices</a></li>
+                      {% for dtype in get_device_types() %}
+                      <li><a class="dropdown-item" href="/devices/type/{{ dtype.id }}">{{ dtype.name }}</a></li>
+                      {% endfor %}
+                    </ul>
+                  </li>
+                  <li><a class="dropdown-item" href="/inventory/audit">Audit</a></li>
+                  <li><a class="dropdown-item" href="/inventory/trailers">Trailer Inventory</a></li>
+                  <li><a class="dropdown-item" href="/inventory/sites">Site Inventory</a></li>
                 </ul>
               </li>
               <li class="nav-item dropdown">

--- a/app/templates/inventory_audit.html
+++ b/app/templates/inventory_audit.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Inventory Audit</h1>
+<p>This page will contain audit details in the future.</p>
+{% endblock %}

--- a/app/templates/inventory_site.html
+++ b/app/templates/inventory_site.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Site Inventory</h1>
+<p>This page will be built out later.</p>
+{% endblock %}

--- a/app/templates/inventory_trailer.html
+++ b/app/templates/inventory_trailer.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Trailer Inventory</h1>
+<p>This page will be built out later.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- nest Devices menu under a new Inventory dropdown
- remove Add Device link from the navigation
- create placeholder pages for Inventory Audit, Trailer Inventory and Site Inventory
- register new Inventory routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d874c07708324ae80292996764b71