### PR TITLE
Add scheduled config pulls for site devices

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -33,11 +33,12 @@ from app.websockets.editor import shell_ws
 from app.websockets.terminal import router as terminal_ws_router
 from app.routes.welcome import router as welcome_router, WELCOME_TEXT
 from app.utils.auth import get_current_user
-from app.tasks import start_queue_worker
+from app.tasks import start_queue_worker, start_config_scheduler
 from app.utils.templates import templates
 
 app = FastAPI()
 start_queue_worker(app)
+start_config_scheduler(app)
 
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -107,6 +107,15 @@ class Device(Base):
     updated_at = Column(DateTime, default=datetime.utcnow)
     last_seen = Column(DateTime, nullable=True)
 
+    # Indicates if device belongs to the active "My Site" group
+    is_active_site_member = Column(Boolean, default=False)
+
+    # Interval for automated config pulls: 'hourly', 'daily', 'weekly', or 'none'
+    config_pull_interval = Column(String, nullable=False, default="none")
+
+    # Timestamp of the last successful scheduled pull
+    last_config_pull = Column(DateTime, nullable=True)
+
     vlan = relationship("VLAN", back_populates="devices")
     ssh_credential = relationship("SSHCredential", back_populates="devices")
     snmp_community = relationship("SNMPCommunity", back_populates="devices")

--- a/app/routes/ssh_tasks.py
+++ b/app/routes/ssh_tasks.py
@@ -127,6 +127,12 @@ async def port_config_action(device_id: int = Form(...), port_name: str = Form(.
     device = db.query(Device).filter(Device.id == device_id).first()
     if not device:
         raise HTTPException(status_code=404, detail="Device not found")
+    if not device.is_active_site_member:
+        raise HTTPException(status_code=403, detail="Device not assigned to My Site")
+    if not device.is_active_site_member:
+        raise HTTPException(status_code=403, detail="Device not assigned to My Site")
+    if not device.is_active_site_member:
+        raise HTTPException(status_code=403, detail="Device not assigned to My Site")
     cred, source = resolve_ssh_credential(db, device, current_user)
     output = ""
     error = None
@@ -246,6 +252,9 @@ async def port_search_action(search: str = Form(...), device_ids: list[int] = Fo
     results = []
     devices = db.query(Device).filter(Device.id.in_(device_ids)).all()
     for device in devices:
+        if not device.is_active_site_member:
+            results.append({"device": device, "output": "", "error": "Not part of My Site", "cred_source": None})
+            continue
         cred, source = resolve_ssh_credential(db, device, current_user)
         output = ""
         error = None
@@ -286,6 +295,9 @@ async def bulk_port_update_action(device_ids: list[int] = Form(...), ports: str 
     ports_list = [p.strip() for p in ports.splitlines() if p.strip()]
     message_parts = []
     for device in devices:
+        if not device.is_active_site_member:
+            message_parts.append(f"{device.hostname}: not in site")
+            continue
         cred, _ = resolve_ssh_credential(db, device, current_user)
         if not cred:
             message_parts.append(f"{device.hostname}: no credentials")

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -5,9 +5,10 @@ import asyncssh
 from app.utils.ssh import build_conn_kwargs
 
 from app.utils.db_session import SessionLocal
-from app.models.models import ConfigBackup
+from app.models.models import ConfigBackup, Device
 from app.utils.audit import log_audit
 import os
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
 QUEUE_INTERVAL = int(os.environ.get("QUEUE_INTERVAL", "60"))
 
@@ -50,4 +51,114 @@ def start_queue_worker(app):
     @app.on_event("startup")
     async def start_worker():
         asyncio.create_task(queue_worker())
+
+
+# -------------------- Scheduled Config Pulls --------------------
+
+scheduler = AsyncIOScheduler()
+
+INTERVAL_MAP = {
+    "hourly": {"hours": 1},
+    "daily": {"days": 1},
+    "weekly": {"weeks": 1},
+}
+
+
+async def run_config_pull(device_id: int):
+    """Perform an SSH config pull and store the result."""
+    db = SessionLocal()
+    device = db.query(Device).filter(Device.id == device_id).first()
+    if not device:
+        db.close()
+        return
+    cred = device.ssh_credential
+    if not cred:
+        db.close()
+        return
+    conn_kwargs = build_conn_kwargs(cred)
+    output = ""
+    try:
+        async with asyncssh.connect(device.ip, **conn_kwargs) as conn:
+            result = await conn.run("show running-config", check=False)
+            output = result.stdout
+            device.last_seen = datetime.utcnow()
+            device.last_config_pull = datetime.utcnow()
+            backup = ConfigBackup(
+                device_id=device.id,
+                source="scheduled",
+                config_text=output,
+            )
+            db.add(backup)
+            db.commit()
+            max_backups = int(os.environ.get("MAX_BACKUPS", "10"))
+            backups = (
+                db.query(ConfigBackup)
+                .filter(ConfigBackup.device_id == device.id)
+                .order_by(ConfigBackup.created_at.desc())
+                .all()
+            )
+            if len(backups) > max_backups:
+                for old in backups[max_backups:]:
+                    db.delete(old)
+                db.commit()
+            log_audit(db, None, "pull", device, "Scheduled config pull")
+    except Exception as exc:
+        log_audit(db, None, "debug", device, f"Scheduled pull error: {exc}")
+        db.commit()
+    finally:
+        db.close()
+
+
+def schedule_device_config_pull(device: Device):
+    """Register or update a scheduled config pull job for the device."""
+    job_id = f"config_pull_{device.id}"
+    if (
+        not device.is_active_site_member
+        or device.config_pull_interval == "none"
+    ):
+        try:
+            scheduler.remove_job(job_id)
+        except Exception:
+            pass
+        return
+
+    trigger_args = INTERVAL_MAP.get(device.config_pull_interval)
+    if not trigger_args:
+        return
+
+    scheduler.add_job(
+        run_config_pull,
+        trigger="interval",
+        id=job_id,
+        kwargs={"device_id": device.id},
+        replace_existing=True,
+        **trigger_args,
+    )
+
+
+def unschedule_device_config_pull(device_id: int):
+    """Remove a scheduled job for the device if present."""
+    job_id = f"config_pull_{device_id}"
+    try:
+        scheduler.remove_job(job_id)
+    except Exception:
+        pass
+
+
+def start_config_scheduler(app):
+    @app.on_event("startup")
+    async def start_sched():
+        scheduler.start()
+        db = SessionLocal()
+        devices = (
+            db.query(Device)
+            .filter(
+                Device.is_active_site_member.is_(True),
+                Device.config_pull_interval != "none",
+            )
+            .all()
+        )
+        for dev in devices:
+            schedule_device_config_pull(dev)
+        db.close()
 

--- a/app/templates/device_form.html
+++ b/app/templates/device_form.html
@@ -104,6 +104,20 @@
       On R1
     </label>
   </div>
+  <div>
+    <label class="inline-flex items-center">
+      <input type="checkbox" name="is_active_site_member" value="1" class="mr-2" {% if device and device.is_active_site_member %}checked{% endif %}>
+      Part of My Site
+    </label>
+  </div>
+  <div>
+    <label class="block">Config Pull Interval</label>
+    <select name="config_pull_interval" class="w-full p-2 text-black">
+      {% for opt in ['none','hourly','daily','weekly'] %}
+      <option value="{{ opt }}" {% if device and device.config_pull_interval == opt %}selected{% endif %}>{{ opt.title() }}</option>
+      {% endfor %}
+    </select>
+  </div>
   <div class="md:col-span-2">
     <button type="submit" class="bg-blue-600 px-4 py-2">Submit</button>
     <a href="/devices" class="ml-2 underline">Cancel</a>

--- a/app/websockets/terminal.py
+++ b/app/websockets/terminal.py
@@ -45,6 +45,10 @@ async def terminal_ws(websocket: WebSocket, device_id: int):
             await websocket.send_text("Device not found")
             await websocket.close()
             return
+        if not device.is_active_site_member:
+            await websocket.send_text("Device not assigned to My Site")
+            await websocket.close()
+            return
 
         cred, _ = resolve_ssh_credential(db, device, user)
         if not cred:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ google-auth
 psycopg2-binary
 gunicorn
 requests
+apscheduler

--- a/seed_data.py
+++ b/seed_data.py
@@ -69,6 +69,8 @@ def main():
                     ssh_credential_id=cred.id,
                     snmp_community_id=snmp.id,
                     location_id=loc.id,
+                    is_active_site_member=True,
+                    config_pull_interval="none",
                 )
                 db.add(device)
             db.commit()


### PR DESCRIPTION
## Summary
- extend `Device` with site membership and config pull fields
- schedule config pulls with APScheduler
- restrict live interactions to site devices only
- allow enabling config pulls via device form

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_684d88588c408324a723673ff1b9f8d7