### PR TITLE
Fix FastAPI request parameter

### DIFF
--- a/app/routes/bulk.py
+++ b/app/routes/bulk.py
@@ -56,12 +56,12 @@ async def bulk_vlan_push_form(
 
 @router.post("/vlan-push")
 async def bulk_vlan_push_action(
+    request: Request,
     vlan_id: int = Form(...),
     template_id: Optional[int] = Form(None),
     config_text: str = Form(""),
     model_filter: str = Form(""),
     confirm: str | None = Form(None),
-    request: Request | None = None,
     db: Session = Depends(get_db),
     current_user=Depends(require_role("editor")),
 ):


### PR DESCRIPTION
## Summary
- remove `Request | None` union from `bulk_vlan_push_action`
- reorder arguments so required `Request` comes first

## Testing
- `python -m py_compile app/routes/bulk.py`
- `find app -name '*.py' | xargs python -m py_compile`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d97f727c4832488855af874031788