### PR TITLE
Add VLAN usage report

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ from app.routes import (
     inventory_router,
     admin_site_router,
     bulk_router,
+    reports_router,
 )
 from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
@@ -78,6 +79,7 @@ app.include_router(login_events_router)
 app.include_router(inventory_router)
 app.include_router(admin_site_router)
 app.include_router(bulk_router)
+app.include_router(reports_router)
 
 
 @app.exception_handler(HTTPException)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -24,6 +24,7 @@ from .login_events import router as login_events_router
 from .inventory import router as inventory_router
 from .admin_site import router as admin_site_router
 from .bulk import router as bulk_router
+from .reports import router as reports_router
 
 __all__ = [
     "auth_router",
@@ -52,4 +53,5 @@ __all__ = [
     "inventory_router",
     "admin_site_router",
     "bulk_router",
+    "reports_router",
 ]

--- a/app/routes/reports.py
+++ b/app/routes/reports.py
@@ -1,0 +1,57 @@
+from fastapi import APIRouter, Request, Depends
+from fastapi.responses import Response
+from sqlalchemy.orm import Session
+import csv
+import io
+
+from app.utils.db_session import get_db
+from app.utils.auth import require_role, get_user_site_ids
+from app.models.models import VLAN, Device
+from app.utils.templates import templates
+
+router = APIRouter(prefix="/reports")
+
+@router.get("/vlan-usage")
+async def vlan_usage(
+    request: Request,
+    format: str | None = None,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("user")),
+):
+    site_ids = get_user_site_ids(db, current_user)
+    vlans = db.query(VLAN).order_by(VLAN.tag).all()
+    report = []
+    for vlan in vlans:
+        devices = (
+            db.query(Device)
+            .filter(Device.vlan_id == vlan.id, Device.site_id.in_(site_ids))
+            .all()
+        )
+        report.append({"vlan": vlan, "devices": devices, "count": len(devices)})
+
+    if format == "csv":
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["VLAN Tag", "Description", "Hostname", "IP", "Model", "Config Pull"])
+        for row in report:
+            vlan = row["vlan"]
+            if row["devices"]:
+                for d in row["devices"]:
+                    writer.writerow([
+                        vlan.tag,
+                        vlan.description or "",
+                        d.hostname,
+                        d.ip,
+                        d.model or "",
+                        d.config_pull_interval,
+                    ])
+            else:
+                writer.writerow([vlan.tag, vlan.description or "", "", "", "", ""])
+        return Response(
+            output.getvalue(),
+            media_type="text/csv",
+            headers={"Content-Disposition": "attachment; filename=vlan_usage.csv"},
+        )
+
+    context = {"request": request, "report": report, "current_user": current_user}
+    return templates.TemplateResponse("vlan_usage_report.html", context)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -59,6 +59,12 @@
                 </ul>
               </li>
               <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Reports</a>
+                <ul class="dropdown-menu">
+                  <li><a class="dropdown-item" href="/reports/vlan-usage">VLAN Usage</a></li>
+                </ul>
+              </li>
+              <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">SSH</a>
                 <ul class="dropdown-menu">
                   <li><a class="dropdown-item" href="/ssh/port-config">Port Config</a></li>

--- a/app/templates/vlan_usage_report.html
+++ b/app/templates/vlan_usage_report.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">VLAN Usage Report</h1>
+<a href="?format=csv" class="underline">Download CSV</a>
+{% for row in report %}
+  <details class="mb-3">
+    <summary class="px-2 py-1 cursor-pointer {% if row.count == 0 %}bg-red-700{% elif row.count > 10 %}bg-yellow-700{% else %}bg-gray-800{% endif %}">
+      VLAN {{ row.vlan.tag }} - {{ row.vlan.description or '' }} ({{ row.count }} devices)
+    </summary>
+    {% if row.devices %}
+    <table class="min-w-full bg-black mt-2">
+      <thead>
+        <tr>
+          <th class="px-4 py-2 text-left">Hostname</th>
+          <th class="px-4 py-2 text-left">IP</th>
+          <th class="px-4 py-2 text-left">Model</th>
+          <th class="px-4 py-2 text-left">Config Pull</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for d in row.devices %}
+        <tr class="border-t border-gray-700">
+          <td class="px-4 py-2">{{ d.hostname }}</td>
+          <td class="px-4 py-2">{{ d.ip }}</td>
+          <td class="px-4 py-2">{{ d.model or '' }}</td>
+          <td class="px-4 py-2">{{ d.config_pull_interval }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
+  </details>
+{% else %}
+  <p>No VLANs found.</p>
+{% endfor %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add reports router with VLAN usage report endpoint
- support optional CSV export of VLAN usage
- link VLAN usage under new Reports dropdown in nav

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d98f40eac832486959dd8b525ae64