### PR TITLE
Add config snapshot export

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.routes import (
     admin_site_router,
     bulk_router,
     reports_router,
+    export_router,
 )
 from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
@@ -80,6 +81,7 @@ app.include_router(inventory_router)
 app.include_router(admin_site_router)
 app.include_router(bulk_router)
 app.include_router(reports_router)
+app.include_router(export_router)
 
 
 @app.exception_handler(HTTPException)

--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -13,6 +13,7 @@
     <ul class="dropdown-menu">
       <li><a class="dropdown-item" href="/export/inventory.csv">Export to CSV</a></li>
       <li><a class="dropdown-item" href="/export/inventory.pdf">Export to PDF</a></li>
+      <li><a class="dropdown-item" href="/export/config-snapshot.zip">Download Config Snapshot</a></li>
     </ul>
   </div>
 {% endif %}


### PR DESCRIPTION
## Summary
- export latest configs for all devices in user's sites as a zip
- register export router and expose a Download Config Snapshot button

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d9bedb9348324bad1ad71fd45e805