### PR TITLE
Add port status history tracking

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -16,6 +16,8 @@ from .models import (
     DeviceEditLog,
     BannedIP,
     LoginEvent,
+    EmailLog,
+    PortStatusHistory,
 )
 
 __all__ = [
@@ -36,4 +38,6 @@ __all__ = [
     "DeviceEditLog",
     "BannedIP",
     "LoginEvent",
+    "EmailLog",
+    "PortStatusHistory",
 ]

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -303,3 +303,18 @@ class EmailLog(Base):
     details = Column(Text, nullable=True)
 
     site = relationship("Site")
+
+class PortStatusHistory(Base):
+    __tablename__ = "port_status_history"
+
+    id = Column(Integer, primary_key=True)
+    device_id = Column(Integer, ForeignKey("devices.id"), nullable=False)
+    interface_name = Column(String, nullable=False)
+    oper_status = Column(String, nullable=True)
+    admin_status = Column(String, nullable=True)
+    speed = Column(Integer, nullable=True)
+    poe_draw = Column(Integer, nullable=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    device = relationship("Device")
+

--- a/app/templates/port_history.html
+++ b/app/templates/port_history.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Port History for {{ device.hostname }}</h1>
+<a href="/devices/{{ device.id }}/ports" class="underline">Back to Ports</a>
+<form method="get" class="my-4">
+  <label class="mr-2">Interface:
+    <select name="interface" onchange="this.form.submit()">
+      <option value="">All</option>
+      {% for intf in interfaces %}
+      <option value="{{ intf }}" {% if interface == intf %}selected{% endif %}>{{ intf }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label class="mr-2">Start:
+    <input type="date" name="start" value="{{ start or '' }}" onchange="this.form.submit()">
+  </label>
+  <label class="mr-2">End:
+    <input type="date" name="end" value="{{ end or '' }}" onchange="this.form.submit()">
+  </label>
+  <label>
+    <input type="checkbox" name="changes_only" value="1" {% if changes_only %}checked{% endif %} onchange="this.form.submit()">
+    Changes only
+  </label>
+</form>
+<table class="min-w-full bg-black">
+  <thead>
+    <tr>
+      <th class="px-4 py-2 text-left">Timestamp</th>
+      <th class="px-4 py-2 text-left">Interface</th>
+      <th class="px-4 py-2 text-left">Oper Status</th>
+      <th class="px-4 py-2 text-left">Admin Status</th>
+      <th class="px-4 py-2 text-left">Speed</th>
+      <th class="px-4 py-2 text-left">PoE Draw</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for entry in entries %}
+    <tr class="border-t border-gray-700">
+      <td class="px-4 py-2">{{ entry.timestamp }}</td>
+      <td class="px-4 py-2">{{ entry.interface_name }}</td>
+      <td class="px-4 py-2">{{ entry.oper_status }}</td>
+      <td class="px-4 py-2">{{ entry.admin_status }}</td>
+      <td class="px-4 py-2">{{ entry.speed or '' }} Mbps</td>
+      <td class="px-4 py-2">{{ entry.poe_draw or '' }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- introduce `PortStatusHistory` model for tracking SNMP port states
- log port status in `/devices/{device_id}/ports`
- display port history via new `/devices/{device_id}/ports/history` route
- schedule daily cleanup of old history records

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9d0aec808324b096d35f4727c07e