### PR TITLE
Add universal config comparison feature

### DIFF
--- a/app/static/dark.css
+++ b/app/static/dark.css
@@ -46,3 +46,7 @@ textarea {
 .navbar .dropdown:hover .dropdown-menu {
   display: block;
 }
+.diff_add { background-color: #14532d; }
+.diff_chg { background-color: #78350f; }
+.diff_sub { background-color: #7f1d1d; }
+table.diff { width: 100%; }

--- a/app/templates/audit_log.html
+++ b/app/templates/audit_log.html
@@ -10,6 +10,7 @@
       <th class="px-4 py-2 text-left">Device</th>
       <th class="px-4 py-2 text-left">Action</th>
       <th class="px-4 py-2 text-left">Details</th>
+      <th class="px-4 py-2 text-left">Compare</th>
     </tr>
   </thead>
   <tbody>
@@ -20,6 +21,11 @@
       <td class="px-4 py-2">{{ entry.device.hostname if entry.device else '' }}</td>
       <td class="px-4 py-2">{{ entry.action_type }}</td>
       <td class="px-4 py-2">{{ entry.details }}</td>
+      <td class="px-4 py-2">
+        {% if entry.device %}
+        <a href="/compare-configs?device_id={{ entry.device.id }}" class="underline text-blue-400">Diff</a>
+        {% endif %}
+      </td>
     </tr>
   {% endfor %}
   </tbody>

--- a/app/templates/compare_configs.html
+++ b/app/templates/compare_configs.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Compare Configs</h1>
+<form method="get" class="mb-4">
+  <label for="device_id" class="me-2">Device:</label>
+  <select name="device_id" id="device_id" onchange="this.form.submit()" class="form-select d-inline w-auto">
+    {% for dev in devices %}
+    <option value="{{ dev.id }}" {% if device and dev.id == device.id %}selected{% endif %}>{{ dev.hostname }}</option>
+    {% endfor %}
+  </select>
+  {% if device %}
+  <label for="backup_a" class="ms-4 me-2">Config A:</label>
+  <select name="backup_a" id="backup_a" class="form-select d-inline w-auto">
+    {% for b in backups %}
+    <option value="{{ b.id }}" {% if b.id == backup_a %}selected{% endif %}>{{ b.created_at }}</option>
+    {% endfor %}
+  </select>
+  <label for="backup_b" class="ms-4 me-2">Config B:</label>
+  <select name="backup_b" id="backup_b" class="form-select d-inline w-auto">
+    {% for b in backups %}
+    <option value="{{ b.id }}" {% if b.id == backup_b %}selected{% endif %}>{{ b.created_at }}</option>
+    {% endfor %}
+  </select>
+  <button type="submit" class="btn btn-primary ms-2">Compare</button>
+  {% endif %}
+</form>
+{% if device %}
+<p class="mb-2">Device type: <span class="badge bg-secondary">{{ device.device_type.name }}</span></p>
+{% endif %}
+{% if diff_table %}
+<div class="overflow-auto">
+  {{ diff_table | safe }}
+</div>
+{% elif backup_a and backup_b %}
+<p class="text-red-500">Unable to load selected configs.</p>
+{% endif %}
+{% endblock %}

--- a/app/templates/config_list.html
+++ b/app/templates/config_list.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">Config Backups for {{ device.hostname }}</h1>
+<p><a href="/compare-configs?device_id={{ device.id }}" class="text-blue-400 underline">Compare</a></p>
 {% if device.last_snmp_check %}
 <p class="mb-4">
   {% if device.snmp_reachable %}


### PR DESCRIPTION
## Summary
- implement `/compare-configs` route for manual diff of any device's backups
- show a device drop-down and config selectors with diff output
- display device type badge and style diff output
- link comparison page from config history and audit log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da29ce0d0832498d4c993b347db45