### PR TITLE
Add SNMP trap listener and viewer

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -31,6 +31,7 @@ from app.routes import (
     bulk_router,
     reports_router,
     export_router,
+    snmp_traps_router,
 )
 from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
@@ -38,12 +39,13 @@ from app.websockets.editor import shell_ws
 from app.websockets.terminal import router as terminal_ws_router
 from app.routes.welcome import router as welcome_router, WELCOME_TEXT
 from app.utils.auth import get_current_user
-from app.tasks import start_queue_worker, start_config_scheduler
+from app.tasks import start_queue_worker, start_config_scheduler, setup_trap_listener
 from app.utils.templates import templates
 
 app = FastAPI()
 start_queue_worker(app)
 start_config_scheduler(app)
+setup_trap_listener(app)
 
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
@@ -82,6 +84,7 @@ app.include_router(admin_site_router)
 app.include_router(bulk_router)
 app.include_router(reports_router)
 app.include_router(export_router)
+app.include_router(snmp_traps_router)
 
 
 @app.exception_handler(HTTPException)

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -323,3 +323,18 @@ class PortStatusHistory(Base):
 
     device = relationship("Device")
 
+
+class SNMPTrapLog(Base):
+    __tablename__ = "snmp_trap_logs"
+
+    id = Column(Integer, primary_key=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    source_ip = Column(String, nullable=False)
+    trap_oid = Column(String, nullable=True)
+    message = Column(Text, nullable=True)
+    device_id = Column(Integer, ForeignKey("devices.id"), nullable=True)
+    site_id = Column(Integer, ForeignKey("sites.id"), nullable=True)
+
+    device = relationship("Device")
+    site = relationship("Site")
+

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -26,6 +26,7 @@ from .admin_site import router as admin_site_router
 from .bulk import router as bulk_router
 from .reports import router as reports_router
 from .export import router as export_router
+from .snmp_traps import router as snmp_traps_router
 
 __all__ = [
     "auth_router",
@@ -56,4 +57,5 @@ __all__ = [
     "bulk_router",
     "reports_router",
     "export_router",
+    "snmp_traps_router",
 ]

--- a/app/routes/snmp_traps.py
+++ b/app/routes/snmp_traps.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+from typing import Optional
+from fastapi import APIRouter, Request, Depends
+from app.utils.db_session import get_db
+from sqlalchemy.orm import Session
+from app.utils.auth import require_role
+from app.utils.templates import templates
+from app.models.models import SNMPTrapLog, Device
+
+router = APIRouter()
+
+
+@router.get("/snmp/traps")
+async def view_traps(
+    request: Request,
+    device_id: Optional[int] = None,
+    oid: Optional[str] = None,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("admin")),
+):
+    query = db.query(SNMPTrapLog)
+    if device_id:
+        query = query.filter(SNMPTrapLog.device_id == device_id)
+    if oid:
+        query = query.filter(SNMPTrapLog.trap_oid.contains(oid))
+    if start:
+        try:
+            start_dt = datetime.fromisoformat(start)
+            query = query.filter(SNMPTrapLog.timestamp >= start_dt)
+        except ValueError:
+            pass
+    if end:
+        try:
+            end_dt = datetime.fromisoformat(end)
+            query = query.filter(SNMPTrapLog.timestamp <= end_dt)
+        except ValueError:
+            pass
+    traps = query.order_by(SNMPTrapLog.timestamp.desc()).limit(200).all()
+    devices = db.query(Device).all()
+    context = {
+        "request": request,
+        "traps": traps,
+        "devices": devices,
+        "device_id": device_id,
+        "oid": oid,
+        "start": start,
+        "end": end,
+        "current_user": current_user,
+    }
+    return templates.TemplateResponse("snmp_traps.html", context)
+

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from collections import defaultdict
 import asyncssh
 from puresnmp import Client, PyWrapper, V2C
+from aiosnmp import SnmpV2TrapServer, SnmpMessage
 
 from app.utils.ssh import build_conn_kwargs
 from app.utils.device_detect import detect_ssh_platform
@@ -320,4 +321,78 @@ def start_config_scheduler(app):
             id="snmp_status_poll",
             replace_existing=True,
         )
+
+
+# -------------------- SNMP Trap Listener --------------------
+
+TRAP_PORT = int(os.environ.get("SNMP_TRAP_PORT", "162"))
+_trap_transport = None
+_trap_server = None
+_trap_running = False
+
+
+async def _trap_handler(host, port, message):
+    from app.models.models import SNMPTrapLog, Device
+
+    trap_oid = None
+    parts = []
+    for vb in message.data.varbinds:
+        val = vb.value
+        if vb.oid == "1.3.6.1.6.3.1.1.4.1.0":
+            trap_oid = val.decode() if isinstance(val, (bytes, bytearray)) else str(val)
+        if isinstance(val, (bytes, bytearray)):
+            try:
+                parts.append(val.decode())
+            except Exception:
+                parts.append(val.hex())
+        else:
+            parts.append(str(val))
+    text = "; ".join(parts)
+    if not text:
+        raw = SnmpMessage(message.version, message.community, message.data).encode()
+        text = raw.hex()
+
+    db = SessionLocal()
+    device = db.query(Device).filter(Device.ip == host).first()
+    log = SNMPTrapLog(
+        timestamp=datetime.utcnow(),
+        source_ip=host,
+        trap_oid=trap_oid,
+        message=text,
+        device_id=device.id if device else None,
+        site_id=device.site_id if device else None,
+    )
+    db.add(log)
+    db.commit()
+    db.close()
+
+
+async def start_trap_listener():
+    global _trap_transport, _trap_server, _trap_running
+    if _trap_running:
+        return
+    server = SnmpV2TrapServer(port=TRAP_PORT, handler=_trap_handler)
+    _trap_transport, _ = await server.run()
+    _trap_server = server
+    _trap_running = True
+
+
+async def stop_trap_listener():
+    global _trap_transport, _trap_server, _trap_running
+    if _trap_transport:
+        _trap_transport.close()
+        _trap_transport = None
+    _trap_server = None
+    _trap_running = False
+
+
+def trap_listener_running() -> bool:
+    return _trap_running
+
+
+def setup_trap_listener(app):
+    @app.on_event("startup")
+    async def _start():
+        if os.environ.get("ENABLE_TRAP_LISTENER") == "1":
+            await start_trap_listener()
 

--- a/app/templates/debug_log.html
+++ b/app/templates/debug_log.html
@@ -2,6 +2,19 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">Debug Logs</h1>
+<div class="mb-4">
+  <h2 class="text-lg">SNMP Trap Listener</h2>
+  <p>Status: {{ 'running' if trap_running else 'stopped' }} on port {{ trap_port }}</p>
+  <form method="post" action="/admin/debug/trap-listener">
+    {% if trap_running %}
+    <input type="hidden" name="action" value="stop">
+    <button type="submit" class="bg-red-600 px-3 py-1">Stop Listener</button>
+    {% else %}
+    <input type="hidden" name="action" value="start">
+    <button type="submit" class="bg-green-600 px-3 py-1">Start Listener</button>
+    {% endif %}
+  </form>
+</div>
 <form method="get" class="mb-4">
   <label class="mr-2">Show:
     <select name="show" onchange="this.form.submit()">

--- a/app/templates/snmp_traps.html
+++ b/app/templates/snmp_traps.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">SNMP Traps</h1>
+<form method="get" class="mb-4">
+  <label class="mr-2">Device:
+    <select name="device_id" onchange="this.form.submit()">
+      <option value="">All</option>
+      {% for d in devices %}
+      <option value="{{ d.id }}" {% if device_id and d.id == device_id %}selected{% endif %}>{{ d.hostname }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label class="mr-2">OID:
+    <input type="text" name="oid" value="{{ oid or '' }}" onchange="this.form.submit()">
+  </label>
+  <label class="mr-2">Start:
+    <input type="datetime-local" name="start" value="{{ start or '' }}" onchange="this.form.submit()">
+  </label>
+  <label>End:
+    <input type="datetime-local" name="end" value="{{ end or '' }}" onchange="this.form.submit()">
+  </label>
+</form>
+<table class="min-w-full bg-black">
+  <thead>
+    <tr>
+      <th class="px-4 py-2 text-left">Timestamp</th>
+      <th class="px-4 py-2 text-left">Source IP</th>
+      <th class="px-4 py-2 text-left">OID</th>
+      <th class="px-4 py-2 text-left">Device</th>
+      <th class="px-4 py-2 text-left">Site</th>
+      <th class="px-4 py-2 text-left">Message</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for trap in traps %}
+    <tr class="border-t border-gray-700">
+      <td class="px-4 py-2">{{ trap.timestamp }}</td>
+      <td class="px-4 py-2">{{ trap.source_ip }}</td>
+      <td class="px-4 py-2">{{ trap.trap_oid }}</td>
+      <td class="px-4 py-2">{{ trap.device.hostname if trap.device else '' }}</td>
+      <td class="px-4 py-2">{{ trap.site.name if trap.site else '' }}</td>
+      <td class="px-4 py-2"><details><summary>View</summary><pre>{{ trap.message }}</pre></details></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ super() }}
+<script>
+setInterval(() => { location.reload(); }, 15000);
+</script>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ python-multipart
 itsdangerous
 bcrypt
 puresnmp
+aiosnmp
 websockets
 gspread
 google-auth


### PR DESCRIPTION
## Summary
- log SNMP traps in new `SNMPTrapLog` model
- implement asyncio SNMP trap listener using `aiosnmp`
- expose listener control on debug page
- add `/snmp/traps` view for admins
- auto-refresh trap viewer

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_684da3d8cd8883249f3503f1cb88318c