### PR TITLE
Add syslog listener and live viewer

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,7 @@ from app.routes import (
     reports_router,
     export_router,
     snmp_traps_router,
+    syslog_router,
 )
 from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
@@ -39,13 +40,19 @@ from app.websockets.editor import shell_ws
 from app.websockets.terminal import router as terminal_ws_router
 from app.routes.welcome import router as welcome_router, WELCOME_TEXT
 from app.utils.auth import get_current_user
-from app.tasks import start_queue_worker, start_config_scheduler, setup_trap_listener
+from app.tasks import (
+    start_queue_worker,
+    start_config_scheduler,
+    setup_trap_listener,
+    setup_syslog_listener,
+)
 from app.utils.templates import templates
 
 app = FastAPI()
 start_queue_worker(app)
 start_config_scheduler(app)
 setup_trap_listener(app)
+setup_syslog_listener(app)
 
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
@@ -85,6 +92,7 @@ app.include_router(bulk_router)
 app.include_router(reports_router)
 app.include_router(export_router)
 app.include_router(snmp_traps_router)
+app.include_router(syslog_router)
 
 
 @app.exception_handler(HTTPException)

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -338,3 +338,19 @@ class SNMPTrapLog(Base):
     device = relationship("Device")
     site = relationship("Site")
 
+
+class SyslogEntry(Base):
+    __tablename__ = "syslog_entries"
+
+    id = Column(Integer, primary_key=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    device_id = Column(Integer, ForeignKey("devices.id"), nullable=True)
+    site_id = Column(Integer, ForeignKey("sites.id"), nullable=True)
+    source_ip = Column(String, nullable=False)
+    severity = Column(String, nullable=True)
+    facility = Column(String, nullable=True)
+    message = Column(Text, nullable=True)
+
+    device = relationship("Device")
+    site = relationship("Site")
+

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -27,6 +27,7 @@ from .bulk import router as bulk_router
 from .reports import router as reports_router
 from .export import router as export_router
 from .snmp_traps import router as snmp_traps_router
+from .syslog import router as syslog_router
 
 __all__ = [
     "auth_router",
@@ -58,4 +59,5 @@ __all__ = [
     "reports_router",
     "export_router",
     "snmp_traps_router",
+    "syslog_router",
 ]

--- a/app/routes/admin_debug.py
+++ b/app/routes/admin_debug.py
@@ -12,6 +12,10 @@ from app.tasks import (
     stop_trap_listener,
     trap_listener_running,
     TRAP_PORT,
+    start_syslog_listener,
+    stop_syslog_listener,
+    syslog_listener_running,
+    SYSLOG_PORT,
 )
 
 
@@ -48,6 +52,8 @@ async def debug_logs(
         "users": users,
         "trap_running": trap_listener_running(),
         "trap_port": TRAP_PORT,
+        "syslog_running": syslog_listener_running(),
+        "syslog_port": SYSLOG_PORT,
         "current_user": current_user,
     }
     return templates.TemplateResponse("debug_log.html", context)
@@ -76,4 +82,16 @@ async def toggle_trap_listener(
         await start_trap_listener()
     else:
         await stop_trap_listener()
+    return RedirectResponse(url="/admin/debug", status_code=302)
+
+
+@router.post("/admin/debug/syslog-listener")
+async def toggle_syslog_listener(
+    action: str = Form(...),
+    current_user=Depends(require_role("superadmin")),
+):
+    if action == "start":
+        await start_syslog_listener()
+    else:
+        await stop_syslog_listener()
     return RedirectResponse(url="/admin/debug", status_code=302)

--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -373,6 +373,14 @@ async def edit_device_form(
         model_list,
         sites,
     ) = _load_form_options(db)
+    from app.models.models import SyslogEntry
+    logs = (
+        db.query(SyslogEntry)
+        .filter(SyslogEntry.device_id == device.id)
+        .order_by(SyslogEntry.timestamp.desc())
+        .limit(10)
+        .all()
+    )
     context = {
         "request": request,
         "device": device,
@@ -385,6 +393,7 @@ async def edit_device_form(
         "sites": sites,
         "status_options": STATUS_OPTIONS,
         "form_title": "Edit Device",
+        "syslog_logs": logs,
     }
     return templates.TemplateResponse("device_form.html", context)
 

--- a/app/routes/syslog.py
+++ b/app/routes/syslog.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+from typing import Optional
+from fastapi import APIRouter, Request, Depends
+from sqlalchemy.orm import Session
+
+from app.utils.db_session import get_db
+from app.utils.auth import require_role
+from app.utils.templates import templates
+from app.models.models import SyslogEntry, Device, Site
+
+router = APIRouter()
+
+
+@router.get("/syslog/live")
+async def live_syslog(
+    request: Request,
+    device_id: Optional[int] = None,
+    site_id: Optional[int] = None,
+    severity: Optional[str] = None,
+    q: Optional[str] = None,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("admin")),
+):
+    query = db.query(SyslogEntry)
+    if device_id:
+        query = query.filter(SyslogEntry.device_id == device_id)
+    if site_id:
+        query = query.filter(SyslogEntry.site_id == site_id)
+    if severity:
+        query = query.filter(SyslogEntry.severity == severity)
+    if q:
+        query = query.filter(SyslogEntry.message.ilike(f"%{q}%"))
+    if start:
+        try:
+            start_dt = datetime.fromisoformat(start)
+            query = query.filter(SyslogEntry.timestamp >= start_dt)
+        except ValueError:
+            pass
+    if end:
+        try:
+            end_dt = datetime.fromisoformat(end)
+            query = query.filter(SyslogEntry.timestamp <= end_dt)
+        except ValueError:
+            pass
+    logs = query.order_by(SyslogEntry.timestamp.desc()).limit(200).all()
+    devices = db.query(Device).all()
+    sites = db.query(Site).all()
+    context = {
+        "request": request,
+        "logs": logs,
+        "devices": devices,
+        "sites": sites,
+        "device_id": device_id,
+        "site_id": site_id,
+        "severity": severity,
+        "q": q,
+        "start": start,
+        "end": end,
+        "current_user": current_user,
+    }
+    return templates.TemplateResponse("live_syslog.html", context)

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -396,3 +396,88 @@ def setup_trap_listener(app):
         if os.environ.get("ENABLE_TRAP_LISTENER") == "1":
             await start_trap_listener()
 
+
+# -------------------- Syslog Listener --------------------
+
+SYSLOG_PORT = int(os.environ.get("SYSLOG_PORT", "514"))
+_syslog_transport = None
+_syslog_running = False
+
+from syslog_rfc5424_parser import SyslogMessage, ParseError
+import syslogmp
+
+
+class _SyslogProtocol(asyncio.DatagramProtocol):
+    def datagram_received(self, data, addr):
+        try:
+            text = data.decode().strip()
+        except Exception:
+            return
+
+        timestamp = datetime.utcnow()
+        severity = None
+        facility = None
+        message = text
+        try:
+            msg = SyslogMessage.parse(text)
+            timestamp = msg.timestamp or timestamp
+            severity = str(msg.severity)
+            facility = str(msg.facility)
+            message = msg.msg
+        except Exception:
+            try:
+                m = syslogmp.parse(text)
+                timestamp = m.timestamp or timestamp
+                severity = str(m.severity)
+                facility = str(m.facility)
+                message = m.message
+            except Exception:
+                pass
+
+        db = SessionLocal()
+        from app.models.models import SyslogEntry, Device
+
+        device = db.query(Device).filter(Device.ip == addr[0]).first()
+        log = SyslogEntry(
+            timestamp=timestamp,
+            source_ip=addr[0],
+            severity=severity,
+            facility=facility,
+            message=message,
+            device_id=device.id if device else None,
+            site_id=device.site_id if device else None,
+        )
+        db.add(log)
+        db.commit()
+        db.close()
+
+
+async def start_syslog_listener():
+    global _syslog_transport, _syslog_running
+    if _syslog_running:
+        return
+    loop = asyncio.get_running_loop()
+    _syslog_transport, _ = await loop.create_datagram_endpoint(
+        _SyslogProtocol, local_addr=("0.0.0.0", SYSLOG_PORT)
+    )
+    _syslog_running = True
+
+
+async def stop_syslog_listener():
+    global _syslog_transport, _syslog_running
+    if _syslog_transport:
+        _syslog_transport.close()
+        _syslog_transport = None
+    _syslog_running = False
+
+
+def syslog_listener_running() -> bool:
+    return _syslog_running
+
+
+def setup_syslog_listener(app):
+    @app.on_event("startup")
+    async def _start_syslog():
+        if os.environ.get("ENABLE_SYSLOG_LISTENER") == "1":
+            await start_syslog_listener()
+

--- a/app/templates/debug_log.html
+++ b/app/templates/debug_log.html
@@ -15,6 +15,19 @@
     {% endif %}
   </form>
 </div>
+<div class="mb-4">
+  <h2 class="text-lg">Syslog Listener</h2>
+  <p>Status: {{ 'running' if syslog_running else 'stopped' }} on port {{ syslog_port }}</p>
+  <form method="post" action="/admin/debug/syslog-listener">
+    {% if syslog_running %}
+    <input type="hidden" name="action" value="stop">
+    <button type="submit" class="bg-red-600 px-3 py-1">Stop Listener</button>
+    {% else %}
+    <input type="hidden" name="action" value="start">
+    <button type="submit" class="bg-green-600 px-3 py-1">Start Listener</button>
+    {% endif %}
+  </form>
+</div>
 <form method="get" class="mb-4">
   <label class="mr-2">Show:
     <select name="show" onchange="this.form.submit()">

--- a/app/templates/device_form.html
+++ b/app/templates/device_form.html
@@ -130,6 +130,15 @@
     <a href="/devices" class="ml-2 underline">Cancel</a>
   </div>
 </form>
+{% if device %}
+<h2 class="text-lg mt-4">Recent Syslog</h2>
+<ul class="mb-4">
+  {% for log in syslog_logs %}
+  <li>{{ log.timestamp }} - {{ log.severity }} - {{ log.message }}</li>
+  {% endfor %}
+</ul>
+<a href="/syslog/live?device_id={{ device.id }}" class="underline">View All Logs</a>
+{% endif %}
 <script>
 document.addEventListener('DOMContentLoaded', function () {
   const ipField = document.getElementById('ip-field');

--- a/app/templates/live_syslog.html
+++ b/app/templates/live_syslog.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Live Syslog</h1>
+<form method="get" class="mb-4">
+  <label class="mr-2">Device:
+    <select name="device_id" onchange="this.form.submit()">
+      <option value="">All</option>
+      {% for d in devices %}
+      <option value="{{ d.id }}" {% if device_id and d.id == device_id %}selected{% endif %}>{{ d.hostname }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label class="mr-2">Site:
+    <select name="site_id" onchange="this.form.submit()">
+      <option value="">All</option>
+      {% for s in sites %}
+      <option value="{{ s.id }}" {% if site_id and s.id == site_id %}selected{% endif %}>{{ s.name }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label class="mr-2">Severity:
+    <input type="text" name="severity" value="{{ severity or '' }}" onchange="this.form.submit()">
+  </label>
+  <label class="mr-2">Keyword:
+    <input type="text" name="q" value="{{ q or '' }}" onchange="this.form.submit()">
+  </label>
+  <label class="mr-2">Start:
+    <input type="datetime-local" name="start" value="{{ start or '' }}" onchange="this.form.submit()">
+  </label>
+  <label>End:
+    <input type="datetime-local" name="end" value="{{ end or '' }}" onchange="this.form.submit()">
+  </label>
+</form>
+<table class="min-w-full bg-black">
+  <thead>
+    <tr>
+      <th class="px-4 py-2 text-left">Timestamp</th>
+      <th class="px-4 py-2 text-left">Source IP</th>
+      <th class="px-4 py-2 text-left">Device</th>
+      <th class="px-4 py-2 text-left">Severity</th>
+      <th class="px-4 py-2 text-left">Message</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for log in logs %}
+    <tr class="border-t border-gray-700">
+      <td class="px-4 py-2">{{ log.timestamp }}</td>
+      <td class="px-4 py-2">{{ log.source_ip }}</td>
+      <td class="px-4 py-2">{{ log.device.hostname if log.device else '' }}</td>
+      <td class="px-4 py-2">{{ log.severity }}</td>
+      <td class="px-4 py-2"><details><summary>View</summary><pre>{{ log.message }}</pre></details></td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ super() }}
+<script>
+setInterval(() => { location.reload(); }, 15000);
+</script>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ gunicorn
 requests
 apscheduler
 reportlab
+syslog-rfc5424-parser
+syslogmp


### PR DESCRIPTION
## Summary
- introduce `SyslogEntry` model
- implement syslog listener and startup hook
- enable toggles on debug page
- display recent syslog on device edit page
- add live syslog viewer page
- wire up new routes and requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684da70fcbd48324ae3c33c8354b4d7a