### PR TITLE
Implement Tag Manager and autocomplete

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -33,6 +33,7 @@ from app.routes import (
     export_router,
     snmp_traps_router,
     syslog_router,
+    tag_manager_router,
 )
 from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
@@ -93,6 +94,7 @@ app.include_router(reports_router)
 app.include_router(export_router)
 app.include_router(snmp_traps_router)
 app.include_router(syslog_router)
+app.include_router(tag_manager_router)
 
 
 @app.exception_handler(HTTPException)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -28,6 +28,7 @@ from .reports import router as reports_router
 from .export import router as export_router
 from .snmp_traps import router as snmp_traps_router
 from .syslog import router as syslog_router
+from .tag_manager import router as tag_manager_router
 
 __all__ = [
     "auth_router",
@@ -60,4 +61,5 @@ __all__ = [
     "export_router",
     "snmp_traps_router",
     "syslog_router",
+    "tag_manager_router",
 ]

--- a/app/routes/tag_manager.py
+++ b/app/routes/tag_manager.py
@@ -1,0 +1,114 @@
+from fastapi import APIRouter, Request, Depends, Form, HTTPException
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from app.utils.db_session import get_db
+from app.utils.auth import require_role, get_current_user
+from app.utils.templates import templates
+from app.utils.tags import add_tag_to_device, remove_tag_from_device
+from app.models.models import Tag
+
+router = APIRouter()
+
+
+@router.get("/admin/tags")
+async def tag_manager_page(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    tags = db.query(Tag).order_by(Tag.name).all()
+    counts = {t.id: len(t.devices) for t in tags}
+    context = {
+        "request": request,
+        "tags": tags,
+        "counts": counts,
+        "current_user": current_user,
+    }
+    return templates.TemplateResponse("tag_manager.html", context)
+
+
+@router.post("/admin/tags/{tag_id}/rename")
+async def rename_tag(
+    tag_id: int,
+    new_name: str = Form(...),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    name = new_name.strip().lower()
+    if name == "":
+        return RedirectResponse(url="/admin/tags", status_code=302)
+    existing = db.query(Tag).filter(func.lower(Tag.name) == name).first()
+    if existing and existing.id != tag.id:
+        for dev in list(tag.devices):
+            if existing not in dev.tags:
+                add_tag_to_device(db, dev, existing, current_user)
+            remove_tag_from_device(db, dev, tag, current_user)
+        db.delete(tag)
+    else:
+        tag.name = name
+    db.commit()
+    return RedirectResponse(url="/admin/tags", status_code=302)
+
+
+@router.post("/admin/tags/{tag_id}/merge")
+async def merge_tag(
+    tag_id: int,
+    target_id: int = Form(...),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    source = db.query(Tag).filter(Tag.id == tag_id).first()
+    target = db.query(Tag).filter(Tag.id == target_id).first()
+    if not source or not target:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    if source.id == target.id:
+        return RedirectResponse(url="/admin/tags", status_code=302)
+    for dev in list(source.devices):
+        if target not in dev.tags:
+            add_tag_to_device(db, dev, target, current_user)
+        remove_tag_from_device(db, dev, source, current_user)
+    db.delete(source)
+    db.commit()
+    return RedirectResponse(url="/admin/tags", status_code=302)
+
+
+@router.post("/admin/tags/{tag_id}/delete")
+async def delete_tag(
+    tag_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    tag = db.query(Tag).filter(Tag.id == tag_id).first()
+    if tag:
+        for dev in list(tag.devices):
+            remove_tag_from_device(db, dev, tag, current_user)
+        db.delete(tag)
+        db.commit()
+    return RedirectResponse(url="/admin/tags", status_code=302)
+
+
+@router.get("/tags/{tag_name}")
+async def devices_by_tag(
+    tag_name: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    tag = db.query(Tag).filter(func.lower(Tag.name) == tag_name.lower()).first()
+    if not tag:
+        raise HTTPException(status_code=404, detail="Tag not found")
+    devices = tag.devices
+    context = {
+        "request": request,
+        "tag": tag,
+        "devices": devices,
+        "current_user": current_user,
+    }
+    return templates.TemplateResponse("devices_by_tag.html", context)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -94,6 +94,7 @@
                     <li><a class="dropdown-item" href="/admin/ssh">SSH Credentials</a></li>
                     <li><a class="dropdown-item" href="/admin/snmp">SNMP Credentials</a></li>
                     <li><a class="dropdown-item" href="/device-types">Device Types</a></li>
+                    <li><a class="dropdown-item" href="/admin/tags">Tag Manager</a></li>
                     <li><a class="dropdown-item" href="/admin/locations">Locations</a></li>
                     <li><a class="dropdown-item" href="/admin/audit">Audit Log</a></li>
                     <li><a class="dropdown-item" href="/admin/ip-bans">IP Bans</a></li>

--- a/app/templates/device_form.html
+++ b/app/templates/device_form.html
@@ -126,6 +126,15 @@
     </select>
   </div>
   <div class="md:col-span-2">
+    <label class="block">Tags</label>
+    <input type="text" name="tag_names" list="tag-list" value="{{ device.tags | rejectattr('name', 'in', ['complete','incomplete']) | map(attribute='name') | join(', ') if device else '' }}" class="w-full p-2 text-black" />
+    <datalist id="tag-list">
+      {% for t in get_tags() %}
+      <option value="{{ t.name }}">{{ t.name }}</option>
+      {% endfor %}
+    </datalist>
+  </div>
+  <div class="md:col-span-2">
     <button type="submit" class="bg-blue-600 px-4 py-2">Submit</button>
     <a href="/devices" class="ml-2 underline">Cancel</a>
   </div>

--- a/app/templates/devices_by_tag.html
+++ b/app/templates/devices_by_tag.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Devices tagged '{{ tag.name }}'</h1>
+<table class="min-w-full bg-black">
+  <thead>
+    <tr>
+      <th class="px-4 py-2 text-left">Hostname</th>
+      <th class="px-4 py-2 text-left">IP</th>
+      <th class="px-4 py-2 text-left">Tags</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for dev in devices %}
+    <tr class="border-t border-gray-700">
+      <td class="px-4 py-2"><a href="/devices/{{ dev.id }}/edit" class="underline">{{ dev.hostname }}</a></td>
+      <td class="px-4 py-2">{{ dev.ip }}</td>
+      <td class="px-4 py-2">{{ dev.tags | map(attribute='name') | join(', ') }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/tag_manager.html
+++ b/app/templates/tag_manager.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Tag Manager</h1>
+<table class="min-w-full bg-black mt-4">
+  <thead>
+    <tr>
+      <th class="px-4 py-2 text-left">Tag</th>
+      <th class="px-4 py-2 text-left">Count</th>
+      <th class="px-4 py-2 text-left">Rename</th>
+      <th class="px-4 py-2 text-left">Merge Into</th>
+      <th class="px-4 py-2"></th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for tag in tags %}
+    <tr class="border-t border-gray-700">
+      <td class="px-4 py-2">{{ tag.name }}</td>
+      <td class="px-4 py-2">{{ counts.get(tag.id, 0) }}</td>
+      <td class="px-4 py-2">
+        <form method="post" action="/admin/tags/{{ tag.id }}/rename" class="d-inline">
+          <input type="text" name="new_name" class="w-32 p-1 text-black" />
+          <button type="submit" class="btn btn-sm btn-secondary">Rename</button>
+        </form>
+      </td>
+      <td class="px-4 py-2">
+        <form method="post" action="/admin/tags/{{ tag.id }}/merge" class="d-inline">
+          <select name="target_id" class="text-black">
+            {% for t in tags %}
+              {% if t.id != tag.id %}
+              <option value="{{ t.id }}">{{ t.name }}</option>
+              {% endif %}
+            {% endfor %}
+          </select>
+          <button type="submit" class="btn btn-sm btn-warning">Merge</button>
+        </form>
+      </td>
+      <td class="px-4 py-2">
+        <form method="post" action="/admin/tags/{{ tag.id }}/delete" class="d-inline">
+          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete tag?')">Delete</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/utils/tags.py
+++ b/app/utils/tags.py
@@ -1,9 +1,35 @@
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 
 from app.models.models import Device, Tag, DeviceType, Location
+from app.utils.audit import log_audit
+from app.models.models import User
 
 
-def update_device_complete_tag(db: Session, device: Device) -> None:
+def get_or_create_tag(db: Session, name: str) -> Tag:
+    """Return existing tag matching name (case-insensitive) or create it."""
+    name = name.lower()
+    tag = db.query(Tag).filter(func.lower(Tag.name) == name).first()
+    if not tag:
+        tag = Tag(name=name)
+        db.add(tag)
+        db.flush()
+    return tag
+
+
+def add_tag_to_device(db: Session, device: Device, tag: Tag, user: User | None) -> None:
+    if tag not in device.tags:
+        device.tags.append(tag)
+        log_audit(db, user, "tag_add", device, f"Added tag {tag.name}")
+
+
+def remove_tag_from_device(db: Session, device: Device, tag: Tag, user: User | None) -> None:
+    if tag in device.tags:
+        device.tags.remove(tag)
+        log_audit(db, user, "tag_remove", device, f"Removed tag {tag.name}")
+
+
+def update_device_complete_tag(db: Session, device: Device, user: User | None = None) -> None:
     """Ensure device has the correct complete/incomplete tag."""
     required = [
         device.hostname,
@@ -20,35 +46,19 @@ def update_device_complete_tag(db: Session, device: Device) -> None:
         device.snmp_community_id,
     ]
     is_complete = all(required)
-    complete = db.query(Tag).filter(Tag.name == "complete").first()
-    incomplete = db.query(Tag).filter(Tag.name == "incomplete").first()
-    if not complete:
-        complete = Tag(name="complete")
-        db.add(complete)
-    if not incomplete:
-        incomplete = Tag(name="incomplete")
-        db.add(incomplete)
-    db.flush()
+    complete = get_or_create_tag(db, "complete")
+    incomplete = get_or_create_tag(db, "incomplete")
     for t in list(device.tags):
         if t.name in ("complete", "incomplete"):
-            device.tags.remove(t)
+            remove_tag_from_device(db, device, t, user)
     if is_complete:
-        device.tags.append(complete)
+        add_tag_to_device(db, device, complete, user)
     else:
-        device.tags.append(incomplete)
-
-
-def _ensure_tag(db: Session, name: str) -> Tag:
-    tag = db.query(Tag).filter(Tag.name == name).first()
-    if not tag:
-        tag = Tag(name=name)
-        db.add(tag)
-        db.flush()
-    return tag
+        add_tag_to_device(db, device, incomplete, user)
 
 
 def update_device_attribute_tags(
-    db: Session, device: Device, old: dict | None = None
+    db: Session, device: Device, old: dict | None = None, user: User | None = None
 ) -> None:
     """Sync manufacturer, device type and location tags for a device."""
     old = old or {}
@@ -56,9 +66,9 @@ def update_device_attribute_tags(
     def remove_tag(name: str | None) -> None:
         if not name:
             return
-        tag = db.query(Tag).filter(Tag.name == name).first()
-        if tag and tag in device.tags:
-            device.tags.remove(tag)
+        tag = db.query(Tag).filter(func.lower(Tag.name) == name.lower()).first()
+        if tag:
+            remove_tag_from_device(db, device, tag, user)
 
     # Remove outdated tags if values changed
     if old.get("manufacturer") and old["manufacturer"] != device.manufacturer:
@@ -75,16 +85,13 @@ def update_device_attribute_tags(
             remove_tag(loc.name)
 
     # Ensure current tags
-    manu_tag = _ensure_tag(db, device.manufacturer)
-    if manu_tag not in device.tags:
-        device.tags.append(manu_tag)
+    manu_tag = get_or_create_tag(db, device.manufacturer)
+    add_tag_to_device(db, device, manu_tag, user)
 
     if device.device_type:
-        dtype_tag = _ensure_tag(db, device.device_type.name)
-        if dtype_tag not in device.tags:
-            device.tags.append(dtype_tag)
+        dtype_tag = get_or_create_tag(db, device.device_type.name)
+        add_tag_to_device(db, device, dtype_tag, user)
 
     if device.location_ref:
-        loc_tag = _ensure_tag(db, device.location_ref.name)
-        if loc_tag not in device.tags:
-            device.tags.append(loc_tag)
+        loc_tag = get_or_create_tag(db, device.location_ref.name)
+        add_tag_to_device(db, device, loc_tag, user)

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -1,6 +1,6 @@
 from fastapi.templating import Jinja2Templates
 from app.utils.db_session import SessionLocal
-from app.models.models import DeviceType
+from app.models.models import DeviceType, Tag
 
 templates = Jinja2Templates(directory="app/templates")
 
@@ -32,3 +32,12 @@ def get_device_types():
 # Make function available in Jinja templates
 templates.env.globals["get_device_types"] = get_device_types
 templates.env.filters["format_uptime"] = format_uptime
+
+
+def get_tags():
+    db = SessionLocal()
+    tags = db.query(Tag).order_by(Tag.name).all()
+    db.close()
+    return tags
+
+templates.env.globals["get_tags"] = get_tags


### PR DESCRIPTION
## Summary
- add Tag Manager routes and templates for superadmins
- make tags case-insensitive
- log tag add/remove in audit log
- add tag autocomplete on device forms
- list devices by tag with `/tags/{tag_name}`

## Testing
- `pytest -q`
- `python -m py_compile app/routes/tag_manager.py app/utils/tags.py app/routes/devices.py app/routes/task_views.py app/utils/templates.py app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_684dacc52ca48324813c33edacfdd052