### PR TITLE
Fix SnmpMessage import path

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -3,7 +3,8 @@ from datetime import datetime, timedelta
 from collections import defaultdict
 import asyncssh
 from puresnmp import Client, PyWrapper, V2C
-from aiosnmp import SnmpV2TrapServer, SnmpMessage
+from aiosnmp import SnmpV2TrapServer
+from aiosnmp.snmp import SnmpMessage
 
 from app.utils.ssh import build_conn_kwargs
 from app.utils.device_detect import detect_ssh_platform

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ python-multipart
 itsdangerous
 bcrypt
 puresnmp
-aiosnmp
+aiosnmp>=0.7
 websockets
 gspread
 google-auth


### PR DESCRIPTION
## Summary
- adjust SnmpMessage import to new `aiosnmp.snmp` path
- pin `aiosnmp` version

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `./start.sh` *(fails: Could not connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_684db0060c1483248836986ccfbc0587