### PR TITLE
Fix nested devices menu

### DIFF
--- a/app/static/dark.css
+++ b/app/static/dark.css
@@ -46,6 +46,14 @@ textarea {
 .navbar .dropdown:hover .dropdown-menu {
   display: block;
 }
+
+/* Show nested dropdown menus on hover */
+.navbar .dropdown-menu .dropend:hover > .dropdown-menu {
+  display: block;
+  top: 0;
+  left: 100%;
+  margin-left: 0.1rem;
+}
 .diff_add { background-color: #14532d; }
 .diff_chg { background-color: #78350f; }
 .diff_sub { background-color: #7f1d1d; }


### PR DESCRIPTION
## Summary
- show nested menus in dark theme

## Testing
- `pytest --maxfail=1 -q`


------
https://chatgpt.com/codex/tasks/task_e_684db2d59b508324abf1dc69ce944417