### PR TITLE
Remove manufacturer from device type model

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -62,7 +62,6 @@ class DeviceType(Base):
 
     id = Column(Integer, primary_key=True)
     name = Column(String, unique=True, nullable=False)
-    manufacturer = Column(String, nullable=False)
 
     devices = relationship("Device", back_populates="device_type")
 

--- a/app/routes/device_types.py
+++ b/app/routes/device_types.py
@@ -33,7 +33,6 @@ async def new_device_type_form(request: Request, current_user=Depends(require_ro
 async def create_device_type(
     request: Request,
     name: str = Form(...),
-    manufacturer: str = Form(...),
     db: Session = Depends(get_db),
     current_user=Depends(require_role("superadmin")),
 ):
@@ -41,13 +40,13 @@ async def create_device_type(
     if existing:
         context = {
             "request": request,
-            "dtype": {"name": name, "manufacturer": manufacturer},
+            "dtype": {"name": name},
             "form_title": "New Device Type",
             "error": "Name already exists",
         }
         return templates.TemplateResponse("device_type_form.html", context)
 
-    dtype = DeviceType(name=name, manufacturer=manufacturer)
+    dtype = DeviceType(name=name)
     db.add(dtype)
     db.commit()
     return RedirectResponse(url="/device-types", status_code=302)
@@ -72,7 +71,6 @@ async def update_device_type(
     type_id: int,
     request: Request,
     name: str = Form(...),
-    manufacturer: str = Form(...),
     db: Session = Depends(get_db),
     current_user=Depends(require_role("superadmin")),
 ):
@@ -84,11 +82,9 @@ async def update_device_type(
     if existing:
         context = {"request": request, "dtype": dtype, "form_title": "Edit Device Type", "error": "Name already exists"}
         dtype.name = name
-        dtype.manufacturer = manufacturer
         return templates.TemplateResponse("device_type_form.html", context)
 
     dtype.name = name
-    dtype.manufacturer = manufacturer
     db.commit()
     return RedirectResponse(url="/device-types", status_code=302)
 

--- a/app/routes/task_views.py
+++ b/app/routes/task_views.py
@@ -53,7 +53,7 @@ CSV_TABLES = {
         ],
     },
     "vlans": {"model": VLAN, "fields": ["tag", "description"]},
-    "device_types": {"model": DeviceType, "fields": ["name", "manufacturer"]},
+    "device_types": {"model": DeviceType, "fields": ["name"]},
     "ssh_credentials": {
         "model": SSHCredential,
         "fields": ["name", "username", "password", "private_key"],

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,15 +25,10 @@
               <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Inventory</a>
                 <ul class="dropdown-menu">
-                  <li class="dropend">
-                    <a class="dropdown-item dropdown-toggle" href="#" data-bs-toggle="dropdown" aria-expanded="false">Devices</a>
-                    <ul class="dropdown-menu">
-                      <li><a class="dropdown-item" href="/devices">All Devices</a></li>
-                      {% for dtype in get_device_types() %}
-                      <li><a class="dropdown-item" href="/devices/type/{{ dtype.id }}">{{ dtype.name }}</a></li>
-                      {% endfor %}
-                    </ul>
-                  </li>
+                  <li><a class="dropdown-item" href="/devices">All Devices</a></li>
+                  {% for dtype in get_device_types() %}
+                  <li><a class="dropdown-item" href="/devices/type/{{ dtype.id }}">{{ dtype.name }}</a></li>
+                  {% endfor %}
                   <li><a class="dropdown-item" href="/inventory/audit">Audit</a></li>
                   <li><a class="dropdown-item" href="/inventory/trailers">Trailer Inventory</a></li>
                   <li><a class="dropdown-item" href="/inventory/sites">Site Inventory</a></li>

--- a/app/templates/device_type_form.html
+++ b/app/templates/device_type_form.html
@@ -7,10 +7,6 @@
     <label class="block">Name</label>
     <input type="text" name="name" value="{{ dtype.name if dtype else '' }}" class="w-full p-2 text-black" required />
   </div>
-  <div>
-    <label class="block">Manufacturer</label>
-    <input type="text" name="manufacturer" value="{{ dtype.manufacturer if dtype else '' }}" class="w-full p-2 text-black" required />
-  </div>
   {% if error %}
   <p class="text-red-500">{{ error }}</p>
   {% endif %}

--- a/app/templates/device_type_list.html
+++ b/app/templates/device_type_list.html
@@ -9,7 +9,6 @@
     <tr>
       <th class="px-2"><input type="checkbox" id="select-all"></th>
       <th class="px-4 py-2 text-left">Name</th>
-      <th class="px-4 py-2 text-left">Manufacturer</th>
       <th></th>
     </tr>
   </thead>
@@ -18,7 +17,6 @@
     <tr class="border-t border-gray-700">
       <td class="px-2"><input type="checkbox" name="selected" value="{{ dt.id }}"></td>
       <td class="px-4 py-2">{{ dt.name }}</td>
-      <td class="px-4 py-2">{{ dt.manufacturer }}</td>
       <td class="px-4 py-2">
         <a href="/device-types/{{ dt.id }}/edit" class="text-blue-400 underline mr-2">Edit</a>
         <form method="post" action="/device-types/{{ dt.id }}/delete" style="display:inline">

--- a/seed_data.py
+++ b/seed_data.py
@@ -44,17 +44,17 @@ def main():
         # Seed device types
         switch_type = db.query(DeviceType).filter_by(name="Switch").first()
         if not switch_type:
-            switch_type = DeviceType(name="Switch", manufacturer="Cisco")
+            switch_type = DeviceType(name="Switch")
             db.add(switch_type)
 
         ap_type = db.query(DeviceType).filter_by(name="AP").first()
         if not ap_type:
-            ap_type = DeviceType(name="AP", manufacturer="Cisco")
+            ap_type = DeviceType(name="AP")
             db.add(ap_type)
 
         camera_type = db.query(DeviceType).filter_by(name="IP Camera").first()
         if not camera_type:
-            camera_type = DeviceType(name="IP Camera", manufacturer="Generic")
+            camera_type = DeviceType(name="IP Camera")
             db.add(camera_type)
         db.commit()
 


### PR DESCRIPTION
## Summary
- drop the manufacturer column from `DeviceType`
- update CRUD routes and forms for device types
- simplify inventory dropdown to show device types directly
- update seeding and task views to match new schema

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684db8a375488324835d0c8d8047e7e7