### PR TITLE
Add Device Import Wizard

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -309,6 +309,7 @@ class EmailLog(Base):
 
     site = relationship("Site")
 
+
 class PortStatusHistory(Base):
     __tablename__ = "port_status_history"
 
@@ -407,4 +408,20 @@ class SiteDashboardWidget(Base):
     position = Column(Integer, default=0)
     enabled = Column(Boolean, default=True)
 
+    site = relationship("Site")
+
+
+class ImportLog(Base):
+    __tablename__ = "import_logs"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+    file_name = Column(String, nullable=False)
+    device_count = Column(Integer, default=0)
+    site_id = Column(Integer, ForeignKey("sites.id"), nullable=True)
+    notes = Column(Text, nullable=True)
+    success = Column(Boolean, default=True)
+
+    user = relationship("User")
     site = relationship("Site")

--- a/app/routes/bulk.py
+++ b/app/routes/bulk.py
@@ -1,18 +1,32 @@
 from datetime import datetime
 from typing import Optional
+import csv
+import io
+import json
 
-from fastapi import APIRouter, Request, Depends, Form
+from fastapi import APIRouter, Request, Depends, Form, UploadFile, File
 from fastapi.responses import RedirectResponse
+from sqlalchemy import or_
+import openpyxl
 from sqlalchemy.orm import Session
 import asyncssh
 
-from app.models.models import Device, VLAN, ConfigBackup, PortConfigTemplate
+from app.models.models import (
+    Device,
+    VLAN,
+    ConfigBackup,
+    PortConfigTemplate,
+    ImportLog,
+    Site,
+)
 from app.utils.db_session import get_db
 from app.utils.auth import require_role, get_user_site_ids
 from app.utils.ssh import build_conn_kwargs, resolve_ssh_credential
 from app.utils.device_detect import detect_ssh_platform
 from app.utils.templates import templates
 from app.utils.audit import log_audit
+from app.utils.tags import get_or_create_tag, add_tag_to_device
+from app.routes.devices import _format_ip
 
 router = APIRouter(prefix="/bulk")
 
@@ -37,7 +51,9 @@ async def bulk_vlan_push_form(
 
     device_count = None
     if vlan_id:
-        q = db.query(Device).filter(Device.vlan_id == vlan_id, Device.site_id.in_(site_ids))
+        q = db.query(Device).filter(
+            Device.vlan_id == vlan_id, Device.site_id.in_(site_ids)
+        )
         if model_filter:
             q = q.filter(Device.model.ilike(f"%{model_filter}%"))
         device_count = q.count()
@@ -68,7 +84,11 @@ async def bulk_vlan_push_action(
     site_ids = get_user_site_ids(db, current_user)
     template = None
     if template_id:
-        template = db.query(PortConfigTemplate).filter(PortConfigTemplate.id == template_id).first()
+        template = (
+            db.query(PortConfigTemplate)
+            .filter(PortConfigTemplate.id == template_id)
+            .first()
+        )
         if template:
             config_text = template.config_text
     q = db.query(Device).filter(Device.vlan_id == vlan_id, Device.site_id.in_(site_ids))
@@ -80,11 +100,15 @@ async def bulk_vlan_push_action(
         vlan = db.query(VLAN).filter(VLAN.id == vlan_id).first()
         context = {
             "request": request,
-            "vlans": db.query(VLAN).filter(VLAN.id.in_(
-                db.query(Device.vlan_id)
-                .filter(Device.site_id.in_(site_ids), Device.vlan_id.is_not(None))
-                .distinct()
-            )).all(),
+            "vlans": db.query(VLAN)
+            .filter(
+                VLAN.id.in_(
+                    db.query(Device.vlan_id)
+                    .filter(Device.site_id.in_(site_ids), Device.vlan_id.is_not(None))
+                    .distinct()
+                )
+            )
+            .all(),
             "templates": db.query(PortConfigTemplate).all(),
             "selected_vlan": vlan_id,
             "model_filter": model_filter,
@@ -127,5 +151,205 @@ async def bulk_vlan_push_action(
         db.add(backup)
         db.commit()
 
-    log_audit(db, current_user, "bulk_vlan_push", None, f"VLAN push to {len(devices)} devices")
+    log_audit(
+        db, current_user, "bulk_vlan_push", None, f"VLAN push to {len(devices)} devices"
+    )
     return RedirectResponse(url="/tasks?message=Bulk+push+queued", status_code=302)
+
+
+def _parse_upload(file: UploadFile) -> tuple[list[str], list[list[str]]]:
+    """Return (columns, rows) parsed from CSV or XLSX upload."""
+    content = file.file.read()
+    file.file.close()
+    if file.filename.lower().endswith(".xlsx"):
+        wb = openpyxl.load_workbook(io.BytesIO(content))
+        ws = wb.active
+        columns = [str(c.value).strip() if c.value is not None else "" for c in ws[1]]
+        rows = []
+        for r in ws.iter_rows(min_row=2, values_only=True):
+            rows.append([str(v) if v is not None else "" for v in r])
+    else:
+        reader = csv.reader(io.StringIO(content.decode()))
+        data = list(reader)
+        if not data:
+            return [], []
+        columns = [c.strip() for c in data[0]]
+        rows = [list(r) for r in data[1:]]
+    return columns, rows
+
+
+def _map_rows(
+    columns: list[str], rows: list[list[str]], mapping: dict[str, str]
+) -> list[dict]:
+    mapped: list[dict] = []
+    for r in rows:
+        data = {}
+        for i, val in enumerate(r):
+            field = mapping.get(str(i))
+            if not field or field == "skip":
+                continue
+            data[field] = val.strip()
+        mapped.append(data)
+    return mapped
+
+
+@router.get("/device-import")
+async def device_import_form(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("editor")),
+):
+    sites = []
+    if current_user.role == "superadmin":
+        from app.models.models import Site
+
+        sites = db.query(Site).all()
+    context = {"request": request, "current_user": current_user, "sites": sites}
+    return templates.TemplateResponse("device_import_upload.html", context)
+
+
+@router.post("/device-import")
+async def device_import_wizard(
+    request: Request,
+    import_file: UploadFile = File(None),
+    file_data: str = Form(None),
+    site_id: str = Form(None),
+    confirm: str = Form(None),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("editor")),
+):
+    if import_file:
+        columns, rows = _parse_upload(import_file)
+        data = json.dumps({"columns": columns, "rows": rows})
+        fields = ["skip", "hostname", "ip", "device_type", "model", "vlan", "tags"]
+        context = {
+            "request": request,
+            "columns": columns,
+            "preview": rows[:5],
+            "file_data": data,
+            "fields": fields,
+            "site_id": site_id or "",
+            "current_user": current_user,
+        }
+        return templates.TemplateResponse("device_import_map.html", context)
+
+    if file_data and not confirm:
+        form = await request.form()
+        raw = json.loads(file_data)
+        mapping = {
+            str(i): form.get(f"map_{i}", "skip") for i in range(len(raw["columns"]))
+        }
+        mapping_json = json.dumps(mapping)
+        mapped_rows = _map_rows(raw["columns"], raw["rows"], mapping)
+        duplicates = []
+        for row in mapped_rows:
+            ip = row.get("ip")
+            host = row.get("hostname")
+            if not ip and not host:
+                continue
+            existing = (
+                db.query(Device)
+                .filter(or_(Device.ip == ip, Device.hostname == host))
+                .first()
+            )
+            if existing:
+                duplicates.append({"row": row, "existing": existing})
+        context = {
+            "request": request,
+            "duplicates": duplicates,
+            "mapping_json": mapping_json,
+            "file_data": file_data,
+            "site_id": site_id or "",
+            "current_user": current_user,
+        }
+        return templates.TemplateResponse("device_import_confirm.html", context)
+
+    if confirm and file_data:
+        mapping = json.loads(request.form.get("mapping_json"))
+        raw = json.loads(file_data)
+        mapped_rows = _map_rows(raw["columns"], raw["rows"], mapping)
+        added = 0
+        skipped = 0
+        updated = 0
+        errors = []
+        user_site_ids = get_user_site_ids(db, current_user)
+        chosen_site = int(site_id) if site_id else None
+        if chosen_site is None and len(user_site_ids) == 1:
+            chosen_site = user_site_ids[0]
+        action = request.form.get("conflict_action", "skip")
+        for row in mapped_rows:
+            ip = row.get("ip")
+            host = row.get("hostname")
+            if not ip or not host:
+                errors.append(f"Missing required fields in row {row}")
+                continue
+            ip = _format_ip(ip)
+            existing = (
+                db.query(Device)
+                .filter(or_(Device.ip == ip, Device.hostname == host))
+                .first()
+            )
+            if existing:
+                if action == "skip":
+                    skipped += 1
+                    continue
+                if action in {"overwrite", "merge"}:
+                    if action == "overwrite":
+                        existing.ip = ip
+                        existing.hostname = host
+                        if row.get("model"):
+                            existing.model = row["model"]
+                        if row.get("vlan"):
+                            existing.vlan_id = row["vlan"]
+                    else:
+                        if not existing.model and row.get("model"):
+                            existing.model = row["model"]
+                        if not existing.vlan_id and row.get("vlan"):
+                            existing.vlan_id = row["vlan"]
+                    updated += 1
+                    device = existing
+                else:
+                    skipped += 1
+                    continue
+            else:
+                device = Device(
+                    hostname=host,
+                    ip=ip,
+                    model=row.get("model"),
+                    manufacturer=row.get("manufacturer") or "",
+                    device_type_id=None,
+                    vlan_id=row.get("vlan"),
+                    site_id=chosen_site,
+                    created_by_id=current_user.id,
+                )
+                db.add(device)
+                added += 1
+            tags_val = row.get("tags")
+            if tags_val:
+                names = [t.strip().lower() for t in tags_val.split(",") if t.strip()]
+                for name in names:
+                    tag = get_or_create_tag(db, name)
+                    add_tag_to_device(db, device, tag, current_user)
+        db.commit()
+        db.add(
+            ImportLog(
+                user_id=current_user.id,
+                file_name="upload",
+                device_count=len(mapped_rows),
+                site_id=chosen_site,
+                notes="Imported",
+                success=len(errors) == 0,
+            )
+        )
+        db.commit()
+        context = {
+            "request": request,
+            "added": added,
+            "skipped": skipped,
+            "updated": updated,
+            "errors": errors,
+            "current_user": current_user,
+        }
+        return templates.TemplateResponse("device_import_result.html", context)
+
+    return RedirectResponse(url="/bulk/device-import", status_code=302)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -68,9 +68,14 @@
                   <li><a class="dropdown-item" href="/ssh/port-search">Port Search</a></li>
                   <li><a class="dropdown-item" href="/ssh/bulk-port-update">Bulk Port Update</a></li>
                   <li><a class="dropdown-item" href="/bulk/vlan-push">VLAN Bulk Push</a></li>
-                  <li><a class="dropdown-item" href="/ssh/netbird-connect">Initiate Netbird Connection</a></li>
+                <li><a class="dropdown-item" href="/ssh/netbird-connect">Initiate Netbird Connection</a></li>
                 </ul>
               </li>
+              {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
+              <li class="nav-item">
+                <a class="nav-link" href="/bulk/device-import">Bulk Add Devices</a>
+              </li>
+              {% endif %}
             </ul>
             <div class="d-flex align-items-center">
               {% if current_user %}
@@ -91,6 +96,7 @@
                     <li><a class="dropdown-item" href="/device-types">Device Types</a></li>
                     <li><a class="dropdown-item" href="/admin/tags">Tag Manager</a></li>
                     <li><a class="dropdown-item" href="/admin/locations">Locations</a></li>
+                    <li><a class="dropdown-item" href="/bulk/device-import">Device Import</a></li>
                     <li><a class="dropdown-item" href="/admin/audit">Audit Log</a></li>
                     <li><a class="dropdown-item" href="/admin/ip-bans">IP Bans</a></li>
                     <li><a class="dropdown-item" href="/admin/users">User Management</a></li>
@@ -100,6 +106,7 @@
                     <li><a class="dropdown-item" href="/admin/snmp">SNMP Credentials</a></li>
                     <li><a class="dropdown-item" href="/device-types">Device Types</a></li>
                     <li><a class="dropdown-item" href="/admin/locations">Locations</a></li>
+                    <li><a class="dropdown-item" href="/bulk/device-import">Device Import</a></li>
                     {% endif %}
                   </ul>
                 </div>

--- a/app/templates/device_import_confirm.html
+++ b/app/templates/device_import_confirm.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">Confirm Import</h1>
+<form method="post" class="space-y-4">
+  <input type="hidden" name="file_data" value="{{ file_data }}" />
+  <input type="hidden" name="mapping_json" value='{{ mapping_json }}' />
+  <input type="hidden" name="site_id" value="{{ site_id }}" />
+  {% if duplicates %}
+  <p class="text-red-400">{{ duplicates|length }} conflicts detected.</p>
+  {% for d in duplicates %}
+  <p class="text-red-400">{{ d.row.hostname }} / {{ d.row.ip }} already exists as {{ d.existing.hostname }}</p>
+  {% endfor %}
+  {% endif %}
+  <label class="block">On conflict:
+    <select name="conflict_action" class="text-black">
+      <option value="skip">Skip</option>
+      <option value="overwrite">Overwrite</option>
+      <option value="merge">Merge</option>
+    </select>
+  </label>
+  <button type="submit" name="confirm" value="yes" class="bg-blue-600 px-4 py-2">Import</button>
+</form>
+{% endblock %}

--- a/app/templates/device_import_map.html
+++ b/app/templates/device_import_map.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">Map Columns</h1>
+<form method="post" class="space-y-4">
+  <input type="hidden" name="file_data" value="{{ file_data }}" />
+  <input type="hidden" name="site_id" value="{{ site_id }}" />
+  <table class="table-auto mb-4 border">
+    <thead>
+      <tr>
+        {% for col in columns %}<th class="border px-2">{{ col }}</th>{% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in preview %}
+      <tr>
+        {% for cell in row %}<td class="border px-2">{{ cell }}</td>{% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <div>
+    <p>Map each column:</p>
+    {% for col in columns %}
+    <label class="block">{{ col }}
+      <select name="map_{{ loop.index0 }}" class="text-black">
+        {% for f in fields %}
+        <option value="{{ f }}">{{ f }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    {% endfor %}
+  </div>
+  <button type="submit" class="bg-blue-600 px-4 py-2">Next</button>
+</form>
+{% endblock %}

--- a/app/templates/device_import_result.html
+++ b/app/templates/device_import_result.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">Import Results</h1>
+<ul class="mb-4">
+  <li>Devices added: {{ added }}</li>
+  <li>Devices skipped: {{ skipped }}</li>
+  <li>Devices updated: {{ updated }}</li>
+</ul>
+{% if errors %}
+<p class="text-red-400">Errors:</p>
+<ul>
+  {% for e in errors %}<li>{{ e }}</li>{% endfor %}
+</ul>
+{% endif %}
+<a href="/devices" class="underline">Return to devices</a>
+{% endblock %}

--- a/app/templates/device_import_upload.html
+++ b/app/templates/device_import_upload.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">Device Import</h1>
+<form method="post" enctype="multipart/form-data" class="space-y-4">
+  {% if current_user.role == 'superadmin' %}
+  <div>
+    <label class="block">Site</label>
+    <select name="site_id" class="w-full p-2 text-black">
+      {% for s in sites %}
+      <option value="{{ s.id }}">{{ s.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  {% endif %}
+  <div>
+    <label class="block">CSV or Spreadsheet</label>
+    <input type="file" name="import_file" required class="w-full text-black" />
+  </div>
+  <button type="submit" class="bg-blue-600 px-4 py-2">Next</button>
+</form>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ apscheduler
 reportlab
 syslog-rfc5424-parser
 syslogmp
+
+openpyxl


### PR DESCRIPTION
## Summary
- add `ImportLog` model
- extend `/bulk` routes with a multi-step device import wizard
- add templates for uploading, mapping, confirming and results
- link device import in navbar for editors/admins and admin dropdown
- support spreadsheet uploads via `openpyxl`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684db9884ecc8324b04d36d256dae8d5