### PR TITLE
Add customizable device columns

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -22,6 +22,7 @@ from .models import (
     InterfaceChangeLog,
     DashboardWidget,
     SiteDashboardWidget,
+    ColumnPreference,
 )
 
 __all__ = [
@@ -48,4 +49,5 @@ __all__ = [
     "InterfaceChangeLog",
     "DashboardWidget",
     "SiteDashboardWidget",
+    "ColumnPreference",
 ]

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -411,6 +411,19 @@ class SiteDashboardWidget(Base):
     site = relationship("Site")
 
 
+class ColumnPreference(Base):
+    __tablename__ = "column_preferences"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    view = Column(String, nullable=False)
+    name = Column(String, nullable=False)
+    position = Column(Integer, default=0)
+    enabled = Column(Boolean, default=True)
+
+    user = relationship("User")
+
+
 class ImportLog(Base):
     __tablename__ = "import_logs"
 

--- a/app/templates/device_column_prefs.html
+++ b/app/templates/device_column_prefs.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="text-xl mb-4">Device Column Preferences</h1>
+<form method="post">
+  {% for name, label in column_labels.items() %}
+  <div class="mb-2">
+    <label class="inline-flex items-center">
+      <input type="checkbox" name="columns" value="{{ name }}" class="mr-2" {% if prefs[name] %}checked{% endif %}>
+      {{ label }}
+    </label>
+  </div>
+  {% endfor %}
+  <button type="submit" class="bg-blue-600 px-4 py-2">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">Devices</h1>
+<a href="/devices/column-prefs" class="underline block mb-2">Customize Columns</a>
 {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
   <a href="/devices/new" class="underline">Add Device</a>
 {% endif %}
@@ -43,65 +44,65 @@
   <thead>
     <tr>
       <th class="px-2"><input type="checkbox" id="select-all"></th>
-      <th class="px-4 py-2 text-left">Hostname</th>
-      <th class="px-4 py-2 text-left">IP</th>
-      <th class="px-4 py-2 text-left">MAC</th>
-      <th class="px-4 py-2 text-left">Asset Tag</th>
-      <th class="px-4 py-2 text-left">Model</th>
-      <th class="px-4 py-2 text-left">Manufacturer</th>
-      <th class="px-4 py-2 text-left">Platform</th>
-      <th class="px-4 py-2 text-left">Serial</th>
-      <th class="px-4 py-2 text-left">Location</th>
-      <th class="px-4 py-2 text-left">On Lasso</th>
-      <th class="px-4 py-2 text-left">On R1</th>
-      <th class="px-4 py-2 text-left">Type</th>
-      <th class="px-4 py-2 text-left">State</th>
-      <th class="px-4 py-2 text-left">VLAN</th>
-      <th class="px-4 py-2 text-left">SSH Profile</th>
-      <th class="px-4 py-2 text-left">SNMP Profile</th>
-      <th class="px-4 py-2 text-left">Status</th>
-      <th class="px-4 py-2 text-left">Tags</th>
+      {% if column_prefs.hostname %}<th class="px-4 py-2 text-left">{{ column_labels['hostname'] }}</th>{% endif %}
+      {% if column_prefs.ip %}<th class="px-4 py-2 text-left">{{ column_labels['ip'] }}</th>{% endif %}
+      {% if column_prefs.mac %}<th class="px-4 py-2 text-left">{{ column_labels['mac'] }}</th>{% endif %}
+      {% if column_prefs.asset_tag %}<th class="px-4 py-2 text-left">{{ column_labels['asset_tag'] }}</th>{% endif %}
+      {% if column_prefs.model %}<th class="px-4 py-2 text-left">{{ column_labels['model'] }}</th>{% endif %}
+      {% if column_prefs.manufacturer %}<th class="px-4 py-2 text-left">{{ column_labels['manufacturer'] }}</th>{% endif %}
+      {% if column_prefs.platform %}<th class="px-4 py-2 text-left">{{ column_labels['platform'] }}</th>{% endif %}
+      {% if column_prefs.serial %}<th class="px-4 py-2 text-left">{{ column_labels['serial'] }}</th>{% endif %}
+      {% if column_prefs.location %}<th class="px-4 py-2 text-left">{{ column_labels['location'] }}</th>{% endif %}
+      {% if column_prefs.on_lasso %}<th class="px-4 py-2 text-left">{{ column_labels['on_lasso'] }}</th>{% endif %}
+      {% if column_prefs.on_r1 %}<th class="px-4 py-2 text-left">{{ column_labels['on_r1'] }}</th>{% endif %}
+      {% if column_prefs.type %}<th class="px-4 py-2 text-left">{{ column_labels['type'] }}</th>{% endif %}
+      {% if column_prefs.state %}<th class="px-4 py-2 text-left">{{ column_labels['state'] }}</th>{% endif %}
+      {% if column_prefs.vlan %}<th class="px-4 py-2 text-left">{{ column_labels['vlan'] }}</th>{% endif %}
+      {% if column_prefs.ssh_profile %}<th class="px-4 py-2 text-left">{{ column_labels['ssh_profile'] }}</th>{% endif %}
+      {% if column_prefs.snmp_profile %}<th class="px-4 py-2 text-left">{{ column_labels['snmp_profile'] }}</th>{% endif %}
+      {% if column_prefs.status %}<th class="px-4 py-2 text-left">{{ column_labels['status'] }}</th>{% endif %}
+      {% if column_prefs.tags %}<th class="px-4 py-2 text-left">{{ column_labels['tags'] }}</th>{% endif %}
     </tr>
   </thead>
   <tbody>
   {% for device in devices %}
     <tr class="border-t border-gray-700">
       <td class="px-2"><input type="checkbox" name="selected" value="{{ device.id }}"></td>
-      <td class="px-4 py-2">{{ device.hostname }}</td>
-      <td class="px-4 py-2 {% if device.ip and duplicate_ips.get(device.ip) %}duplicate{% endif %}" title="{{ duplicate_ips.get(device.ip)|join(', ') if duplicate_ips.get(device.ip) }}">{{ device.ip }}</td>
-      <td class="px-4 py-2 {% if device.mac and duplicate_macs.get(device.mac) %}duplicate{% endif %}" title="{{ duplicate_macs.get(device.mac)|join(', ') if duplicate_macs.get(device.mac) }}">{{ device.mac or '' }}</td>
-      <td class="px-4 py-2 {% if device.asset_tag and duplicate_tags.get(device.asset_tag) %}duplicate{% endif %}" title="{{ duplicate_tags.get(device.asset_tag)|join(', ') if duplicate_tags.get(device.asset_tag) }}">{{ device.asset_tag or '' }}</td>
-      <td class="px-4 py-2">{{ device.model or '' }}</td>
-      <td class="px-4 py-2">{{ device.manufacturer }}</td>
-      <td class="px-4 py-2">{{ device.detected_platform or '' }}</td>
-      <td class="px-4 py-2">{{ device.serial_number or '' }}</td>
-      <td class="px-4 py-2">{{ device.location_ref.name if device.location_ref else '' }}</td>
-      <td class="px-4 py-2">{{ '✔' if device.on_lasso else '' }}</td>
-      <td class="px-4 py-2">{{ '✔' if device.on_r1 else '' }}</td>
-      <td class="px-4 py-2">{{ device.device_type.name if device.device_type else '' }}</td>
-      <td class="px-4 py-2">{{ device.status or '' }}</td>
-      <td class="px-4 py-2">{{ device.vlan.tag if device.vlan else '' }}</td>
-      <td class="px-4 py-2">
+      {% if column_prefs.hostname %}<td class="px-4 py-2">{{ device.hostname }}</td>{% endif %}
+      {% if column_prefs.ip %}<td class="px-4 py-2 {% if device.ip and duplicate_ips.get(device.ip) %}duplicate{% endif %}" title="{{ duplicate_ips.get(device.ip)|join(', ') if duplicate_ips.get(device.ip) }}">{{ device.ip }}</td>{% endif %}
+      {% if column_prefs.mac %}<td class="px-4 py-2 {% if device.mac and duplicate_macs.get(device.mac) %}duplicate{% endif %}" title="{{ duplicate_macs.get(device.mac)|join(', ') if duplicate_macs.get(device.mac) }}">{{ device.mac or '' }}</td>{% endif %}
+      {% if column_prefs.asset_tag %}<td class="px-4 py-2 {% if device.asset_tag and duplicate_tags.get(device.asset_tag) %}duplicate{% endif %}" title="{{ duplicate_tags.get(device.asset_tag)|join(', ') if duplicate_tags.get(device.asset_tag) }}">{{ device.asset_tag or '' }}</td>{% endif %}
+      {% if column_prefs.model %}<td class="px-4 py-2">{{ device.model or '' }}</td>{% endif %}
+      {% if column_prefs.manufacturer %}<td class="px-4 py-2">{{ device.manufacturer }}</td>{% endif %}
+      {% if column_prefs.platform %}<td class="px-4 py-2">{{ device.detected_platform or '' }}</td>{% endif %}
+      {% if column_prefs.serial %}<td class="px-4 py-2">{{ device.serial_number or '' }}</td>{% endif %}
+      {% if column_prefs.location %}<td class="px-4 py-2">{{ device.location_ref.name if device.location_ref else '' }}</td>{% endif %}
+      {% if column_prefs.on_lasso %}<td class="px-4 py-2">{{ '✔' if device.on_lasso else '' }}</td>{% endif %}
+      {% if column_prefs.on_r1 %}<td class="px-4 py-2">{{ '✔' if device.on_r1 else '' }}</td>{% endif %}
+      {% if column_prefs.type %}<td class="px-4 py-2">{{ device.device_type.name if device.device_type else '' }}</td>{% endif %}
+      {% if column_prefs.state %}<td class="px-4 py-2">{{ device.status or '' }}</td>{% endif %}
+      {% if column_prefs.vlan %}<td class="px-4 py-2">{{ device.vlan.tag if device.vlan else '' }}</td>{% endif %}
+      {% if column_prefs.ssh_profile %}<td class="px-4 py-2">
         {{ device.ssh_credential.name if device.ssh_credential else '' }}
         {% if device.ssh_credential %}
           {% if device.ssh_profile_is_default %}(default){% else %}(manual){% endif %}
         {% endif %}
         {% if personal_creds.get(device.id) %}(personal){% endif %}
-      </td>
-      <td class="px-4 py-2">{{ device.snmp_community.name if device.snmp_community else '' }}</td>
-      <td class="px-4 py-2">
+      </td>{% endif %}
+      {% if column_prefs.snmp_profile %}<td class="px-4 py-2">{{ device.snmp_community.name if device.snmp_community else '' }}</td>{% endif %}
+      {% if column_prefs.status %}<td class="px-4 py-2">
         {% if device.snmp_reachable %}
           <span class="text-green-400">●</span>
         {% else %}
           <span class="text-red-400">●</span>
         {% endif %}
         {{ device.uptime_seconds | format_uptime }}
-      </td>
-      <td class="px-4 py-2">{{ device.tags | map(attribute='name') | join(', ') }}</td>
+      </td>{% endif %}
+      {% if column_prefs.tags %}<td class="px-4 py-2">{{ device.tags | map(attribute='name') | join(', ') }}</td>{% endif %}
     </tr>
     {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
     <tr class="border-b border-gray-700">
-      <td colspan="18" class="px-4 py-2 text-right">
+      <td colspan="{{ column_count }}" class="px-4 py-2 text-right">
         <a href="/devices/{{ device.id }}/edit" class="btn btn-sm btn-secondary me-2">Edit</a>
         <form method="post" action="/devices/{{ device.id }}/delete" class="d-inline">
           <button type="submit" class="btn btn-sm btn-danger me-2" onclick="return confirm('Delete device?')">Delete</button>

--- a/app/utils/columns.py
+++ b/app/utils/columns.py
@@ -1,0 +1,55 @@
+from sqlalchemy.orm import Session
+
+from app.models.models import ColumnPreference
+
+DEFAULT_DEVICE_COLUMNS = [
+    "hostname",
+    "ip",
+    "mac",
+    "asset_tag",
+    "model",
+    "manufacturer",
+    "platform",
+    "serial",
+    "location",
+    "on_lasso",
+    "on_r1",
+    "type",
+    "state",
+    "vlan",
+    "ssh_profile",
+    "snmp_profile",
+    "status",
+    "tags",
+]
+
+DEVICE_COLUMN_LABELS = {
+    "hostname": "Hostname",
+    "ip": "IP",
+    "mac": "MAC",
+    "asset_tag": "Asset Tag",
+    "model": "Model",
+    "manufacturer": "Manufacturer",
+    "platform": "Platform",
+    "serial": "Serial",
+    "location": "Location",
+    "on_lasso": "On Lasso",
+    "on_r1": "On R1",
+    "type": "Type",
+    "state": "State",
+    "vlan": "VLAN",
+    "ssh_profile": "SSH Profile",
+    "snmp_profile": "SNMP Profile",
+    "status": "Status",
+    "tags": "Tags",
+}
+
+
+def load_column_preferences(db: Session, user_id: int, view: str) -> dict[str, bool]:
+    if view == "device_list":
+        prefs = {name: True for name in DEFAULT_DEVICE_COLUMNS}
+    else:
+        prefs = {}
+    for row in db.query(ColumnPreference).filter_by(user_id=user_id, view=view).all():
+        prefs[row.name] = row.enabled
+    return prefs


### PR DESCRIPTION
## Summary
- create `ColumnPreference` model for saving column selections
- load/save column preferences for device list
- add utilities for default columns
- allow editing device column preferences via new page
- render device list columns conditionally using saved prefs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684dda906e5083249520de8fe9aaf041