### PR TITLE
Style table corners and show version in tunables

### DIFF
--- a/app/routes/tunables.py
+++ b/app/routes/tunables.py
@@ -48,7 +48,16 @@ async def list_tunables(
     db: Session = Depends(get_db),
     current_user=Depends(require_role("admin")),
 ):
-    context = {"request": request, "groups": grouped_tunables(db)}
+    version_row = (
+        db.query(SystemTunable)
+        .filter(SystemTunable.name == "App Version")
+        .first()
+    )
+    context = {
+        "request": request,
+        "groups": grouped_tunables(db),
+        "version": version_row.value if version_row else "unknown",
+    }
     return templates.TemplateResponse("tunables.html", context)
 
 

--- a/app/static/themes/blue.css
+++ b/app/static/themes/blue.css
@@ -16,8 +16,10 @@ textarea {
 table {
   background-color: #003366;
   color: #f8f9fa;
-  border-radius: 0.5rem;
+  border-radius: 0.75rem;
   overflow: hidden;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 table thead th {
@@ -78,6 +80,7 @@ a.text-blue-400 {
   padding: 0.25rem 0.5rem;
   border-radius: 0.375rem;
   text-decoration: none;
+  display: inline-block;
 }
 a.underline:hover,
 a.text-blue-400:hover {

--- a/app/static/themes/dark.css
+++ b/app/static/themes/dark.css
@@ -17,8 +17,10 @@ textarea {
 table {
   background-color: #222034;
   color: #f8f9fa;
-  border-radius: 0.5rem;
+  border-radius: 0.75rem;
   overflow: hidden;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 .table thead th {
@@ -86,6 +88,7 @@ a.text-blue-400 {
   padding: 0.25rem 0.5rem;
   border-radius: 0.375rem;
   text-decoration: none;
+  display: inline-block;
 }
 a.underline:hover,
 a.text-blue-400:hover {

--- a/app/static/themes/light.css
+++ b/app/static/themes/light.css
@@ -16,8 +16,10 @@ textarea {
 table {
   background-color: #ffffff;
   color: #212529;
-  border-radius: 0.5rem;
+  border-radius: 0.75rem;
   overflow: hidden;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 table thead th {
@@ -78,6 +80,7 @@ a.text-blue-400 {
   padding: 0.25rem 0.5rem;
   border-radius: 0.375rem;
   text-decoration: none;
+  display: inline-block;
 }
 a.underline:hover,
 a.text-blue-400:hover {

--- a/app/templates/tunables.html
+++ b/app/templates/tunables.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">System Tunables</h1>
+<p class="mb-3">Current Version: <span class="fw-bold">{{ version }}</span></p>
 
 <ul class="nav nav-tabs" id="tunableTabs" role="tablist">
   {% for function in groups.keys() %}

--- a/seed_tunables.py
+++ b/seed_tunables.py
@@ -172,6 +172,14 @@ def main():
                 data_type="text",
                 description="Default sender address for outgoing mail",
             ),
+            SystemTunable(
+                name="App Version",
+                value="1.0.0",
+                function="General",
+                file_type="application",
+                data_type="text",
+                description="Deployed application version",
+            ),
         ]
         db.add_all(samples)
         db.commit()


### PR DESCRIPTION
## Summary
- soften table styling across themes
- style plain links like buttons
- store `App Version` in system tunables
- expose version on the tunables page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684de924e4648324881a4600dfc11586