### PR TITLE
Remove bootstrap btn classes from links

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -82,9 +82,9 @@
             </ul>
             <div class="d-flex align-items-center">
               {% if current_user %}
-                <a class="btn btn-sm btn-outline-light me-2" href="/dashboard">Dashboard</a>
-                <a class="btn btn-sm btn-outline-light me-2" href="/users/me">My Profile</a>
-                <a class="btn btn-sm btn-outline-light me-2" href="/user/ssh">SSH Profiles</a>
+                <a class="text-blue-400 underline mr-2" href="/dashboard">Dashboard</a>
+                <a class="text-blue-400 underline mr-2" href="/users/me">My Profile</a>
+                <a class="text-blue-400 underline mr-2" href="/user/ssh">SSH Profiles</a>
                 {% if current_user.role in ['admin','superadmin'] %}
                 <div class="btn-group me-2">
                   <button type="button" class="btn btn-sm btn-outline-light dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
@@ -113,9 +113,9 @@
                   </ul>
                 </div>
                 {% endif %}
-                <a href="/auth/logout" class="btn btn-sm btn-outline-warning">Logout</a>
+                <a href="/auth/logout" class="text-blue-400 underline">Logout</a>
               {% else %}
-                <a href="/auth/login" class="btn btn-sm btn-outline-light">Login</a>
+                <a href="/auth/login" class="text-blue-400 underline">Login</a>
               {% endif %}
             </div>
           </div>

--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -103,19 +103,19 @@
     {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
     <tr class="border-b border-gray-700">
       <td colspan="{{ column_count }}" class="px-4 py-2 text-right">
-        <a href="/devices/{{ device.id }}/edit" class="btn btn-sm btn-secondary me-2">Edit</a>
+        <a href="/devices/{{ device.id }}/edit" class="text-blue-400 underline mr-2">Edit</a>
         <form method="post" action="/devices/{{ device.id }}/delete" class="d-inline">
           <button type="submit" class="btn btn-sm btn-danger me-2" onclick="return confirm('Delete device?')">Delete</button>
         </form>
         <form method="post" action="/devices/{{ device.id }}/pull-config" class="d-inline">
           <button type="submit" class="btn btn-sm btn-success me-2">Pull Config</button>
         </form>
-        <a href="/devices/{{ device.id }}/push-config" class="btn btn-sm btn-warning me-2">Push Config</a>
-        <a href="/devices/{{ device.id }}/configs" class="btn btn-sm btn-info me-2">Configs</a>
+        <a href="/devices/{{ device.id }}/push-config" class="text-blue-400 underline mr-2">Push Config</a>
+        <a href="/devices/{{ device.id }}/configs" class="text-blue-400 underline mr-2">Configs</a>
         {% if device.snmp_community %}
-        <a href="/devices/{{ device.id }}/ports" class="btn btn-sm btn-primary me-2">Port Status</a>
-        <a href="/devices/{{ device.id }}/port-map" class="btn btn-sm btn-secondary me-2">Port Map</a>
-        <a href="/devices/{{ device.id }}/ports/edit" class="btn btn-sm btn-secondary">Port Editor</a>
+        <a href="/devices/{{ device.id }}/ports" class="text-blue-400 underline mr-2">Port Status</a>
+        <a href="/devices/{{ device.id }}/port-map" class="text-blue-400 underline mr-2">Port Map</a>
+        <a href="/devices/{{ device.id }}/ports/edit" class="text-blue-400 underline">Port Editor</a>
         {% endif %}
       </td>
     </tr>

--- a/app/templates/not_authorised.html
+++ b/app/templates/not_authorised.html
@@ -5,7 +5,7 @@
   <div class="container">
     <a class="navbar-brand" href="/">CES Inventory</a>
     <div class="d-flex">
-      <a href="/auth/login" class="btn btn-sm btn-outline-light">Login</a>
+      <a href="/auth/login" class="text-blue-400 underline">Login</a>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
## Summary
- switch device list links to underline styling
- convert login and logout links in base template
- remove leftover btn class from not_authorised template

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684ded85bfb48324a99d0296e1f725d0