### PR TITLE
Refactor theme overrides for Tailwind

### DIFF
--- a/app/static/themes/blue.css
+++ b/app/static/themes/blue.css
@@ -3,70 +3,9 @@ body {
   color: #f8f9fa;
 }
 
-.form-control,
-.form-select,
-textarea {
-  background-color: #002b5c;
-  color: #f8f9fa;
-  border: 1px solid #6c757d;
-  border-radius: 0.375rem;
-}
-
-.card,
-.table,
-table {
-  background-color: #003b6f;
-  color: #f8f9fa;
-  border-radius: 1rem;
-  overflow: hidden;
-  border-collapse: separate;
-  border-spacing: 0;
-  border: 1px solid #004c89;
-  width: 100%;
-}
-
-table thead th {
-  color: #ffffff;
-  background-color: #004080;
-}
-
-.alert {
-  border: 1px solid #6c757d;
-}
-
-.dropdown-menu {
-  background-color: #002b5c;
-  color: #f8f9fa;
-  border-radius: 0.375rem;
-}
-
-.dropdown-item {
-  color: #f8f9fa;
-}
-
-.dropdown-item:hover {
-  background-color: #004080;
-}
-
 .duplicate {
   background-color: #7f1d1d;
 }
-
-.navbar-dark.bg-dark {
-  background-color: #003366 !important;
-}
-
-.navbar .dropdown-menu .dropend:hover > .dropdown-menu {
-  display: block;
-  top: 0;
-  left: 100%;
-  margin-left: 0.1rem;
-}
-
-.diff_add { background-color: #065f46; }
-.diff_chg { background-color: #6b21a8; }
-.diff_sub { background-color: #7f1d1d; }
-table.diff { width: 100%; }
 
 .bg-black {
   background-color: #001a33 !important;
@@ -89,3 +28,8 @@ a.underline:hover,
 a.text-blue-400:hover {
   background-color: #0b5ed7;
 }
+
+.diff_add { background-color: #065f46; }
+.diff_chg { background-color: #6b21a8; }
+.diff_sub { background-color: #7f1d1d; }
+table.diff { width: 100%; }

--- a/app/static/themes/dark.css
+++ b/app/static/themes/dark.css
@@ -3,57 +3,8 @@ body {
   color: #f8f9fa;
 }
 
-.form-control,
-.form-select,
-textarea {
-  background-color: #212033;
-  color: #f8f9fa;
-  border: 1px solid #6c757d;
-  border-radius: 0.375rem;
-}
-
-.card,
-.table,
-table {
-  background-color: #292b40;
-  color: #f8f9fa;
-  border-radius: 1rem;
-  overflow: hidden;
-  border-collapse: separate;
-  border-spacing: 0;
-  border: 1px solid #444;
-  width: 100%;
-}
-
-.table thead th {
-  color: #ffffff;
-  background-color: #332f45;
-}
-
-.alert {
-  border: 1px solid #6c757d;
-}
-
-.dropdown-menu {
-  background-color: #212033;
-  color: #f8f9fa;
-  border-radius: 0.375rem;
-}
-
-.dropdown-item {
-  color: #f8f9fa;
-}
-
-.dropdown-item:hover {
-  background-color: #332f45;
-}
-
 .duplicate {
   background-color: #7f1d1d;
-}
-
-.navbar .dropdown:hover .dropdown-menu {
-  display: block;
 }
 
 /* Match navbar background to dark theme */
@@ -61,19 +12,6 @@ table {
   background-color: #222034 !important;
 }
 
-/* Show nested dropdown menus on hover */
-.navbar .dropdown-menu .dropend:hover > .dropdown-menu {
-  display: block;
-  top: 0;
-  left: 100%;
-  margin-left: 0.1rem;
-}
-.diff_add { background-color: #065f46; }
-.diff_chg { background-color: #6b21a8; }
-.diff_sub { background-color: #7f1d1d; }
-table.diff { width: 100%; }
-
-/* Override default Tailwind black background */
 .bg-black {
   background-color: #1f1f1f !important;
 }
@@ -82,7 +20,6 @@ table.diff { width: 100%; }
   border-color: #444 !important;
 }
 
-/* Style plain links as softer buttons */
 a.underline,
 a.text-blue-400 {
   color: #ffffff;
@@ -96,3 +33,8 @@ a.underline:hover,
 a.text-blue-400:hover {
   background-color: #5b21b6;
 }
+
+.diff_add { background-color: #065f46; }
+.diff_chg { background-color: #6b21a8; }
+.diff_sub { background-color: #7f1d1d; }
+table.diff { width: 100%; }

--- a/app/static/themes/light.css
+++ b/app/static/themes/light.css
@@ -3,51 +3,6 @@ body {
   color: #212529;
 }
 
-.form-control,
-.form-select,
-textarea {
-  background-color: #ffffff;
-  color: #212529;
-  border: 1px solid #ced4da;
-  border-radius: 0.375rem;
-}
-
-.card,
-.table,
-table {
-  background-color: #ffffff;
-  color: #212529;
-  border-radius: 1rem;
-  overflow: hidden;
-  border-collapse: separate;
-  border-spacing: 0;
-  border: 1px solid #ced4da;
-  width: 100%;
-}
-
-table thead th {
-  color: #212529;
-  background-color: #e9ecef;
-}
-
-.alert {
-  border: 1px solid #ced4da;
-}
-
-.dropdown-menu {
-  background-color: #ffffff;
-  color: #212529;
-  border-radius: 0.375rem;
-}
-
-.dropdown-item {
-  color: #212529;
-}
-
-.dropdown-item:hover {
-  background-color: #e9ecef;
-}
-
 .duplicate {
   background-color: #f8d7da;
 }
@@ -55,18 +10,6 @@ table thead th {
 .navbar-dark.bg-dark {
   background-color: #343a40 !important;
 }
-
-.navbar .dropdown-menu .dropend:hover > .dropdown-menu {
-  display: block;
-  top: 0;
-  left: 100%;
-  margin-left: 0.1rem;
-}
-
-.diff_add { background-color: #d1e7dd; }
-.diff_chg { background-color: #fff3cd; }
-.diff_sub { background-color: #f8d7da; }
-table.diff { width: 100%; }
 
 .bg-black {
   background-color: #ffffff !important;
@@ -89,3 +32,8 @@ a.underline:hover,
 a.text-blue-400:hover {
   background-color: #0069d9;
 }
+
+.diff_add { background-color: #d1e7dd; }
+.diff_chg { background-color: #fff3cd; }
+.diff_sub { background-color: #f8d7da; }
+table.diff { width: 100%; }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,43 @@
+module.exports = {
+  content: [
+    './app/templates/**/*.html',
+    './app/static/js/**/*.js'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        blue: {
+          900: '#001f3f',
+          800: '#002b5c',
+          700: '#003b6f',
+          600: '#004c89',
+          500: '#004080'
+        },
+        dark: {
+          900: '#1a1a2e',
+          800: '#212033',
+          700: '#292b40',
+          600: '#444',
+          500: '#332f45'
+        },
+        light: {
+          900: '#f8f9fa',
+          800: '#ffffff',
+          700: '#e9ecef',
+          600: '#ced4da',
+          500: '#dee2e6',
+          400: '#212529'
+        }
+      },
+      fontFamily: {
+        mono: ['Courier New', 'monospace'],
+        sans: ['Arial', 'Helvetica', 'sans-serif'],
+        serif: ['Georgia', 'Times New Roman', 'serif']
+      },
+      borderRadius: {
+        xl: '1rem'
+      }
+    }
+  },
+  plugins: []
+};


### PR DESCRIPTION
## Summary
- introduce a `tailwind.config.js` with custom colors and fonts
- clean up theme styles to remove old Bootstrap overrides
- keep only the minimal classes for theme colors and diffs

## Testing
- `pytest -q`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_684df499b6e08324987eb4f90ab31039