### PR TITLE
Remove leftover bootstrap selectors

### DIFF
--- a/app/static/themes/dark.css
+++ b/app/static/themes/dark.css
@@ -7,8 +7,8 @@ body {
   background-color: #7f1d1d;
 }
 
-/* Match navbar background to dark theme */
-.navbar-dark.bg-dark {
+/* Match navigation background to dark theme */
+nav.bg-gray-800 {
   background-color: #222034 !important;
 }
 

--- a/app/static/themes/light.css
+++ b/app/static/themes/light.css
@@ -7,7 +7,7 @@ body {
   background-color: #f8d7da;
 }
 
-.navbar-dark.bg-dark {
+nav.bg-gray-800 {
   background-color: #343a40 !important;
 }
 


### PR DESCRIPTION
## Summary
- drop `.navbar-dark.bg-dark` rules
- update CSS selectors to style Tailwind nav markup

## Testing
- `python -m compileall -q app`


------
https://chatgpt.com/codex/tasks/task_e_684df58f7ee48324bd36e8f14a9c1aa2