### PR TITLE
Add Dark Colourful theme

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -199,7 +199,7 @@ class User(Base):
     hashed_password = Column(String, nullable=False)
     role = Column(String, nullable=False, default="viewer")
     is_active = Column(Boolean, default=True)
-    theme = Column(String, nullable=False, default="dark")
+    theme = Column(String, nullable=False, default="dark_colourful")
     font = Column(String, nullable=False, default="sans")
     created_at = Column(DateTime, default=datetime.utcnow)
 

--- a/app/routes/admin_users.py
+++ b/app/routes/admin_users.py
@@ -39,7 +39,7 @@ async def new_user_form(request: Request, current_user=Depends(require_role("sup
         "show_active": True,
         "require_password": True,
         "cancel_url": "/admin/users",
-        "themes": ["dark", "light", "blue", "bw", "homebrew"],
+        "themes": ["dark_colourful", "dark", "light", "blue", "bw", "homebrew"],
         "fonts": ["sans", "serif", "mono"],
     }
     return templates.TemplateResponse("user_form.html", context)
@@ -52,7 +52,7 @@ async def create_user(
     password: str = Form(...),
     role: str = Form(...),
     is_active: bool = Form(False),
-    theme: str = Form("dark"),
+    theme: str = Form("dark_colourful"),
     font: str = Form("sans"),
     db: Session = Depends(get_db),
     current_user=Depends(require_role("superadmin")),
@@ -68,7 +68,7 @@ async def create_user(
             "show_active": True,
             "require_password": True,
             "cancel_url": "/admin/users",
-            "themes": ["dark", "light", "blue", "bw", "homebrew"],
+            "themes": ["dark_colourful", "dark", "light", "blue", "bw", "homebrew"],
             "fonts": ["sans", "serif", "mono"],
         }
         return templates.TemplateResponse("user_form.html", context)
@@ -109,7 +109,7 @@ async def edit_user_form(
         "show_active": True,
         "email_readonly": True,
         "cancel_url": "/admin/users",
-        "themes": ["dark", "light", "blue", "bw", "homebrew"],
+        "themes": ["dark_colourful", "dark", "light", "blue", "bw", "homebrew"],
         "fonts": ["sans", "serif", "mono"],
     }
     return templates.TemplateResponse("user_form.html", context)
@@ -121,7 +121,7 @@ async def update_user(
     request: Request,
     role: str = Form(...),
     is_active: bool = Form(False),
-    theme: str = Form("dark"),
+    theme: str = Form("dark_colourful"),
     font: str = Form("sans"),
     password: str | None = Form(None),
     db: Session = Depends(get_db),

--- a/app/routes/user_pages.py
+++ b/app/routes/user_pages.py
@@ -24,7 +24,7 @@ async def edit_my_profile_form(request: Request, current_user: User = Depends(re
         "user": current_user,
         "current_user": current_user,
         "error": None,
-        "themes": ["dark", "light", "blue", "bw", "homebrew"],
+        "themes": ["dark_colourful", "dark", "light", "blue", "bw", "homebrew"],
         "fonts": ["sans", "serif", "mono"],
     }
     return templates.TemplateResponse("user_form.html", context)
@@ -35,7 +35,7 @@ async def update_my_profile(
     request: Request,
     email: str = Form(...),
     password: str | None = Form(None),
-    theme: str = Form("dark"),
+    theme: str = Form("dark_colourful"),
     font: str = Form("sans"),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_role("viewer")),
@@ -48,7 +48,7 @@ async def update_my_profile(
             "user": current_user,
             "current_user": current_user,
             "error": "Email already in use",
-            "themes": ["dark", "light", "blue", "bw", "homebrew"],
+            "themes": ["dark_colourful", "dark", "light", "blue", "bw", "homebrew"],
             "fonts": ["sans", "serif", "mono"],
         }
         return templates.TemplateResponse("user_form.html", context)

--- a/app/static/themes/dark_colourful.css
+++ b/app/static/themes/dark_colourful.css
@@ -1,0 +1,88 @@
+body {
+  background-color: #111827;
+  color: #d1d5db;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #f3f4f6;
+}
+
+nav.bg-gray-800 {
+  background-color: #1f2937 !important;
+}
+
+.card, .bg-gray-800 {
+  background-color: #1f2937;
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0 0.25rem;
+}
+
+table thead th {
+  background-color: #332f45;
+  color: #ffffff;
+  font-weight: bold;
+  padding: 0.5rem 1rem;
+}
+
+table tbody tr:hover {
+  background-color: #374151;
+}
+
+table td {
+  padding: 0.5rem 1rem;
+}
+
+button, .btn {
+  border-radius: 0.375rem;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.875rem;
+}
+
+button.edit {
+  background-color: #facc15;
+  color: #000000;
+}
+button.edit:hover {
+  background-color: #fde047;
+}
+
+button.interface {
+  background-color: #3b82f6;
+  color: #ffffff;
+}
+button.interface:hover {
+  background-color: #60a5fa;
+}
+
+button.delete {
+  background-color: #dc2626;
+  color: #ffffff;
+}
+button.delete:hover {
+  background-color: #ef4444;
+}
+
+button.add {
+  background-color: #22c55e;
+  color: #ffffff;
+}
+button.add:hover {
+  background-color: #4ade80;
+}
+
+.logout {
+  border: 1px solid #d97706;
+  color: #facc15;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+}
+.logout:hover {
+  background-color: #78350f;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}CES Inventory{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    {% set theme = (current_user.theme if current_user else 'dark') if current_user is defined else 'dark' %}
+    {% set theme = (current_user.theme if current_user else 'dark_colourful') if current_user is defined else 'dark_colourful' %}
     {% set font = (current_user.font if current_user else 'sans') if current_user is defined else 'sans' %}
     <link rel="stylesheet" href="/static/themes/{{ theme }}.css">
     <link rel="stylesheet" href="/static/fonts/{{ font }}.css">

--- a/seed_superuser.py
+++ b/seed_superuser.py
@@ -22,7 +22,7 @@ def main():
             hashed_password=hashed_pw,
             role="superadmin",
             is_active=True,
-            theme="dark",
+            theme="dark_colourful",
             font="sans",
         )
         db.add(user)


### PR DESCRIPTION
## Summary
- add Dark Colourful CSS theme and set it as default
- update user and admin pages to recognise new theme
- set default user theme to Dark Colourful
- adjust seed script for superuser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df9e0b0e0832492b02b33ff981a9d