### PR TITLE
Add test for default dark theme

### DIFF
--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import importlib
+from unittest import mock
+from fastapi.testclient import TestClient
+
+
+def get_test_app():
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    # Remove imported app modules to ensure patches apply
+    for m in list(sys.modules):
+        if m.startswith("app"):
+            del sys.modules[m]
+    with mock.patch("sqlalchemy.create_engine"), \
+         mock.patch("sqlalchemy.schema.MetaData.create_all"), \
+         mock.patch("app.tasks.start_queue_worker"), \
+         mock.patch("app.tasks.start_config_scheduler"), \
+         mock.patch("app.tasks.setup_trap_listener"), \
+         mock.patch("app.tasks.setup_syslog_listener"):
+        return importlib.import_module("app.main").app
+
+
+app = get_test_app()
+client = TestClient(app)
+
+
+def test_index_references_dark_colourful():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "dark_colourful.css" in response.text
+
+
+def test_dark_colourful_css_served():
+    response = client.get("/static/themes/dark_colourful.css")
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add basic pytest suite for verifying dark theme usage
- ensure `/static/themes/dark_colourful.css` is served

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e00d45f6c8324b8ccc95446700507