### PR TITLE
Add shutdown cleanup hooks

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,5 +15,7 @@ except Exception:  # pragma: no cover - optional deps may be missing during test
 
     tasks.start_queue_worker = _noop
     tasks.start_config_scheduler = _noop
+    tasks.stop_queue_worker = _noop
+    tasks.stop_config_scheduler = _noop
     tasks.setup_trap_listener = _noop
     tasks.setup_syslog_listener = _noop

--- a/app/main.py
+++ b/app/main.py
@@ -44,6 +44,8 @@ from app.utils.auth import get_current_user
 from app.tasks import (
     start_queue_worker,
     start_config_scheduler,
+    stop_queue_worker,
+    stop_config_scheduler,
     setup_trap_listener,
     setup_syslog_listener,
 )
@@ -54,6 +56,13 @@ start_queue_worker(app)
 start_config_scheduler(app)
 setup_trap_listener(app)
 setup_syslog_listener(app)
+
+
+@app.on_event("shutdown")
+async def shutdown_cleanup():
+    await stop_queue_worker()
+    stop_config_scheduler()
+
 
 static_dir = os.path.join(os.path.dirname(__file__), "static")
 app.mount("/static", StaticFiles(directory=static_dir), name="static")

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import importlib
+import threading
+import asyncio
+from unittest import mock
+from fastapi.testclient import TestClient
+
+
+def get_app_for_shutdown():
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    for m in list(sys.modules):
+        if m.startswith("app"):
+            del sys.modules[m]
+
+    async def dummy_run_push_queue_once():
+        await asyncio.sleep(0)
+
+    def simple_config_scheduler(app):
+        from app.tasks import scheduler
+
+        @app.on_event("startup")
+        async def start_sched():
+            scheduler.start()
+
+    with mock.patch("sqlalchemy.create_engine"), mock.patch(
+        "sqlalchemy.schema.MetaData.create_all"
+    ), mock.patch(
+        "app.tasks.run_push_queue_once", dummy_run_push_queue_once
+    ), mock.patch(
+        "app.tasks.start_config_scheduler", simple_config_scheduler
+    ), mock.patch(
+        "app.tasks.setup_trap_listener"
+    ), mock.patch(
+        "app.tasks.setup_syslog_listener"
+    ):
+        return importlib.import_module("app.main").app
+
+
+def test_background_threads_cleanup():
+    start_threads = threading.active_count()
+    app = get_app_for_shutdown()
+    with TestClient(app) as client:
+        client.get("/")
+        assert threading.active_count() >= start_threads
+    # After shutdown, thread count should return to original
+    assert threading.active_count() == start_threads


### PR DESCRIPTION
## Summary
- expose methods to stop the queue worker and scheduler
- register shutdown event to run those methods
- stub new functions in `app.__init__`
- test that shutdown removes background threads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e06a163248324982a740835692856