### PR TITLE
Fix base template doctype and optional proxy middleware

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,10 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import JSONResponse
 
 from starlette.middleware.sessions import SessionMiddleware
-from starlette.middleware.proxy_headers import ProxyHeadersMiddleware
+try:
+    from starlette.middleware.proxy_headers import ProxyHeadersMiddleware
+except Exception:  # Module may be unavailable in some Starlette versions
+    ProxyHeadersMiddleware = None
 import os
 
 from app.routes import (
@@ -55,7 +58,8 @@ from app.utils.templates import templates
 app = FastAPI()
 # Respect headers like X-Forwarded-Proto so generated URLs use the
 # correct scheme when behind a reverse proxy.
-app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+if ProxyHeadersMiddleware:
+    app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 start_queue_worker(app)
 start_config_scheduler(app)
 setup_trap_listener(app)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
## Summary
- ensure HTML uses a standards-compliant `<!DOCTYPE html>`
- fall back if `ProxyHeadersMiddleware` is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e0ab7aa448324a29d94c9d95c3e45