### PR TITLE
Fix logout redirect URL

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -74,7 +74,8 @@ async def login(
 async def logout(request: Request):
     """Clear the user session and redirect to login."""
     request.session.clear()
-    return RedirectResponse(url="/login", status_code=302)
+    # Redirect to the prefixed login route
+    return RedirectResponse(url="/auth/login", status_code=302)
 
 
 @router.get("/me")


### PR DESCRIPTION
## Summary
- fix incorrect redirect after logout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684e130362308324b1bfc524cfe533ac