### PR TITLE
Fix static path references

### DIFF
--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -608,9 +608,11 @@ async def upload_damage_photo(
         raise HTTPException(status_code=403, detail="Device not assigned to your site")
     if not photo.content_type.startswith("image/"):
         raise HTTPException(status_code=400, detail="Invalid file type")
-    os.makedirs("app/static/damage", exist_ok=True)
+    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    damage_dir = os.path.join(base_dir, "static", "damage")
+    os.makedirs(damage_dir, exist_ok=True)
     filename = f"{device_id}_{int(datetime.utcnow().timestamp())}_{photo.filename}"
-    path = os.path.join("app/static/damage", filename)
+    path = os.path.join(damage_dir, filename)
     with open(path, "wb") as f:
         f.write(await photo.read())
     record = DeviceDamage(device_id=device.id, filename=filename)

--- a/app/routes/export.py
+++ b/app/routes/export.py
@@ -94,7 +94,8 @@ async def export_inventory_pdf(
     title = Paragraph("Device Inventory", styles["Title"])
     date = Paragraph(datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC"), styles["Normal"])
 
-    logo_path = os.path.join("app", "static", "logo.png")
+    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    logo_path = os.path.join(base_dir, "static", "logo.png")
     if os.path.exists(logo_path):
         try:
             elements.append(Image(logo_path, width=100, height=50))


### PR DESCRIPTION
## Summary
- ensure `devices.py` builds static damage path relative to project root
- ensure `export.py` locates logo.png using the same project root

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1c83ea888324a06ca4fd3b7797ee