### PR TITLE
Fix static directory path for FastAPI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -72,7 +72,9 @@ async def shutdown_cleanup():
     stop_config_scheduler()
 
 
-static_dir = os.path.join(os.path.dirname(__file__), "static")
+static_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "static")
+)
 app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
 # Store login information in signed cookies


### PR DESCRIPTION
## Summary
- ensure static directory uses absolute path for mounting

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e23faf6908324a6d6556812c560aa