### PR TITLE
Fix missing device list context

### DIFF
--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -261,6 +261,8 @@ async def list_devices_by_type(
             )
             if personal:
                 personal_map[d.id] = True
+    column_prefs = load_column_preferences(db, current_user.id, "device_list")
+    column_count = 1 + sum(1 for v in column_prefs.values() if v)
     context = {
         "request": request,
         "devices": devices,
@@ -271,6 +273,9 @@ async def list_devices_by_type(
         "duplicate_tags": duplicate_tags,
         "personal_creds": personal_map,
         "message": None,
+        "column_prefs": column_prefs,
+        "column_labels": DEVICE_COLUMN_LABELS,
+        "column_count": column_count,
     }
     return templates.TemplateResponse("device_list.html", context)
 


### PR DESCRIPTION
## Summary
- ensure `column_prefs` is available when listing devices by type

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e251a780883249eb09141c10f72fe