### PR TITLE
Fix damage photo filename sanitization

### DIFF
--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -616,7 +616,8 @@ async def upload_damage_photo(
         raise HTTPException(status_code=400, detail="Invalid file type")
     damage_dir = os.path.join(STATIC_DIR, "damage")
     os.makedirs(damage_dir, exist_ok=True)
-    filename = f"{device_id}_{int(datetime.utcnow().timestamp())}_{photo.filename}"
+    safe_name = os.path.basename(photo.filename)
+    filename = f"{device_id}_{int(datetime.utcnow().timestamp())}_{safe_name}"
     path = os.path.join(damage_dir, filename)
     with open(path, "wb") as f:
         f.write(await photo.read())

--- a/tests/test_damage_upload.py
+++ b/tests/test_damage_upload.py
@@ -1,0 +1,73 @@
+import os
+import io
+import sys
+import importlib
+from unittest import mock
+import types
+import asyncio
+from fastapi import UploadFile
+from starlette.datastructures import Headers
+
+
+def get_test_app():
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    for m in list(sys.modules):
+        if m.startswith("app"):
+            del sys.modules[m]
+    with mock.patch("sqlalchemy.create_engine"), \
+         mock.patch("sqlalchemy.schema.MetaData.create_all"), \
+         mock.patch("app.tasks.start_queue_worker"), \
+         mock.patch("app.tasks.start_config_scheduler"), \
+         mock.patch("app.tasks.setup_trap_listener"), \
+         mock.patch("app.tasks.setup_syslog_listener"):
+        return importlib.import_module("app.main").app
+
+
+def test_upload_damage_photo_sanitizes_filename(tmp_path, monkeypatch):
+    app = get_test_app()
+    from app.routes import devices as devices_module
+    from app.models.models import DeviceDamage, Device
+
+    # Prepare dummy device and DB session
+    dummy_device = types.SimpleNamespace(id=1, site_id=1)
+
+    class DummyQuery:
+        def __init__(self, result):
+            self._result = result
+        def filter(self, *args, **kwargs):
+            return self
+        def first(self):
+            return self._result
+
+    class DummyDB:
+        def __init__(self):
+            self.added = []
+        def query(self, model):
+            if model is Device:
+                return DummyQuery(dummy_device)
+            return DummyQuery(None)
+        def add(self, obj):
+            self.added.append(obj)
+        def commit(self):
+            pass
+
+    db = DummyDB()
+    monkeypatch.setattr(devices_module, "user_in_site", lambda db_, user, site_id: True)
+    monkeypatch.setattr(devices_module, "STATIC_DIR", str(tmp_path))
+
+    photo = UploadFile(
+        io.BytesIO(b"data"),
+        filename="../foo.png",
+        headers=Headers({"content-type": "image/png"})
+    )
+    user = types.SimpleNamespace(id=1, role="editor")
+
+    asyncio.run(devices_module.upload_damage_photo(1, photo, db=db, current_user=user))
+
+    assert db.added, "record not added"
+    record = db.added[0]
+    assert os.path.basename(record.filename) == record.filename
+    assert record.filename.endswith("_foo.png")
+    saved_path = tmp_path / "damage" / record.filename
+    assert saved_path.is_file()
+    assert saved_path.read_bytes() == b"data"


### PR DESCRIPTION
## Summary
- sanitize uploaded damage photo filenames before saving
- add regression test for filename sanitization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2f9135e883248abc13bd6feaaa04