### PR TITLE
Fix static path mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Set the `AUTO_SEED` environment variable to `0` or `false` to skip the automatic
 Adjust `WORKERS`, `TIMEOUT` and `PORT` as needed. The server listens on
 `0.0.0.0` so it can be proxied by a web server such as Nginx.
 
+By default static assets are served from the `static` directory under the
+repository root.  Deployments may mount this folder elsewhere (for example at
+`/static` inside a Docker container).  Set the `STATIC_DIR` environment variable
+to the desired location so the application mounts that directory.
+
 ## Nginx reverse proxy with SSL
 
 Install Nginx on the host and create a server block that proxies requests to

--- a/app/main.py
+++ b/app/main.py
@@ -75,6 +75,11 @@ async def shutdown_cleanup():
 # Path to the ``static`` directory at the repository root
 from app.utils.paths import STATIC_DIR
 
+# Ensure the static directory exists to avoid startup errors when it has been
+# mounted from outside the repository (for example at ``/static`` in Docker
+# deployments).
+os.makedirs(STATIC_DIR, exist_ok=True)
+
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 # Store login information in signed cookies

--- a/app/utils/paths.py
+++ b/app/utils/paths.py
@@ -1,7 +1,15 @@
 import os
 
 # Base directory of the project repository
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+BASE_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
 
-# Absolute path to the "static" directory at the project root
-STATIC_DIR = os.path.join(BASE_DIR, "static")
+# Absolute path to the "static" directory.
+#
+# The application historically assumed that static assets live under the
+# repository root, i.e. ``BASE_DIR/static``.  Some deployment setups mount the
+# ``static`` directory elsewhere (for example at ``/static``) which caused the
+# app to still look under ``/app/static``.  Allow overriding the location via the
+# ``STATIC_DIR`` environment variable so these deployments work out of the box.
+STATIC_DIR = os.environ.get("STATIC_DIR", os.path.join(BASE_DIR, "static"))


### PR DESCRIPTION
## Summary
- ensure STATIC_DIR exists before mounting in FastAPI
- document STATIC_DIR env var for deployments

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e314415d48324a3a2aa54df24a1b1