### PR TITLE
Update Node.js installation instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR /app
 
 # Install build dependencies (for bcrypt, etc.)
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc nodejs npm \
+    && apt-get install -y --no-install-recommends curl gcc gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt ./

--- a/README.md
+++ b/README.md
@@ -8,12 +8,18 @@ Tailwind CSS has been removed from the project. Styling and components now rely 
 
 The steps below assume a brand new system with no tools installed. Commands are written so they can be copied and pasted directly into a terminal.
 
+> **Note**: The CSS build process requires **Node.js 18 or newer**. The steps below install Node.js 20 from the NodeSource repository.
+
 ### Ubuntu Development Setup
 
 ```bash
 # install required system packages
 sudo apt update
-sudo apt install -y git python3 python3-venv python3-pip nodejs npm postgresql
+sudo apt install -y git python3 python3-venv python3-pip postgresql curl
+
+# install Node.js (version 20.x) from NodeSource
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt install -y nodejs
 
 # clone the repository and enter the folder
 git clone https://github.com/youruser/Master-IP-App.git
@@ -49,10 +55,17 @@ Visit [http://localhost:8000](http://localhost:8000) and log in with the credent
 
 ### Ubuntu Production Setup
 
+> **Note**: Production deployments also require **Node.js 18+**. The commands
+> below install Node.js 20 using NodeSource.
+
 ```bash
 # install system packages
 sudo apt update
-sudo apt install -y git python3 python3-venv python3-pip nodejs npm postgresql
+sudo apt install -y git python3 python3-venv python3-pip postgresql curl
+
+# install Node.js (version 20.x) from NodeSource
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt install -y nodejs
 
 # clone the repository and enter it
 git clone https://github.com/youruser/Master-IP-App.git

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "engines": {
+    "node": ">=18"
+  },
   "devDependencies": {
     "unocss": "^66.2.0"
   }


### PR DESCRIPTION
## Summary
- document Node.js 20 installation for local setup
- update production instructions to use Node.js 20
- ensure the Dockerfile installs Node.js 20
- specify a minimum Node version in `package.json`

## Testing
- `npm install`
- `npm run build:css`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684eadaf3b7c83249ef552d3a6e2beec