### PR TITLE
Fix start script env sourcing

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,8 +2,8 @@
 # Start Gunicorn with Uvicorn workers for production
 set -e
 
-# Load environment variables from .env if present
-if [ -f .env ]; then
+# Load environment variables from .env if DATABASE_URL is not set
+if [ -z "${DATABASE_URL}" ] && [ -f .env ]; then
     set -a
     . .env
     set +a


### PR DESCRIPTION
## Summary
- avoid loading `.env` when `DATABASE_URL` is already defined

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ebc9e8e948324a2ae02c0ebb236a5