### PR TITLE
Fix wait_for_db error logging

### DIFF
--- a/wait_for_db.py
+++ b/wait_for_db.py
@@ -16,7 +16,7 @@ for attempt in range(1, max_attempts + 1):
         print("Database is ready")
         break
     except Exception as exc:
-        print(f"Attempt {attempt}/{max_attempts} - waiting for database...")
+        print(f"Attempt {attempt}/{max_attempts} - waiting for database: {exc}")
         time.sleep(delay)
 else:
     print("Could not connect to database. Exiting.")


### PR DESCRIPTION
## Summary
- surface psycopg connection errors when retrying wait_for_db

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ebd4b0ffc832487116af3c22060b5