### PR TITLE
Support URL prefix via ROOT_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,13 @@ Adjust `WORKERS`, `TIMEOUT` and `PORT` as needed. The server listens on
 `0.0.0.0` so it can be proxied by a web server such as Nginx.
 
 By default static assets are served from the `static` directory under the
-repository root.  Deployments may mount this folder elsewhere (for example at
-`/static` inside a Docker container).  Set the `STATIC_DIR` environment variable
+repository root. Deployments may mount this folder elsewhere (for example at
+`/static` inside a Docker container). Set the `STATIC_DIR` environment variable
 to the desired location so the application mounts that directory.
+
+If the app is exposed under a URL prefix (e.g. `/inventory/` instead of `/`),
+set the `ROOT_PATH` environment variable to that prefix so all generated links
+including static asset URLs use the correct path.
 
 ## Nginx reverse proxy with SSL
 

--- a/app/main.py
+++ b/app/main.py
@@ -55,7 +55,8 @@ from app.tasks import (
 )
 from app.utils.templates import templates
 
-app = FastAPI()
+# Allow deploying the app under a URL prefix by setting ROOT_PATH.
+app = FastAPI(root_path=os.environ.get("ROOT_PATH", ""))
 # Respect headers like X-Forwarded-Proto so generated URLs use the
 # correct scheme when behind a reverse proxy.
 if ProxyHeadersMiddleware:


### PR DESCRIPTION
## Summary
- allow configuring FastAPI `root_path` with `ROOT_PATH` env var
- document `ROOT_PATH` in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ec1d130e883249948bd7be848ce44