### PR TITLE
Fix static path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ Set the `AUTO_SEED` environment variable to `0` or `false` to skip the automatic
 Adjust `WORKERS`, `TIMEOUT` and `PORT` as needed. The server listens on
 `0.0.0.0` so it can be proxied by a web server such as Nginx.
 
-By default static assets are served from the `static` directory under the
-repository root. Deployments may mount this folder elsewhere (for example at
-`/static` inside a Docker container). Set the `STATIC_DIR` environment variable
-to the desired location so the application mounts that directory.
+Static assets are served from the `static` directory under the repository root.
+This location is fixed. When deploying inside containers or under a reverse
+proxy, ensure that `/path/to/Master-IP-App/static` is accessible at `/static` so
+the application can find its assets.
 
 If the app is exposed under a URL prefix (e.g. `/inventory/` instead of `/`),
 set the `ROOT_PATH` environment variable to that prefix so all generated links

--- a/app/utils/paths.py
+++ b/app/utils/paths.py
@@ -5,11 +5,11 @@ BASE_DIR = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
 
-# Absolute path to the "static" directory.
+# Absolute path to the ``static`` directory.
 #
-# The application historically assumed that static assets live under the
-# repository root, i.e. ``BASE_DIR/static``.  Some deployment setups mount the
-# ``static`` directory elsewhere (for example at ``/static``) which caused the
-# app to still look under ``/app/static``.  Allow overriding the location via the
-# ``STATIC_DIR`` environment variable so these deployments work out of the box.
-STATIC_DIR = os.environ.get("STATIC_DIR", os.path.join(BASE_DIR, "static"))
+# Static assets are always served from ``BASE_DIR/static``.  Earlier versions of
+# the application allowed overriding this path via the ``STATIC_DIR``
+# environment variable.  That behaviour caused inconsistencies when the
+# directory was mounted at a different location.  The path is now fixed to the
+# repository's ``static`` folder so all components refer to the same location.
+STATIC_DIR = os.path.join(BASE_DIR, "static")


### PR DESCRIPTION
## Summary
- simplify static path logic by removing `STATIC_DIR` env var support
- document fixed static assets path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ec370de5c8324bb79274a89a7e9f0