### PR TITLE
Fix static file URLs under ROOT_PATH

### DIFF
--- a/app/templates/device_form.html
+++ b/app/templates/device_form.html
@@ -149,7 +149,7 @@
 <h2 class="text-lg mt-4">Damage Photos</h2>
 <div class="grid gap-2 grid-cols-2 md:grid-cols-3 mb-2">
   {% for photo in damage_photos %}
-  <img src="/static/damage/{{ photo.filename }}" class="max-w-full h-auto" />
+  <img src="{{ request.url_for('static', path='damage/' ~ photo.filename) }}" class="max-w-full h-auto" />
   {% endfor %}
 </div>
 <form method="post" action="/devices/{{ device.id }}/damage" enctype="multipart/form-data" class="mb-4">

--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -117,5 +117,5 @@
 
 {% block extra_scripts %}
 <script>window.deviceId = {{ device.id }};</script>
-<script src="/static/js/port_status.js"></script>
+<script src="{{ request.url_for('static', path='js/port_status.js') }}"></script>
 {% endblock %}

--- a/app/templates/terminal.html
+++ b/app/templates/terminal.html
@@ -8,5 +8,5 @@
 <script>
   window.deviceId = {{ device.id }};
 </script>
-<script src="/static/js/terminal.js"></script>
+<script src="{{ request.url_for('static', path='js/terminal.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure generated static paths respect `ROOT_PATH`
- use `url_for('static', ...)` for JS and images

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ec6c9e3008324935d99f6730c3a3b