### PR TITLE
Fix static asset path prefix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - db
     environment:
       DATABASE_URL: postgresql://masteruser:masterpass@db:5432/master_ip_db
+      ROOT_PATH: ""
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
## Summary
- ensure the `ROOT_PATH` env is cleared in docker-compose

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ecd512a7c8324824b0b5d3ffcf53f