### PR TITLE
Add nginx service and enable ProxyHeadersMiddleware

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,8 +5,8 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.sessions import SessionMiddleware
 try:
     from starlette.middleware.proxy_headers import ProxyHeadersMiddleware
-except Exception:  # Module may be unavailable in some Starlette versions
-    ProxyHeadersMiddleware = None
+except ImportError:  # Fallback for older Starlette versions
+    from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 import os
 
 from app.routes import (
@@ -56,11 +56,10 @@ from app.tasks import (
 from app.utils.templates import templates
 
 # Allow deploying the app under a URL prefix by setting ROOT_PATH.
-app = FastAPI(root_path=os.environ.get("ROOT_PATH", ""))
+app = FastAPI()
 # Respect headers like X-Forwarded-Proto so generated URLs use the
 # correct scheme when behind a reverse proxy.
-if ProxyHeadersMiddleware:
-    app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 start_queue_worker(app)
 start_config_scheduler(app)
 setup_trap_listener(app)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,5 +25,17 @@ services:
     volumes:
       - .:/app
 
+  nginx:
+    image: nginx:latest
+    ports:
+      - "443:443"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/certs:/etc/nginx/certs:ro
+    depends_on:
+      - web
+    networks:
+      - default
+
 volumes:
   postgres_data:

--- a/nginx/certs/README.md
+++ b/nginx/certs/README.md
@@ -1,0 +1,1 @@
+Place SSL certificate files here

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,24 @@
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate /etc/nginx/certs/selfsigned.crt;
+    ssl_certificate_key /etc/nginx/certs/selfsigned.key;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    location / {
+        proxy_pass http://web:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /static/ {
+        proxy_pass http://web:8000/static/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/tests/test_root_path_static.py
+++ b/tests/test_root_path_static.py
@@ -7,7 +7,6 @@ from fastapi.testclient import TestClient
 
 def get_test_app():
     os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
-    os.environ["ROOT_PATH"] = "/app"
     # Remove imported app modules to ensure patches apply
     for m in list(sys.modules):
         if m.startswith("app"):
@@ -28,4 +27,4 @@ client = TestClient(app)
 def test_static_urls_include_root_path():
     response = client.get("/")
     assert response.status_code == 200
-    assert "/app/static/" in response.text
+    assert "/static/" in response.text


### PR DESCRIPTION
## Summary
- run FastAPI without `root_path`
- always enable `ProxyHeadersMiddleware`
- add nginx reverse proxy service
- provide nginx HTTPS config and placeholder cert directory
- update test expecting no ROOT_PATH usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ed74a1d2c832490a12e7845e6bd3e