### PR TITLE
Add fixed header with logo support

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ from app.routes import (
     snmp_traps_router,
     syslog_router,
     tag_manager_router,
+    admin_logo_router,
 )
 from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
@@ -124,6 +125,7 @@ app.include_router(export_router)
 app.include_router(snmp_traps_router)
 app.include_router(syslog_router)
 app.include_router(tag_manager_router)
+app.include_router(admin_logo_router)
 
 
 @app.exception_handler(HTTPException)

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -29,6 +29,7 @@ from .export import router as export_router
 from .snmp_traps import router as snmp_traps_router
 from .syslog import router as syslog_router
 from .tag_manager import router as tag_manager_router
+from .admin_logo import router as admin_logo_router
 
 __all__ = [
     "auth_router",
@@ -62,4 +63,5 @@ __all__ = [
     "snmp_traps_router",
     "syslog_router",
     "tag_manager_router",
+    "admin_logo_router",
 ]

--- a/app/routes/admin_logo.py
+++ b/app/routes/admin_logo.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Request, Depends, UploadFile, File, HTTPException
+from fastapi.responses import RedirectResponse
+import os
+
+from app.utils.auth import require_role
+from app.utils.templates import templates
+from app.utils.paths import STATIC_DIR
+
+router = APIRouter()
+
+@router.get("/admin/logo")
+async def logo_form(request: Request, current_user=Depends(require_role("superadmin"))):
+    logo_exists = os.path.exists(os.path.join(STATIC_DIR, "logo.png"))
+    context = {"request": request, "logo_exists": logo_exists, "current_user": current_user}
+    return templates.TemplateResponse("logo_form.html", context)
+
+
+@router.post("/admin/logo")
+async def upload_logo(
+    logo: UploadFile = File(...),
+    current_user=Depends(require_role("superadmin")),
+):
+    if not logo.content_type.startswith("image/"):
+        raise HTTPException(status_code=400, detail="Invalid file type")
+    os.makedirs(STATIC_DIR, exist_ok=True)
+    path = os.path.join(STATIC_DIR, "logo.png")
+    with open(path, "wb") as f:
+        f.write(await logo.read())
+    return RedirectResponse(url="/admin/logo", status_code=302)
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,6 +14,26 @@
   </head>
   <body>
     <header>
+      <div class="top-header">
+        <div class="container mx-auto flex items-center justify-between">
+          <div class="logo-box flex items-center">
+            {% if logo_url() %}
+            <img src="{{ logo_url() }}" alt="Logo" class="h-10 mr-2" />
+            {% endif %}
+            <span>CEST Master IP and Config Tool</span>
+            {% if current_user and current_user.role == 'superadmin' %}
+            <a href="/admin/logo" class="ml-2 underline text-sm">Upload Logo</a>
+            {% endif %}
+          </div>
+          <div class="login-area">
+            {% if current_user %}
+            <a href="/auth/logout" class="logout">Logout</a>
+            {% else %}
+            <a href="/auth/login" class="logout">Login</a>
+            {% endif %}
+          </div>
+        </div>
+      </div>
       {% block nav %}
       <nav class="bg-gray-800 text-white">
         <div class="container mx-auto flex flex-wrap items-center justify-between" x-data="{open:false}">
@@ -112,9 +132,6 @@
                 {% endif %}
                 <div id="admin-menu" data-admin-menu data-label="{{ 'Super Admin' if current_user.role == 'superadmin' else 'Admin' }}" data-items='{{ admin_items|tojson }}'></div>
                 {% endif %}
-                <a href="/auth/logout" class="text-blue-400 underline">Logout</a>
-              {% else %}
-                <a href="/auth/login" class="text-blue-400 underline">Login</a>
               {% endif %}
             </div>
           </div>

--- a/app/templates/logo_form.html
+++ b/app/templates/logo_form.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Upload Logo</h1>
+{% if logo_exists %}
+  <img src="{{ request.url_for('static', path='logo.png') }}" alt="Logo" class="h-20 mb-4">
+{% endif %}
+<form method="post" enctype="multipart/form-data">
+  <input type="file" name="logo" accept="image/*" class="mb-2 text-black" required>
+  <button type="submit" class="bg-blue-600 px-4 py-2">Upload</button>
+</form>
+{% endblock %}

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -41,3 +41,17 @@ def get_tags():
     return tags
 
 templates.env.globals["get_tags"] = get_tags
+
+import os
+from app.utils.paths import STATIC_DIR
+
+
+def logo_url() -> str | None:
+    """Return the URL for the uploaded logo if it exists."""
+    path = os.path.join(STATIC_DIR, "logo.png")
+    if os.path.exists(path):
+        return "/static/logo.png"
+    return None
+
+
+templates.env.globals["logo_url"] = logo_url

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -63,3 +63,25 @@ nav.bg-gray-800 .menu-right {
   display: flex;
   align-items: center;
 }
+
+.top-header {
+  background-color: #000;
+  color: #fff;
+  padding: 0.5rem 0;
+}
+
+.top-header a.logout {
+  color: #fff;
+  text-decoration: none;
+  padding: 0.25rem 0.5rem;
+  border: none;
+  background: none;
+}
+
+.top-header a.logout:hover {
+  text-decoration: underline;
+}
+
+.top-header .logo-box img {
+  height: 40px;
+}


### PR DESCRIPTION
## Summary
- add reusable logo_url helper
- add admin routes/template for uploading logo
- show new black & white header with logo and login/logout
- style new header in layout.css

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684edb1a3e088324bf2d3a088e2088bd