### PR TITLE
Update logout and menu styles

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,9 +27,9 @@
           </div>
           <div class="login-area">
             {% if current_user %}
-            <a href="/auth/logout" class="logout">Logout</a>
+            <a href="/auth/logout" class="logout-btn logged-in">Logout</a>
             {% else %}
-            <a href="/auth/login" class="logout">Login</a>
+            <a href="/auth/login" class="logout-btn logged-out">Login</a>
             {% endif %}
           </div>
         </div>

--- a/app/templates/ssh_menu.html
+++ b/app/templates/ssh_menu.html
@@ -2,13 +2,13 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">SSH Tasks</h1>
-<ul class="list-disc ml-6 space-y-1">
-  <li><a class="underline text-blue-400" href="/ssh/port-config">Port Config</a></li>
-  <li><a class="underline text-blue-400" href="/ssh/port-check">Port Check</a></li>
-  <li><a class="underline text-blue-400" href="/ssh/config-check">Config Check</a></li>
-  <li><a class="underline text-blue-400" href="/ssh/port-search">Port Search</a></li>
-  <li><a class="underline text-blue-400" href="/ssh/bulk-port-update">Bulk Port Update</a></li>
-  <li><a class="underline text-blue-400" href="/bulk/vlan-push">VLAN Bulk Push</a></li>
-  <li><a class="underline text-blue-400" href="/ssh/netbird-connect">Initiate Netbird Connection</a></li>
-</ul>
+<div class="flex flex-wrap gap-2 bg-gray-700 p-2 rounded">
+  <a class="bg-gray-600 text-white px-3 py-1 rounded" href="/ssh/port-config">Port Config</a>
+  <a class="bg-gray-600 text-white px-3 py-1 rounded" href="/ssh/port-check">Port Check</a>
+  <a class="bg-gray-600 text-white px-3 py-1 rounded" href="/ssh/config-check">Config Check</a>
+  <a class="bg-gray-600 text-white px-3 py-1 rounded" href="/ssh/port-search">Port Search</a>
+  <a class="bg-gray-600 text-white px-3 py-1 rounded" href="/ssh/bulk-port-update">Bulk Port Update</a>
+  <a class="bg-gray-600 text-white px-3 py-1 rounded" href="/bulk/vlan-push">VLAN Bulk Push</a>
+  <a class="bg-gray-600 text-white px-3 py-1 rounded" href="/ssh/netbird-connect">Initiate Netbird Connection</a>
+</div>
 {% endblock %}

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -70,16 +70,22 @@ nav.bg-gray-800 .menu-right {
   padding: 0.5rem 0;
 }
 
-.top-header a.logout {
-  color: #fff;
+.top-header a.logout-btn {
   text-decoration: none;
   padding: 0.25rem 0.5rem;
-  border: none;
+  border-radius: 0.25rem;
+  border: 1px solid #fff;
+  color: #fff;
   background: none;
 }
 
-.top-header a.logout:hover {
+.top-header a.logout-btn:hover {
   text-decoration: underline;
+}
+
+.top-header a.logged-in {
+  border-color: #d97706;
+  color: #facc15;
 }
 
 .top-header .logo-box img {

--- a/static/css/unocss.css
+++ b/static/css/unocss.css
@@ -52,7 +52,9 @@
 .group:hover .group-hover\:block{display:block;}
 .inline-block{display:inline-block;}
 .hidden{display:none;}
+.h-10{height:2.5rem;}
 .h-14{height:3.5rem;}
+.h-20{height:5rem;}
 .h-auto{height:auto;}
 .h-screen{height:100vh;}
 .max-w-full{max-width:100%;}

--- a/static/themes/dark_colourful.css
+++ b/static/themes/dark_colourful.css
@@ -76,13 +76,24 @@ button.add:hover {
   background-color: #4ade80;
 }
 
-.logout {
+.logged-in {
   border: 1px solid #d97706;
   color: #facc15;
   padding: 0.25rem 0.5rem;
   border-radius: 0.25rem;
   font-size: 0.75rem;
 }
-.logout:hover {
+.logged-in:hover {
   background-color: #78350f;
+}
+
+.logged-out {
+  border: 1px solid #ffffff;
+  color: #ffffff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+}
+.logged-out:hover {
+  background-color: #333333;
 }


### PR DESCRIPTION
## Summary
- add login/logout button styles
- layout menu links in SSH tasks page
- rebuild UnoCSS file

## Testing
- `npx unocss "app/templates/**/*.html" -o static/css/unocss.css`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684eddce769083249e358f0d7029bd71