### PR TITLE
Implement UNO Dark Colourful theme

### DIFF
--- a/static/css/unocss.css
+++ b/static/css/unocss.css
@@ -2,6 +2,26 @@
 *,::before,::after{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgb(0 0 0 / 0);--un-ring-shadow:0 0 rgb(0 0 0 / 0);--un-shadow-inset: ;--un-shadow:0 0 rgb(0 0 0 / 0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgb(147 197 253 / 0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}::backdrop{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgb(0 0 0 / 0);--un-ring-shadow:0 0 rgb(0 0 0 / 0);--un-shadow-inset: ;--un-shadow:0 0 rgb(0 0 0 / 0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgb(147 197 253 / 0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}
 /* layer: shortcuts */
 .container{width:100%;}
+.btn:disabled{cursor:not-allowed;opacity:0.5;}
+.table-cell{border-bottom-width:1px;--un-border-opacity:1;border-color:rgb(55 65 81 / var(--un-border-opacity));padding-left:1rem;padding-right:1rem;padding-top:0.5rem;padding-bottom:0.5rem;}
+.btn{border-radius:0.25rem;padding-left:0.75rem;padding-right:0.75rem;padding-top:0.25rem;padding-bottom:0.25rem;font-size:0.875rem;line-height:1.25rem;font-weight:500;--un-shadow:var(--un-shadow-inset) 0 1px 2px 0 var(--un-shadow-color, rgb(0 0 0 / 0.05));box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow);transition-property:color,background-color,border-color,text-decoration-color,fill,stroke;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:150ms;}
+.btn-blue{--un-bg-opacity:1;background-color:rgb(14 165 233 / var(--un-bg-opacity)) /* #0ea5e9 */;--un-text-opacity:1;color:rgb(255 255 255 / var(--un-text-opacity)) /* #fff */;}
+.btn-cyan{--un-bg-opacity:1;background-color:rgb(6 182 212 / var(--un-bg-opacity)) /* #06b6d4 */;--un-text-opacity:1;color:rgb(255 255 255 / var(--un-text-opacity)) /* #fff */;}
+.btn-green{--un-bg-opacity:1;background-color:rgb(22 163 74 / var(--un-bg-opacity)) /* #16a34a */;--un-text-opacity:1;color:rgb(255 255 255 / var(--un-text-opacity)) /* #fff */;}
+.btn-grey{--un-bg-opacity:1;background-color:rgb(75 85 99 / var(--un-bg-opacity)) /* #4b5563 */;--un-text-opacity:1;color:rgb(255 255 255 / var(--un-text-opacity)) /* #fff */;}
+.btn-orange{--un-bg-opacity:1;background-color:rgb(249 115 22 / var(--un-bg-opacity)) /* #f97316 */;--un-text-opacity:1;color:rgb(255 255 255 / var(--un-text-opacity)) /* #fff */;}
+.btn-purple{--un-bg-opacity:1;background-color:rgb(168 85 247 / var(--un-bg-opacity)) /* #a855f7 */;--un-text-opacity:1;color:rgb(255 255 255 / var(--un-text-opacity)) /* #fff */;}
+.btn-red{--un-bg-opacity:1;background-color:rgb(220 38 38 / var(--un-bg-opacity)) /* #dc2626 */;--un-text-opacity:1;color:rgb(255 255 255 / var(--un-text-opacity)) /* #fff */;}
+.btn-yellow{--un-bg-opacity:1;background-color:rgb(234 179 8 / var(--un-bg-opacity)) /* #eab308 */;--un-text-opacity:1;color:rgb(0 0 0 / var(--un-text-opacity)) /* #000 */;}
+.table-header{--un-bg-opacity:1;background-color:rgb(31 41 55 / var(--un-bg-opacity)) /* #1f2937 */;--un-text-opacity:1;color:rgb(255 255 255 / var(--un-text-opacity)) /* #fff */;}
+.btn-blue:hover{--un-bg-opacity:1;background-color:rgb(2 132 199 / var(--un-bg-opacity)) /* #0284c7 */;}
+.btn-cyan:hover{--un-bg-opacity:1;background-color:rgb(8 145 178 / var(--un-bg-opacity)) /* #0891b2 */;}
+.btn-green:hover{--un-bg-opacity:1;background-color:rgb(21 128 61 / var(--un-bg-opacity)) /* #15803d */;}
+.btn-grey:hover{--un-bg-opacity:1;background-color:rgb(55 65 81 / var(--un-bg-opacity)) /* #374151 */;}
+.btn-orange:hover{--un-bg-opacity:1;background-color:rgb(234 88 12 / var(--un-bg-opacity)) /* #ea580c */;}
+.btn-purple:hover{--un-bg-opacity:1;background-color:rgb(147 51 234 / var(--un-bg-opacity)) /* #9333ea */;}
+.btn-red:hover{--un-bg-opacity:1;background-color:rgb(185 28 28 / var(--un-bg-opacity)) /* #b91c1c */;}
+.btn-yellow:hover{--un-bg-opacity:1;background-color:rgb(202 138 4 / var(--un-bg-opacity)) /* #ca8a04 */;}
 @media (min-width: 640px){
 .container{max-width:640px;}
 }
@@ -24,6 +44,7 @@
 .static{position:static;}
 .inset-0{inset:0;}
 .bottom-full{bottom:100%;}
+.right-0{right:0;}
 .grid{display:grid;}
 .grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr));}
 .grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr));}
@@ -106,8 +127,8 @@
 .border-t{border-top-width:1px;}
 .border-gray-700{--un-border-opacity:1;border-color:rgb(55 65 81 / var(--un-border-opacity));}
 .rounded{border-radius:0.25rem;}
-.rounded-md{border-radius:0.375rem;}
 .rounded-full{border-radius:9999px;}
+.rounded-md{border-radius:0.375rem;}
 .bg-black{--un-bg-opacity:1;background-color:rgb(0 0 0 / var(--un-bg-opacity)) /* #000 */;}
 .bg-blue-600{--un-bg-opacity:1;background-color:rgb(37 99 235 / var(--un-bg-opacity)) /* #2563eb */;}
 .bg-gray-600{--un-bg-opacity:1;background-color:rgb(75 85 99 / var(--un-bg-opacity)) /* #4b5563 */;}

--- a/static/themes/dark_colourful.css
+++ b/static/themes/dark_colourful.css
@@ -1,18 +1,20 @@
+/* Dark Colourful theme rebuilt with UnoCSS utilities */
+
 body {
-  background-color: #111827;
-  color: #d1d5db;
+  background-color: #000000; /* bg-black */
+  color: #e5e7eb;            /* text-gray-200 */
 }
 
 h1, h2, h3, h4, h5, h6 {
-  color: #f3f4f6;
+  color: #ffffff;            /* text-white */
 }
 
 nav.bg-gray-800 {
-  background-color: #1f2937 !important;
+  background-color: #1f2937 !important; /* bg-gray-800 */
 }
 
 .card, .bg-gray-800 {
-  background-color: #1f2937;
+  background-color: #1f2937; /* bg-gray-800 */
   border-radius: 0.75rem;
   overflow: hidden;
 }
@@ -20,60 +22,27 @@ nav.bg-gray-800 {
 table {
   width: 100%;
   border-collapse: separate;
-  border-spacing: 0 0.25rem;
+  border-spacing: 0;
 }
 
 table thead th {
-  background-color: #332f45;
+  background-color: #1f2937; /* bg-gray-800 */
   color: #ffffff;
   font-weight: bold;
   padding: 0.5rem 1rem;
 }
 
-table tbody tr:hover {
-  background-color: #374151;
+table tbody tr:nth-child(even) {
+  background-color: #111827; /* bg-gray-900 */
+}
+
+table tbody tr:nth-child(odd) {
+  background-color: #1f2937; /* bg-gray-800 */
 }
 
 table td {
-  padding: 0.5rem 1rem;
-}
-
-button, .btn {
-  border-radius: 0.375rem;
-  padding: 0.25rem 0.75rem;
-  font-size: 0.875rem;
-}
-
-button.edit {
-  background-color: #facc15;
-  color: #000000;
-}
-button.edit:hover {
-  background-color: #fde047;
-}
-
-button.interface {
-  background-color: #3b82f6;
-  color: #ffffff;
-}
-button.interface:hover {
-  background-color: #60a5fa;
-}
-
-button.delete {
-  background-color: #dc2626;
-  color: #ffffff;
-}
-button.delete:hover {
-  background-color: #ef4444;
-}
-
-button.add {
-  background-color: #22c55e;
-  color: #ffffff;
-}
-button.add:hover {
-  background-color: #4ade80;
+  padding: 0.5rem 1rem;      /* px-4 py-2 */
+  border-bottom: 1px solid #374151; /* border-gray-700 */
 }
 
 .logged-in {

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -1,7 +1,37 @@
 import { defineConfig, presetUno } from 'unocss'
 
+/**
+ * UnoCSS configuration defining shortcuts for the Dark Colourful theme.
+ * These shortcuts provide semantic class names for the various button
+ * variants and table utilities used across the templates. A safelist is
+ * also included so UnoCSS generates the classes even when they appear
+ * dynamically (e.g. via Jinja templates).
+ */
+
 export default defineConfig({
   presets: [
     presetUno(),
+  ],
+  // Semantic shortcuts used throughout the templates
+  shortcuts: {
+    'btn':
+      'rounded px-3 py-1 text-sm font-medium shadow-sm transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed',
+    'btn-green': 'bg-green-600 text-white hover:bg-green-700',
+    'btn-yellow': 'bg-yellow-500 text-black hover:bg-yellow-600',
+    'btn-blue': 'bg-sky-500 text-white hover:bg-sky-600',
+    'btn-red': 'bg-red-600 text-white hover:bg-red-700',
+    'btn-grey': 'bg-gray-600 text-white hover:bg-gray-700',
+    'btn-purple': 'bg-purple-500 text-white hover:bg-purple-600',
+    'btn-orange': 'bg-orange-500 text-white hover:bg-orange-600',
+    'btn-cyan': 'bg-cyan-500 text-white hover:bg-cyan-600',
+    'table-cell': 'px-4 py-2 border-b border-gray-700',
+    'table-header': 'bg-gray-800 text-white',
+  },
+  // Ensure UnoCSS includes the shortcuts even when used dynamically
+  safelist: [
+    'btn',
+    'btn-green', 'btn-yellow', 'btn-blue', 'btn-red', 'btn-grey',
+    'btn-purple', 'btn-orange', 'btn-cyan',
+    'table-cell', 'table-header',
   ],
 })


### PR DESCRIPTION
## Summary
- define semantic shortcuts for buttons and table classes in UnoCSS
- rebuild the `dark_colourful.css` theme to match the new dark colourful spec
- regenerate `unocss.css` with the new shortcuts

## Testing
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_684eea38826c83249ee010becf5ee5e1