### PR TITLE
Add animated terminal-style welcome message

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,7 +44,7 @@ from app.routes.tunables import router as tunables_router
 from app.routes.editor import router as editor_router
 from app.websockets.editor import shell_ws
 from app.websockets.terminal import router as terminal_ws_router
-from app.routes.welcome import router as welcome_router, WELCOME_TEXT
+from app.routes.welcome import router as welcome_router, WELCOME_TEXT, INVENTORY_TEXT
 from app.utils.auth import get_current_user
 from app.tasks import (
     start_queue_worker,
@@ -144,10 +144,12 @@ async def read_root(request: Request, current_user=Depends(get_current_user)):
     """Render a role-based welcome page or login screen."""
     if current_user:
         text = WELCOME_TEXT.get(current_user.role, [])
+        inventory = INVENTORY_TEXT.get(current_user.role, [])
         context = {
             "request": request,
             "role": current_user.role,
             "text": text,
+            "inventory_text": inventory,
             "current_user": current_user,
         }
         return templates.TemplateResponse("welcome.html", context)

--- a/app/routes/welcome.py
+++ b/app/routes/welcome.py
@@ -47,10 +47,46 @@ WELCOME_TEXT = {
     ],
 }
 
+# Inventory functions accessible by each role. These lines are displayed on the
+# welcome page below the general role description.
+INVENTORY_TEXT = {
+    "viewer": [
+        "View all devices",
+        "Review inventory audit logs",
+        "Browse trailer inventory",
+        "Browse site inventory",
+    ],
+    "user": [
+        "All viewer functions",
+        "Check switch port status",
+    ],
+    "editor": [
+        "All user functions",
+        "Add or modify device entries",
+        "Add or modify VLANs",
+        "Push or pull configurations",
+    ],
+    "admin": [
+        "All editor functions",
+        "Manage system tunables",
+    ],
+    "superadmin": [
+        "All admin functions",
+        "Manage credentials and view debug/audit logs",
+    ],
+}
+
 @router.get("/welcome/{role}")
 async def welcome_role(role: str, request: Request, current_user=Depends(get_current_user)):
     text = WELCOME_TEXT.get(role, [])
-    context = {"request": request, "role": role, "text": text, "current_user": current_user}
+    inventory = INVENTORY_TEXT.get(role, [])
+    context = {
+        "request": request,
+        "role": role,
+        "text": text,
+        "inventory_text": inventory,
+        "current_user": current_user,
+    }
     return templates.TemplateResponse("welcome.html", context)
 
 

--- a/app/templates/welcome.html
+++ b/app/templates/welcome.html
@@ -1,13 +1,18 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="flex flex-col items-center justify-center text-center mt-10">
-  <h1 class="text-2xl mb-4">Welcome {{ role|title }}</h1>
-  <ul class="list-disc list-inside">
+<div id="welcome-cli" class="flex flex-col items-center justify-center text-center min-h-[50vh] font-mono text-cyan-300 bg-gray-900 p-4 rounded">
+  <div class="cli-line" style="opacity:0">Welcome, {{ current_user.email }}.</div>
+  <div class="cli-line" style="opacity:0">You are a {{ role|title }}, which allows you the following actions:</div>
   {% for line in text %}
-    <li>{{ line }}</li>
+  <div class="cli-line" style="opacity:0">- {{ line }}</div>
   {% endfor %}
-  </ul>
+  <div class="cli-line" style="opacity:0">&nbsp;</div>
+  <div class="cli-line" style="opacity:0">Inventory System Overview</div>
+  <div class="cli-line" style="opacity:0">This system tracks network devices and configurations.</div>
+  {% for line in inventory_text %}
+  <div class="cli-line" style="opacity:0">- {{ line }}</div>
+  {% endfor %}
 </div>
 {% if alert %}
 <div class="mt-4 p-2 bg-yellow-200 text-yellow-900 rounded">{{ alert }}</div>
@@ -35,4 +40,8 @@
   </tbody>
 </table>
 {% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="{{ request.url_for('static', path='js/welcome_cli.js') }}"></script>
 {% endblock %}

--- a/static/js/welcome_cli.js
+++ b/static/js/welcome_cli.js
@@ -1,0 +1,15 @@
+const DELAY = 200; // ms between lines
+
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('welcome-cli');
+  if (!container) return;
+  const lines = Array.from(container.querySelectorAll('.cli-line'));
+  lines.forEach(line => {
+    line.style.opacity = 0;
+  });
+  lines.forEach((line, idx) => {
+    setTimeout(() => {
+      line.style.opacity = 1;
+    }, DELAY * idx);
+  });
+});


### PR DESCRIPTION
## Summary
- show CLI style welcome text with per-role inventory info
- add JS script to reveal lines sequentially

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'puresnmp')*

------
https://chatgpt.com/codex/tasks/task_e_684ef4ffc0008324a36faa406193fbc0