### PR TITLE
Fix submenu spacing

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -89,7 +89,7 @@
               {% endif %}
             </div>
           </div>
-          <div class="space-y-4 mt-1">
+          <div class="mt-1">
             <div x-show="activeTopMenu == 'inventory'" class="border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3" x-cloak>
               <div :class="mobile ? 'flex flex-col space-y-2' : 'flex space-x-2'">
                 <a href="/devices" class="px-4 py-2 text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">All Devices</a>


### PR DESCRIPTION
## Summary
- adjust submenu wrapper margin so every submenu lines up evenly below the top bar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f0e4d3e8883248b88792efc256f91