### PR TITLE
Improve paired form layouts

### DIFF
--- a/app/templates/device_import_upload.html
+++ b/app/templates/device_import_upload.html
@@ -2,19 +2,21 @@
 {% block content %}
 <h1 class="text-xl mb-4">Device Import</h1>
 <form method="post" enctype="multipart/form-data" class="space-y-4">
-  {% if current_user.role == 'superadmin' %}
-  <div>
-    <label for="site_id" class="block">Site</label>
-    <select id="site_id" name="site_id" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
-      {% for s in sites %}
-      <option value="{{ s.id }}">{{ s.name }}</option>
-      {% endfor %}
-    </select>
-  </div>
-  {% endif %}
-  <div>
-    <label for="import_file" class="block">CSV or Spreadsheet</label>
-    <input id="import_file" type="file" name="import_file" required class="w-full text-[var(--input-text)]" />
+  <div class="flex flex-col lg:flex-row gap-6">
+    {% if current_user.role == 'superadmin' %}
+    <div class="flex-1 space-y-2">
+      <label for="site_id" class="block">Site</label>
+      <select id="site_id" name="site_id" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
+        {% for s in sites %}
+        <option value="{{ s.id }}">{{ s.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    {% endif %}
+    <div class="flex-1 space-y-2">
+      <label for="import_file" class="block">CSV or Spreadsheet</label>
+      <input id="import_file" type="file" name="import_file" required class="w-full text-[var(--input-text)]" />
+    </div>
   </div>
   <button type="submit" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Next</button>
 </form>

--- a/app/templates/google_sheets.html
+++ b/app/templates/google_sheets.html
@@ -4,13 +4,15 @@
 <h1 class="text-xl mb-4">Google Sheets Integration</h1>
 
 <form method="post" action="/tasks/google-sheets-config" class="space-y-2 mb-4">
-  <div>
-    <label for="service_account_json" class="block">Service Account JSON Path</label>
-    <input id="service_account_json" type="text" name="service_account_json" value="{{ config.creds }}" class="text-[var(--input-text)] w-96">
-  </div>
-  <div>
-    <label for="spreadsheet_id" class="block">Spreadsheet ID</label>
-    <input id="spreadsheet_id" type="text" name="spreadsheet_id" value="{{ config.sheet_id }}" class="text-[var(--input-text)] w-96">
+  <div class="flex flex-col lg:flex-row gap-6">
+    <div class="flex-1 space-y-2">
+      <label for="service_account_json" class="block">Service Account JSON Path</label>
+      <input id="service_account_json" type="text" name="service_account_json" value="{{ config.creds }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
+    </div>
+    <div class="flex-1 space-y-2">
+      <label for="spreadsheet_id" class="block">Spreadsheet ID</label>
+      <input id="spreadsheet_id" type="text" name="spreadsheet_id" value="{{ config.sheet_id }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
+    </div>
   </div>
   <button type="submit" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Save</button>
 </form>

--- a/app/templates/location_form.html
+++ b/app/templates/location_form.html
@@ -3,17 +3,19 @@
 {% block content %}
 <h1 class="text-xl mb-4">{{ form_title }}</h1>
 <form method="post" class="space-y-4">
-  <div>
-    <label for="name" class="block">Name</label>
-    <input id="name" type="text" name="name" value="{{ location.name if location else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
-  </div>
-  <div>
-    <label for="location_type" class="block">Type</label>
-    <select id="location_type" name="location_type" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required>
-      {% for lt in location_types %}
-      <option value="{{ lt }}" {% if location and location.location_type == lt %}selected{% endif %}>{{ lt }}</option>
-      {% endfor %}
-    </select>
+  <div class="flex flex-col lg:flex-row gap-6">
+    <div class="flex-1 space-y-2">
+      <label for="name" class="block">Name</label>
+      <input id="name" type="text" name="name" value="{{ location.name if location else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
+    </div>
+    <div class="flex-1 space-y-2">
+      <label for="location_type" class="block">Type</label>
+      <select id="location_type" name="location_type" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required>
+        {% for lt in location_types %}
+        <option value="{{ lt }}" {% if location and location.location_type == lt %}selected{% endif %}>{{ lt }}</option>
+        {% endfor %}
+      </select>
+    </div>
   </div>
   {% if error %}
   <p class="p-2 rounded bg-[var(--alert-bg)] text-[var(--btn-text)]">{{ error }}</p>

--- a/app/templates/snmp_form.html
+++ b/app/templates/snmp_form.html
@@ -7,13 +7,15 @@
     <label for="name" class="block">Name</label>
     <input id="name" type="text" name="name" value="{{ profile.name if profile else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
   </div>
-  <div>
-    <label for="community_string" class="block">Community String</label>
-    <input id="community_string" type="text" name="community_string" value="{{ profile.community_string if profile else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
-  </div>
-  <div>
-    <label for="version" class="block">Version</label>
-    <input id="version" type="text" name="version" value="{{ profile.version if profile else '2c' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
+  <div class="flex flex-col lg:flex-row gap-6">
+    <div class="flex-1 space-y-2">
+      <label for="community_string" class="block">Community String</label>
+      <input id="community_string" type="text" name="community_string" value="{{ profile.community_string if profile else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
+    </div>
+    <div class="flex-1 space-y-2">
+      <label for="version" class="block">Version</label>
+      <input id="version" type="text" name="version" value="{{ profile.version if profile else '2c' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
+    </div>
   </div>
   {% if error %}
   <p class="p-2 rounded bg-[var(--alert-bg)] text-[var(--btn-text)]">{{ error }}</p>

--- a/app/templates/ssh_form.html
+++ b/app/templates/ssh_form.html
@@ -7,13 +7,15 @@
     <label for="name" class="block">Name</label>
     <input id="name" type="text" name="name" value="{{ cred.name if cred else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
   </div>
-  <div>
-    <label for="username" class="block">Username</label>
-    <input id="username" type="text" name="username" value="{{ cred.username if cred else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
-  </div>
-  <div>
-    <label for="password" class="block">Password</label>
-    <input id="password" type="password" name="password" value="{{ cred.password if cred else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
+  <div class="flex flex-col lg:flex-row gap-6">
+    <div class="flex-1 space-y-2">
+      <label for="username" class="block">Username</label>
+      <input id="username" type="text" name="username" value="{{ cred.username if cred else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
+    </div>
+    <div class="flex-1 space-y-2">
+      <label for="password" class="block">Password</label>
+      <input id="password" type="password" name="password" value="{{ cred.password if cred else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
+    </div>
   </div>
   <div>
     <label for="private_key" class="block">Private Key</label>

--- a/app/templates/ssh_port_check.html
+++ b/app/templates/ssh_port_check.html
@@ -3,17 +3,19 @@
 {% block content %}
 <h1 class="text-xl mb-4">Port Check</h1>
 <form method="post" class="space-y-4">
-  <div>
-    <label for="device_id" class="block">Switch</label>
-    <select id="device_id" name="device_id" class="p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
-      {% for dev in devices %}
-      <option value="{{ dev.id }}" {% if selected==dev.id %}selected{% endif %}>{{ dev.hostname }}</option>
-      {% endfor %}
-    </select>
-  </div>
-  <div>
-    <label for="port_name" class="block">Port</label>
-    <input id="port_name" type="text" name="port_name" value="{{ port_name or '' }}" class="p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
+  <div class="flex flex-col lg:flex-row gap-6">
+    <div class="flex-1 space-y-2">
+      <label for="device_id" class="block">Switch</label>
+      <select id="device_id" name="device_id" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
+        {% for dev in devices %}
+        <option value="{{ dev.id }}" {% if selected==dev.id %}selected{% endif %}>{{ dev.hostname }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="flex-1 space-y-2">
+      <label for="port_name" class="block">Port</label>
+      <input id="port_name" type="text" name="port_name" value="{{ port_name or '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
+    </div>
   </div>
   <button type="submit" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Check</button>
 </form>

--- a/app/templates/ssh_port_config.html
+++ b/app/templates/ssh_port_config.html
@@ -3,17 +3,19 @@
 {% block content %}
 <h1 class="text-xl mb-4">Port Config</h1>
 <form method="post" class="space-y-4">
-  <div>
-    <label for="device_id" class="block">Switch</label>
-    <select id="device_id" name="device_id" class="p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
-      {% for dev in devices %}
-      <option value="{{ dev.id }}" {% if selected==dev.id %}selected{% endif %}>{{ dev.hostname }}</option>
-      {% endfor %}
-    </select>
-  </div>
-  <div>
-    <label for="port_name" class="block">Port</label>
-    <input id="port_name" type="text" name="port_name" value="{{ port_name or '' }}" class="p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
+  <div class="flex flex-col lg:flex-row gap-6">
+    <div class="flex-1 space-y-2">
+      <label for="device_id" class="block">Switch</label>
+      <select id="device_id" name="device_id" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
+        {% for dev in devices %}
+        <option value="{{ dev.id }}" {% if selected==dev.id %}selected{% endif %}>{{ dev.hostname }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="flex-1 space-y-2">
+      <label for="port_name" class="block">Port</label>
+      <input id="port_name" type="text" name="port_name" value="{{ port_name or '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
+    </div>
   </div>
   <button type="submit" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Fetch Config</button>
 </form>

--- a/app/templates/vlan_form.html
+++ b/app/templates/vlan_form.html
@@ -3,13 +3,15 @@
 {% block content %}
 <h1 class="text-xl mb-4">{{ form_title }}</h1>
 <form method="post" class="space-y-4">
-  <div>
-    <label for="tag" class="block">Tag</label>
-    <input id="tag" type="number" name="tag" value="{{ vlan.tag if vlan else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
-  </div>
-  <div>
-    <label for="description" class="block">Description</label>
-    <input id="description" type="text" name="description" value="{{ vlan.description if vlan else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
+  <div class="flex flex-col lg:flex-row gap-6">
+    <div class="flex-1 space-y-2">
+      <label for="tag" class="block">Tag</label>
+      <input id="tag" type="number" name="tag" value="{{ vlan.tag if vlan else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
+    </div>
+    <div class="flex-1 space-y-2">
+      <label for="description" class="block">Description</label>
+      <input id="description" type="text" name="description" value="{{ vlan.description if vlan else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
+    </div>
   </div>
   {% if error %}
   <p class="p-2 rounded bg-[var(--alert-bg)] text-[var(--btn-text)]">{{ error }}</p>


### PR DESCRIPTION
## Summary
- display name/type fields together on location form
- display tag/description fields together on VLAN form
- align switch/port pairs side-by-side on SSH port tools
- align service account & spreadsheet ID fields on Google Sheets form
- align optional site selection with file upload on device import
- pair username/password inputs on SSH credential form
- pair SNMP community and version fields on SNMP form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f13fe39848324958284c99e05f8ad