### PR TITLE
Remove underline from submenu links

### DIFF
--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -58,6 +58,11 @@ nav.bg-gray-800 a {
   display: block;
 }
 
+/* Ensure all navigation links have no underlines */
+nav a {
+  text-decoration: none;
+}
+
 nav.bg-gray-800 .menu-right {
   margin-left: auto;
   display: flex;


### PR DESCRIPTION
## Summary
- apply a general rule in `layout.css` so nav links don't show underlines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2e9c41d48324a4e30e927aec93e6