### PR TITLE
Fix table layout and icon styles

### DIFF
--- a/app/templates/audit_log.html
+++ b/app/templates/audit_log.html
@@ -2,7 +2,8 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">Audit Log</h1>
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Timestamp</th>
@@ -30,4 +31,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -47,7 +47,7 @@
       {% endif %}
       {% endblock %}
     </header>
-      <div class="container mt-4">
+      <div class="w-full px-4 mt-4">
         <p class="text-base text-[var(--card-text)]">{{ message }}</p>
         {% block content %}{% endblock %}
       </div>

--- a/app/templates/config_list.html
+++ b/app/templates/config_list.html
@@ -14,7 +14,8 @@
   (checked {{ device.last_snmp_check }})
 </p>
 {% endif %}
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Timestamp</th>
@@ -69,4 +70,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/app/templates/debug_log.html
+++ b/app/templates/debug_log.html
@@ -52,7 +52,8 @@
     </select>
   </label>
 </form>
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Timestamp</th>
@@ -76,4 +77,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/app/templates/device_column_prefs.html
+++ b/app/templates/device_column_prefs.html
@@ -10,6 +10,6 @@
     </label>
   </div>
   {% endfor %}
-  <button type="submit" aria-label="Save" class="px-4 py-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">{{ include_icon("save") }}</button>
+  <button type="submit" aria-label="Save" class="px-4 py-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon("save") }}</button>
 </form>
 {% endblock %}

--- a/app/templates/device_form.html
+++ b/app/templates/device_form.html
@@ -141,7 +141,7 @@
     </datalist>
   </div>
   <div class="md:col-span-2">
-    <button type="submit" aria-label="Submit" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">{{ include_icon('check') }}</button>
+    <button type="submit" aria-label="Submit" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('check') }}</button>
     <a href="/devices" class="ml-2 underline">Cancel</a>
   </div>
 </form>
@@ -154,7 +154,7 @@
 </div>
 <form method="post" action="/devices/{{ device.id }}/damage" enctype="multipart/form-data" class="mb-4">
   <input type="file" name="photo" accept="image/*" class="mb-2" required />
-  <button type="submit" aria-label="Upload Photo" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">{{ include_icon('upload') }}</button>
+  <button type="submit" aria-label="Upload Photo" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('upload','text-orange-500') }}</button>
 </form>
 <h2 class="text-lg mt-4">Recent Syslog</h2>
 <ul class="mb-4">

--- a/app/templates/device_import_confirm.html
+++ b/app/templates/device_import_confirm.html
@@ -18,6 +18,6 @@
       <option value="merge">Merge</option>
     </select>
   </label>
-  <button type="submit" name="confirm" value="yes" aria-label="Import" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">{{ include_icon('check-circle') }}</button>
+  <button type="submit" name="confirm" value="yes" aria-label="Import" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('check-circle') }}</button>
 </form>
 {% endblock %}

--- a/app/templates/device_import_map.html
+++ b/app/templates/device_import_map.html
@@ -4,7 +4,8 @@
 <form method="post" class="space-y-4">
   <input type="hidden" name="file_data" value="{{ file_data }}" />
   <input type="hidden" name="site_id" value="{{ site_id }}" />
-  <table class="min-w-full text-left mb-4 border">
+  <div class="w-full overflow-auto px-4">
+  <table class="w-full table-fixed text-left mb-4 border">
     <thead>
       <tr>
         {% for col in columns %}<th class="border px-2">{{ col }}</th>{% endfor %}
@@ -18,6 +19,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
   <div>
     <p class="text-base text-[var(--card-text)]">Map each column:</p>
     {% for col in columns %}
@@ -30,6 +32,6 @@
     </label>
     {% endfor %}
   </div>
-  <button type="submit" aria-label="Next" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">{{ include_icon('arrow-right') }}</button>
+  <button type="submit" aria-label="Next" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('arrow-right') }}</button>
 </form>
 {% endblock %}

--- a/app/templates/device_import_upload.html
+++ b/app/templates/device_import_upload.html
@@ -18,6 +18,6 @@
       <input id="import_file" type="file" name="import_file" required class="w-full text-[var(--input-text)]" />
     </div>
   </div>
-  <button type="submit" aria-label="Next" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">{{ include_icon('arrow-right') }}</button>
+  <button type="submit" aria-label="Next" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('arrow-right') }}</button>
 </form>
 {% endblock %}

--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -8,7 +8,7 @@
 {% endif %}
 {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
   <div class="relative inline-block ml-2" x-data="{open:false}">
-    <button aria-label="Export" class="bg-[var(--card-bg)] p-2 rounded" @click="open = !open">{{ include_icon('download') }}</button>
+    <button aria-label="Export" class="bg-[var(--card-bg)] p-2 text-[var(--btn-text)] rounded" @click="open = !open">{{ include_icon('download','text-orange-500') }}</button>
     <ul x-show="open" @click.away="open = false" class="absolute bg-[var(--card-bg)] py-2 w-48" x-cloak>
       <li><a class="block px-4 py-2 hover:bg-[var(--btn-hover)]" href="/export/inventory.csv">Export to CSV</a></li>
       <li><a class="block px-4 py-2 hover:bg-[var(--btn-hover)]" href="/export/inventory.pdf">Export to PDF</a></li>
@@ -18,7 +18,7 @@
 {% endif %}
 {% if current_user and current_user.role == 'superadmin' %}
   <form method="post" action="/admin/run-push-queue" class="inline">
-    <button type="submit" aria-label="Run Push Queue" class="ml-2 p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">{{ include_icon('refresh-ccw') }}</button>
+    <button type="submit" aria-label="Run Push Queue" class="ml-2 p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('refresh-ccw') }}</button>
   </form>
 {% endif %}
 <form method="get" class="my-2">
@@ -50,8 +50,8 @@
   </label>
   <input x-model="search" type="text" placeholder="Search" class="rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)] px-2 py-1" />
 </div>
-<div class="overflow-x-auto">
-<table class="min-w-full text-left border-collapse">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left border-collapse">
   <thead>
     <tr>
       <th class="table-cell"><input type="checkbox" id="select-all"></th>
@@ -114,19 +114,19 @@
     {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
     <tr class="border-b border-gray-700">
       <td colspan="{{ column_count }}" class="px-4 py-2 text-right">
-        <a href="/devices/{{ device.id }}/edit" aria-label="Edit" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition mr-2">{{ include_icon('pencil') }}</a>
+        <a href="/devices/{{ device.id }}/edit" aria-label="Edit" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('pencil','text-blue-500') }}</a>
         <form method="post" action="/devices/{{ device.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="p-2 mr-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition" onclick="return confirm('Delete device?')">{{ include_icon('trash-2') }}</button>
+          <button type="submit" aria-label="Delete" class="p-2 mr-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" onclick="return confirm('Delete device?')">{{ include_icon('trash-2','text-red-500') }}</button>
         </form>
         <form method="post" action="/devices/{{ device.id }}/pull-config" class="inline">
-          <button type="submit" aria-label="Pull Config" class="p-2 mr-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">{{ include_icon('download') }}</button>
+          <button type="submit" aria-label="Pull Config" class="p-2 mr-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('download','text-orange-500') }}</button>
         </form>
-        <a href="/devices/{{ device.id }}/push-config" aria-label="Push Config" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition mr-2">{{ include_icon('upload') }}</a>
-        <a href="/devices/{{ device.id }}/configs" aria-label="Configs" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition mr-2">{{ include_icon('eye') }}</a>
+        <a href="/devices/{{ device.id }}/push-config" aria-label="Push Config" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('upload','text-orange-500') }}</a>
+        <a href="/devices/{{ device.id }}/configs" aria-label="Configs" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('eye','text-green-500') }}</a>
         {% if device.snmp_community %}
-        <a href="/devices/{{ device.id }}/ports" aria-label="Port Status" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition mr-2">{{ include_icon('eye') }}</a>
-        <a href="/devices/{{ device.id }}/port-map" aria-label="Port Map" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition mr-2">{{ include_icon('link-2') }}</a>
-        <a href="/devices/{{ device.id }}/ports/edit" aria-label="Port Editor" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">{{ include_icon('pencil') }}</a>
+        <a href="/devices/{{ device.id }}/ports" aria-label="Port Status" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('eye','text-green-500') }}</a>
+        <a href="/devices/{{ device.id }}/port-map" aria-label="Port Map" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('link-2') }}</a>
+        <a href="/devices/{{ device.id }}/ports/edit" aria-label="Port Editor" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('pencil','text-blue-500') }}</a>
         {% endif %}
       </td>
     </tr>
@@ -143,7 +143,7 @@
   </div>
 </div>
 </div>
-<button type="submit" aria-label="Delete Selected" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition mt-2">{{ include_icon('trash-2') }}</button>
+<button type="submit" aria-label="Delete Selected" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mt-2">{{ include_icon('trash-2','text-red-500') }}</button>
 </form>
 <script>
 document.getElementById('select-all').addEventListener('change', function(e){

--- a/app/templates/device_type_form.html
+++ b/app/templates/device_type_form.html
@@ -11,7 +11,7 @@
   <p class="p-2 rounded bg-[var(--alert-bg)] text-[var(--btn-text)]">{{ error }}</p>
   {% endif %}
   <div>
-    <button type="submit" aria-label="Submit" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">{{ include_icon('check') }}</button>
+    <button type="submit" aria-label="Submit" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('check') }}</button>
     <a href="/device-types" class="ml-2 underline">Cancel</a>
   </div>
 </form>

--- a/app/templates/device_type_list.html
+++ b/app/templates/device_type_list.html
@@ -16,8 +16,8 @@
   </label>
   <input x-model="search" type="text" placeholder="Search" class="rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)] px-2 py-1" />
 </div>
-<div class="overflow-x-auto">
-<table class="min-w-full text-left border-collapse">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left border-collapse">
   <thead>
     <tr>
       <th class="table-cell"><input type="checkbox" id="select-all"></th>
@@ -31,9 +31,9 @@
       <td class="table-cell"><input type="checkbox" name="selected" value="{{ dt.id }}"></td>
       <td class="table-cell">{{ dt.name }}</td>
       <td class="table-cell">
-        <a href="/device-types/{{ dt.id }}/edit" aria-label="Edit" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition mr-2">{{ include_icon('pencil') }}</a>
+        <a href="/device-types/{{ dt.id }}/edit" aria-label="Edit" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('pencil','text-blue-500') }}</a>
         <form method="post" action="/device-types/{{ dt.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition" onclick="return confirm('Delete type?')">{{ include_icon('trash-2') }}</button>
+          <button type="submit" aria-label="Delete" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" onclick="return confirm('Delete type?')">{{ include_icon('trash-2','text-red-500') }}</button>
         </form>
       </td>
     </tr>
@@ -48,7 +48,7 @@
   </div>
 </div>
 </div>
-<button type="submit" aria-label="Delete Selected" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition mt-2">{{ include_icon('trash-2') }}</button>
+<button type="submit" aria-label="Delete Selected" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mt-2">{{ include_icon('trash-2','text-red-500') }}</button>
 </form>
 <script>
 document.getElementById('select-all').addEventListener('change', function(e){

--- a/app/templates/devices_by_tag.html
+++ b/app/templates/devices_by_tag.html
@@ -2,7 +2,8 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">Devices tagged '{{ tag.name }}'</h1>
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Hostname</th>
@@ -20,4 +21,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/app/templates/ip_ban_list.html
+++ b/app/templates/ip_ban_list.html
@@ -15,8 +15,8 @@
   </label>
   <input x-model="search" type="text" placeholder="Search" class="rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)] px-2 py-1" />
 </div>
-<div class="overflow-x-auto">
-<table class="min-w-full text-left border-collapse">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left border-collapse">
   <thead>
     <tr>
       <th class="table-cell table-header">IP Address</th>
@@ -35,7 +35,7 @@
       <td class="table-cell">{{ ban.ban_reason }}</td>
       <td class="table-cell">
         <form method="post" action="/admin/ip-bans/{{ ban.id }}/unban">
-          <button type='submit' aria-label='Unban' class='px-4 py-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition' onclick="return confirm('Unban this IP?')">{{ include_icon('x-circle') }}</button>
+          <button type='submit' aria-label='Unban' class='px-4 py-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition' onclick="return confirm('Unban this IP?')">{{ include_icon('x-circle') }}</button>
         </form>
       </td>
     </tr>
@@ -65,8 +65,8 @@
   </label>
   <input x-model="search" type="text" placeholder="Search" class="rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)] px-2 py-1" />
 </div>
-<div class="overflow-x-auto">
-<table class="min-w-full text-left border-collapse">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left border-collapse">
   <thead>
     <tr>
       <th class="table-cell table-header">Timestamp</th>

--- a/app/templates/live_syslog.html
+++ b/app/templates/live_syslog.html
@@ -32,7 +32,8 @@
     <input id="end" type="datetime-local" name="end" value="{{ end or '' }}" onchange="this.form.submit()">
   </label>
 </form>
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Timestamp</th>
@@ -54,6 +55,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}
 
 {% block extra_scripts %}

--- a/app/templates/location_list.html
+++ b/app/templates/location_list.html
@@ -4,7 +4,8 @@
 <h1 class="text-xl mb-4">Locations</h1>
 <a href="/admin/locations/new" class="underline">Add Location</a>
 <form method="post" action="/admin/locations/bulk-delete">
-<table class="min-w-full text-left mt-4">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left mt-4">
   <thead>
     <tr>
       <th class="px-2"><input type="checkbox" id="select-all"></th>
@@ -29,6 +30,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 <button type="submit" class="px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Delete Selected</button>
 </form>
 <script>

--- a/app/templates/login_event_list.html
+++ b/app/templates/login_event_list.html
@@ -21,7 +21,8 @@
     <input id="end" type="date" name="end" value="{{ end or '' }}" onchange="this.form.submit()">
   </label>
 </form>
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Timestamp</th>
@@ -45,4 +46,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/app/templates/port_config_template_list.html
+++ b/app/templates/port_config_template_list.html
@@ -3,7 +3,8 @@
 {% block content %}
 <h1 class="text-xl mb-4">Port Config Templates</h1>
 <a href="/network/port-configs/new" class="underline">Add Template</a>
-<table class="min-w-full text-left mt-4">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left mt-4">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Name</th>
@@ -28,4 +29,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/app/templates/port_edit.html
+++ b/app/templates/port_edit.html
@@ -4,7 +4,8 @@
 <h1 class="text-xl mb-4">Edit Ports on {{ device.hostname }}</h1>
 {% if message %}<p class="text-green-400 mb-2">{{ message }}</p>{% endif %}
 <form method="post" class="space-y-4">
-  <table class="min-w-full text-left text-sm">
+  <div class="w-full overflow-auto px-4">
+  <table class="w-full table-fixed text-left text-sm">
     <thead>
       <tr>
         <th class="px-2 py-1 text-left">Name</th>
@@ -42,6 +43,7 @@
     {% endfor %}
     </tbody>
   </table>
+  </div>
   <button type="submit" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Save Changes</button>
   <a href="/devices/{{ device.id }}/port-map" class="ml-2 underline">Back</a>
 </form>

--- a/app/templates/port_history.html
+++ b/app/templates/port_history.html
@@ -23,7 +23,8 @@
     Changes only
   </label>
 </form>
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Timestamp</th>
@@ -47,4 +48,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -68,7 +68,8 @@
 </div>
 {% endif %}
 
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Port Name</th>
@@ -111,6 +112,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}
 
 {% block extra_scripts %}

--- a/app/templates/snmp_list.html
+++ b/app/templates/snmp_list.html
@@ -4,7 +4,8 @@
 <h1 class="text-xl mb-4">SNMP Communities</h1>
 <a href="/admin/snmp/new" class="underline">Add SNMP Profile</a>
 <form method="post" action="/admin/snmp/bulk-delete">
-<table class="min-w-full text-left mt-4">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left mt-4">
   <thead>
     <tr>
       <th class="px-2"><input type="checkbox" id="select-all"></th>
@@ -31,6 +32,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 <button type="submit" class="px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Delete Selected</button>
 </form>
 <script>

--- a/app/templates/snmp_traps.html
+++ b/app/templates/snmp_traps.html
@@ -21,7 +21,8 @@
     <input id="end" type="datetime-local" name="end" value="{{ end or '' }}" onchange="this.form.submit()">
   </label>
 </form>
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Timestamp</th>
@@ -45,6 +46,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}
 
 {% block extra_scripts %}

--- a/app/templates/ssh_list.html
+++ b/app/templates/ssh_list.html
@@ -4,7 +4,8 @@
 <h1 class="text-xl mb-4">SSH Credentials</h1>
 <a href="/admin/ssh/new" class="underline">Add SSH Credential</a>
 <form method="post" action="/admin/ssh/bulk-delete">
-<table class="min-w-full text-left mt-4">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left mt-4">
   <thead>
     <tr>
       <th class="px-2"><input type="checkbox" id="select-all"></th>
@@ -29,6 +30,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 <button type="submit" class="px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Delete Selected</button>
 </form>
 <script>

--- a/app/templates/tag_edit.html
+++ b/app/templates/tag_edit.html
@@ -3,7 +3,8 @@
 {% block content %}
 <h1 class="text-xl mb-4">Edit Tags</h1>
 <form method="post">
-<table class="min-w-full text-left mt-4">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left mt-4">
   <thead>
     <tr>
       <th class="text-left">Device</th>
@@ -21,6 +22,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 <button type="submit" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition mt-2 py-1">Save</button>
 </form>
 <p class="mt-2 text-base text-[var(--card-text)]">Automatic tags <em>complete</em> and <em>incomplete</em> cannot be removed.</p>

--- a/app/templates/tag_manager.html
+++ b/app/templates/tag_manager.html
@@ -2,7 +2,8 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">Tag Manager</h1>
-<table class="min-w-full text-left mt-4">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left mt-4">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Tag</th>
@@ -44,4 +45,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/app/templates/tasks.html
+++ b/app/templates/tasks.html
@@ -3,7 +3,8 @@
 {% block content %}
 <h1 class="text-xl mb-4">Queued Tasks</h1>
 {% if queued %}
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <thead>
     <tr>
       <th class="text-left">Device</th>
@@ -19,6 +20,7 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% else %}
 <p class="text-base text-[var(--card-text)]">No queued tasks.</p>
 {% endif %}

--- a/app/templates/user_detail.html
+++ b/app/templates/user_detail.html
@@ -2,7 +2,8 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">User Details</h1>
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <tbody>
     <tr class="border-t border-gray-700">
       <th class="px-4 py-2 text-left">Email</th>
@@ -22,6 +23,7 @@
     </tr>
   </tbody>
 </table>
+</div>
 {% if current_user and current_user.id == user.id %}
 <a href="/users/me/edit" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Edit Profile</a>
 {% endif %}

--- a/app/templates/user_list.html
+++ b/app/templates/user_list.html
@@ -3,7 +3,8 @@
 {% block content %}
 <h1 class="text-xl mb-4">Users</h1>
 <a href="/admin/users/new" class="underline">Add User</a>
-<table class="min-w-full text-left mt-4">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left mt-4">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Email</th>
@@ -35,4 +36,5 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/app/templates/user_ssh_list.html
+++ b/app/templates/user_ssh_list.html
@@ -3,7 +3,8 @@
 {% block content %}
 <h1 class="text-xl mb-4">My SSH Credentials</h1>
 <a href="/user/ssh/new" class="underline">Add SSH Credential</a>
-<table class="min-w-full text-left mt-4">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left mt-4">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Name</th>
@@ -26,4 +27,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/app/templates/vlan_list.html
+++ b/app/templates/vlan_list.html
@@ -4,7 +4,8 @@
 <h1 class="text-xl mb-4">VLANs</h1>
 <a href="/vlans/new" class="underline">Add VLAN</a>
 <form method="post" action="/vlans/bulk-delete">
-<table class="min-w-full text-left mt-4">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left mt-4">
   <thead>
     <tr>
       <th class="px-2"><input type="checkbox" id="select-all"></th>
@@ -29,6 +30,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 <button type="submit" class="px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Delete Selected</button>
 </form>
 <script>

--- a/app/templates/vlan_usage_report.html
+++ b/app/templates/vlan_usage_report.html
@@ -8,7 +8,8 @@
       VLAN {{ row.vlan.tag }} - {{ row.vlan.description or '' }} ({{ row.count }} devices)
     </summary>
     {% if row.devices %}
-    <table class="min-w-full text-left mt-2">
+    <div class="w-full overflow-auto px-4">
+    <table class="w-full table-fixed text-left mt-2">
       <thead>
         <tr>
           <th class="px-4 py-2 text-left">Hostname</th>
@@ -28,6 +29,7 @@
         {% endfor %}
       </tbody>
     </table>
+    </div>
     {% endif %}
   </details>
 {% else %}

--- a/app/templates/welcome.html
+++ b/app/templates/welcome.html
@@ -19,7 +19,8 @@
 {% endif %}
 {% if login_history %}
 <h2 class="text-xl mt-8 mb-4">Login History</h2>
-<table class="min-w-full text-left">
+<div class="w-full overflow-auto px-4">
+<table class="w-full table-fixed text-left">
   <thead>
     <tr>
       <th class="px-4 py-2 text-left">Timestamp</th>
@@ -39,6 +40,7 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endif %}
 {% endblock %}
 

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -58,15 +58,21 @@ templates.env.globals["logo_url"] = logo_url
 from markupsafe import Markup
 
 
-def include_icon(name: str) -> str:
-    """Return SVG markup for the given icon."""
+def include_icon(name: str, color: str | None = None) -> str:
+    """Return SVG markup for the given icon with optional colour."""
     path = os.path.join(STATIC_DIR, "icons", f"{name}.svg")
     if not os.path.exists(path):
         return ""
     svg = open(path, "r", encoding="utf-8").read()
+    classes = ["w-4", "h-4"]
+    if color:
+        classes.append(color)
+    else:
+        classes.append("text-[var(--btn-text)]")
+    classes.append("transition")
     svg = svg.replace(
         "<svg",
-        '<svg class="w-5 h-5 text-[var(--btn-text)] hover:text-[var(--btn-hover-text)] transition"',
+        f'<svg class="{" ".join(classes)}"',
         1,
     )
     return Markup(svg)

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -3,7 +3,8 @@ body {
 }
 
 .container {
-  max-width: 1000px;
+  width: 100%;
+  max-width: none;
   margin-left: auto;
   margin-right: auto;
   padding-left: 1rem;


### PR DESCRIPTION
## Summary
- ensure all tables use responsive wrappers and full-width layout
- standardize icon colors and sizes
- update `include_icon` helper for customizable color and smaller size
- expand main content container to full width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3b6572e48324b19c54659ec15922