### PR TITLE
Reduce icon size in device tables

### DIFF
--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -8,7 +8,7 @@
 {% endif %}
 {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
   <div class="relative inline-block ml-2" x-data="{open:false}">
-    <button aria-label="Export" class="bg-[var(--card-bg)] p-2 text-[var(--btn-text)] rounded" @click="open = !open">{{ include_icon('download','text-orange-500') }}</button>
+    <button aria-label="Export" class="bg-[var(--card-bg)] p-2 text-[var(--btn-text)] rounded" @click="open = !open">{{ include_icon('download','text-orange-500','1.5') }}</button>
     <ul x-show="open" @click.away="open = false" class="absolute bg-[var(--card-bg)] py-2 w-48" x-cloak>
       <li><a class="block px-4 py-2 hover:bg-[var(--btn-hover)]" href="/export/inventory.csv">Export to CSV</a></li>
       <li><a class="block px-4 py-2 hover:bg-[var(--btn-hover)]" href="/export/inventory.pdf">Export to PDF</a></li>
@@ -18,7 +18,7 @@
 {% endif %}
 {% if current_user and current_user.role == 'superadmin' %}
   <form method="post" action="/admin/run-push-queue" class="inline">
-    <button type="submit" aria-label="Run Push Queue" class="ml-2 p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('refresh-ccw') }}</button>
+    <button type="submit" aria-label="Run Push Queue" class="ml-2 p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('refresh-ccw', None, '1.5') }}</button>
   </form>
 {% endif %}
 <form method="get" class="my-2">
@@ -114,19 +114,19 @@
     {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
     <tr class="border-b border-gray-700">
       <td colspan="{{ column_count }}" class="px-4 py-2 text-right">
-        <a href="/devices/{{ device.id }}/edit" aria-label="Edit" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('pencil','text-blue-500') }}</a>
+        <a href="/devices/{{ device.id }}/edit" aria-label="Edit" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         <form method="post" action="/devices/{{ device.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="p-2 mr-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" onclick="return confirm('Delete device?')">{{ include_icon('trash-2','text-red-500') }}</button>
+          <button type="submit" aria-label="Delete" class="p-2 mr-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" onclick="return confirm('Delete device?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
         </form>
         <form method="post" action="/devices/{{ device.id }}/pull-config" class="inline">
-          <button type="submit" aria-label="Pull Config" class="p-2 mr-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('download','text-orange-500') }}</button>
+          <button type="submit" aria-label="Pull Config" class="p-2 mr-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('download','text-orange-500','1.5') }}</button>
         </form>
-        <a href="/devices/{{ device.id }}/push-config" aria-label="Push Config" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('upload','text-orange-500') }}</a>
-        <a href="/devices/{{ device.id }}/configs" aria-label="Configs" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('eye','text-green-500') }}</a>
+        <a href="/devices/{{ device.id }}/push-config" aria-label="Push Config" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('upload','text-orange-500','1.5') }}</a>
+        <a href="/devices/{{ device.id }}/configs" aria-label="Configs" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('eye','text-green-500','1.5') }}</a>
         {% if device.snmp_community %}
-        <a href="/devices/{{ device.id }}/ports" aria-label="Port Status" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('eye','text-green-500') }}</a>
-        <a href="/devices/{{ device.id }}/port-map" aria-label="Port Map" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('link-2') }}</a>
-        <a href="/devices/{{ device.id }}/ports/edit" aria-label="Port Editor" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('pencil','text-blue-500') }}</a>
+        <a href="/devices/{{ device.id }}/ports" aria-label="Port Status" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('eye','text-green-500','1.5') }}</a>
+        <a href="/devices/{{ device.id }}/port-map" aria-label="Port Map" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('link-2', None, '1.5') }}</a>
+        <a href="/devices/{{ device.id }}/ports/edit" aria-label="Port Editor" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         {% endif %}
       </td>
     </tr>
@@ -143,7 +143,7 @@
   </div>
 </div>
 </div>
-<button type="submit" aria-label="Delete Selected" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mt-2">{{ include_icon('trash-2','text-red-500') }}</button>
+<button type="submit" aria-label="Delete Selected" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mt-2">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
 </form>
 <script>
 document.getElementById('select-all').addEventListener('change', function(e){

--- a/app/templates/device_type_list.html
+++ b/app/templates/device_type_list.html
@@ -31,9 +31,9 @@
       <td class="table-cell"><input type="checkbox" name="selected" value="{{ dt.id }}"></td>
       <td class="table-cell">{{ dt.name }}</td>
       <td class="table-cell">
-        <a href="/device-types/{{ dt.id }}/edit" aria-label="Edit" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('pencil','text-blue-500') }}</a>
+        <a href="/device-types/{{ dt.id }}/edit" aria-label="Edit" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         <form method="post" action="/device-types/{{ dt.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" onclick="return confirm('Delete type?')">{{ include_icon('trash-2','text-red-500') }}</button>
+          <button type="submit" aria-label="Delete" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" onclick="return confirm('Delete type?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
         </form>
       </td>
     </tr>
@@ -48,7 +48,7 @@
   </div>
 </div>
 </div>
-<button type="submit" aria-label="Delete Selected" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mt-2">{{ include_icon('trash-2','text-red-500') }}</button>
+<button type="submit" aria-label="Delete Selected" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mt-2">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
 </form>
 <script>
 document.getElementById('select-all').addEventListener('change', function(e){

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -58,13 +58,16 @@ templates.env.globals["logo_url"] = logo_url
 from markupsafe import Markup
 
 
-def include_icon(name: str, color: str | None = None) -> str:
-    """Return SVG markup for the given icon with optional colour."""
+def include_icon(name: str, color: str | None = None, size: str | int = "3") -> str:
+    """Return SVG markup for the given icon with optional colour and size."""
     path = os.path.join(STATIC_DIR, "icons", f"{name}.svg")
     if not os.path.exists(path):
         return ""
     svg = open(path, "r", encoding="utf-8").read()
-    classes = ["w-3", "h-3"]
+    if str(size) == "1.5":
+        classes = ["w-[0.375rem]", "h-[0.375rem]"]
+    else:
+        classes = [f"w-{size}", f"h-{size}"]
     if color:
         classes.append(color)
     else:

--- a/static/css/unocss.css
+++ b/static/css/unocss.css
@@ -59,6 +59,7 @@
 .group:hover .group-hover\:block{display:block;}
 .inline-block{display:inline-block;}
 .hidden{display:none;}
+.h-\[0\.375rem\]{height:0.375rem;}
 .h-\[3\.9rem\]{height:3.9rem;}
 .h-\[500px\]{height:500px;}
 .h-10{height:2.5rem;}
@@ -70,6 +71,7 @@
 .max-w-lg{max-width:32rem;}
 .max-w-sm{max-width:24rem;}
 .min-h-\[50vh\]{min-height:50vh;}
+.w-\[0\.375rem\]{width:0.375rem;}
 .w-\[21\.5rem\]{width:21.5rem;}
 .w-\[6\.5rem\]{width:6.5rem;}
 .w-1\/2{width:50%;}

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -19,6 +19,6 @@ export default defineConfig({
   },
   // Ensure UnoCSS includes the shortcuts even when used dynamically
   safelist: [
-    'table-cell', 'table-header',
+    'table-cell', 'table-header', 'w-[0.375rem]', 'h-[0.375rem]',
   ],
 })


### PR DESCRIPTION
## Summary
- update `include_icon` helper to accept a `size` parameter
- regenerate CSS and safelist small icon classes
- shrink action icons in `device_list` and `device_type_list` to 50%

## Testing
- `npm run build:css`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684f4b5d14a0832488c2388ffa839186