### PR TITLE
Implement table column customization

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -23,6 +23,7 @@ from .models import (
     DashboardWidget,
     SiteDashboardWidget,
     ColumnPreference,
+    TablePreference,
 )
 
 __all__ = [
@@ -50,4 +51,5 @@ __all__ = [
     "DashboardWidget",
     "SiteDashboardWidget",
     "ColumnPreference",
+    "TablePreference",
 ]

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -443,6 +443,17 @@ class ColumnPreference(Base):
     user = relationship("User")
 
 
+class TablePreference(Base):
+    __tablename__ = "table_preferences"
+
+    user_id = Column(Integer, ForeignKey("users.id"), primary_key=True)
+    table_id = Column(String, primary_key=True)
+    column_widths = Column(Text, nullable=True)
+    visible_columns = Column(Text, nullable=True)
+
+    user = relationship("User")
+
+
 class ImportLog(Base):
     __tablename__ = "import_logs"
 

--- a/app/routes/api.py
+++ b/app/routes/api.py
@@ -4,7 +4,8 @@ from sqlalchemy.orm import Session
 from app.utils.db_session import get_db
 from app.utils.auth import get_current_user
 from app.routes.devices import suggest_vlan_from_ip
-from app.models.models import VLAN
+from app.models.models import VLAN, TablePreference
+import json
 
 router = APIRouter()
 
@@ -27,3 +28,46 @@ async def suggest_vlan(ip: str, db: Session = Depends(get_db), current_user=Depe
             response["label"] = label
         return response
     return {"error": "No match"}
+
+
+@router.get("/api/table-prefs/{table_id}")
+async def get_table_prefs(
+    table_id: str,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    pref = (
+        db.query(TablePreference)
+        .filter_by(user_id=current_user.id, table_id=table_id)
+        .first()
+    )
+    if not pref:
+        return {"column_widths": {}, "visible_columns": []}
+    widths = json.loads(pref.column_widths) if pref.column_widths else {}
+    visible = json.loads(pref.visible_columns) if pref.visible_columns else []
+    return {"column_widths": widths, "visible_columns": visible}
+
+
+@router.post("/api/table-prefs/{table_id}")
+async def save_table_prefs(
+    table_id: str,
+    payload: dict,
+    db: Session = Depends(get_db),
+    current_user=Depends(get_current_user),
+):
+    if not current_user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    pref = (
+        db.query(TablePreference)
+        .filter_by(user_id=current_user.id, table_id=table_id)
+        .first()
+    )
+    if not pref:
+        pref = TablePreference(user_id=current_user.id, table_id=table_id)
+        db.add(pref)
+    pref.column_widths = json.dumps(payload.get("column_widths", {}))
+    pref.visible_columns = json.dumps(payload.get("visible_columns", []))
+    db.commit()
+    return {"status": "ok"}

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -107,3 +107,16 @@ form hr {
 form select {
   margin-bottom: 1rem;
 }
+
+th .resizer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 5px;
+  height: 100%;
+  cursor: col-resize;
+}
+
+body.col-resize {
+  cursor: col-resize;
+}

--- a/static/js/table.js
+++ b/static/js/table.js
@@ -27,3 +27,146 @@ function tableControls() {
     }
   }
 }
+
+function setupTablePrefs() {
+  const pathId = window.location.pathname.replace(/\W/g, '_')
+  document.querySelectorAll('table').forEach((table, idx) => {
+    const tableId = `${pathId}_${idx}`
+    table.dataset.tableId = tableId
+    initResize(table, tableId)
+    insertCustomizeButton(table, tableId)
+    loadPrefs(table, tableId)
+  })
+}
+
+function initResize(table, tableId) {
+  table.querySelectorAll('th').forEach((th, idx) => {
+    th.dataset.colIndex = idx
+    th.style.position = 'relative'
+    const handle = document.createElement('div')
+    handle.className = 'resizer'
+    th.appendChild(handle)
+    let startX, startWidth
+    handle.addEventListener('mousedown', e => {
+      startX = e.pageX
+      startWidth = th.offsetWidth
+      document.body.classList.add('col-resize')
+      const move = e2 => {
+        const w = startWidth + (e2.pageX - startX)
+        th.style.width = w + 'px'
+        table.querySelectorAll('tr').forEach(row => {
+          const cell = row.children[idx]
+          if (cell) cell.style.width = w + 'px'
+        })
+      }
+      const up = () => {
+        document.removeEventListener('mousemove', move)
+        document.removeEventListener('mouseup', up)
+        document.body.classList.remove('col-resize')
+        saveWidths(table, tableId)
+      }
+      document.addEventListener('mousemove', move)
+      document.addEventListener('mouseup', up)
+    })
+  })
+}
+
+function insertCustomizeButton(table, tableId) {
+  const btn = document.createElement('button')
+  btn.textContent = 'Customize Columns'
+  btn.className = 'mb-2 px-2 py-1 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded'
+  table.parentNode.insertBefore(btn, table)
+  btn.addEventListener('click', () => showColumnModal(table, tableId))
+}
+
+function showColumnModal(table, tableId) {
+  const modal = document.createElement('div')
+  modal.className = 'fixed inset-0 bg-black/50 flex items-center justify-center'
+  const box = document.createElement('div')
+  box.className = 'bg-[var(--card-bg)] p-4'
+  const list = document.createElement('div')
+  table.querySelectorAll('th').forEach((th, idx) => {
+    const label = th.textContent.trim() || `Column ${idx+1}`
+    const chk = document.createElement('input')
+    chk.type = 'checkbox'
+    chk.checked = th.style.display !== 'none'
+    chk.dataset.colIndex = idx
+    const lbl = document.createElement('label')
+    lbl.className = 'block'
+    lbl.appendChild(chk)
+    lbl.appendChild(document.createTextNode(' ' + label))
+    list.appendChild(lbl)
+  })
+  const saveBtn = document.createElement('button')
+  saveBtn.textContent = 'Save'
+  saveBtn.className = 'mt-2 px-2 py-1 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded'
+  box.appendChild(list)
+  box.appendChild(saveBtn)
+  modal.appendChild(box)
+  document.body.appendChild(modal)
+  saveBtn.addEventListener('click', () => {
+    list.querySelectorAll('input[type=checkbox]').forEach(chk => {
+      const idx = chk.dataset.colIndex
+      const show = chk.checked
+      table.querySelectorAll('tr').forEach(row => {
+        const cell = row.children[idx]
+        if (cell) cell.style.display = show ? '' : 'none'
+      })
+    })
+    document.body.removeChild(modal)
+    saveVisible(table, tableId)
+  })
+}
+
+function loadPrefs(table, tableId) {
+  fetch(`/api/table-prefs/${tableId}`)
+    .then(r => r.ok ? r.json() : {column_widths:{}, visible_columns:[]})
+    .then(p => {
+      Object.entries(p.column_widths).forEach(([i,w]) => {
+        table.querySelectorAll('tr').forEach(row => {
+          const cell = row.children[i]
+          if (cell) cell.style.width = w
+        })
+      })
+      p.visible_columns.forEach(i => {
+        table.querySelectorAll('tr').forEach(row => {
+          const cell = row.children[i]
+          if (cell) cell.style.display = 'none'
+        })
+      })
+    })
+}
+
+function savePrefs(tableId, data) {
+  fetch(`/api/table-prefs/${tableId}`, {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: JSON.stringify(data)
+  })
+}
+
+function saveWidths(table, tableId) {
+  const widths = {}
+  table.querySelectorAll('th').forEach((th,i)=>{
+    widths[i] = th.offsetWidth + 'px'
+  })
+  savePrefs(tableId, {column_widths: widths, visible_columns: getHidden(table)})
+}
+
+function saveVisible(table, tableId) {
+  savePrefs(tableId, {column_widths: getWidths(table), visible_columns: getHidden(table)})
+}
+
+function getWidths(table) {
+  const w = {}
+  table.querySelectorAll('th').forEach((th,i)=>{ w[i] = th.offsetWidth + 'px' })
+  return w
+}
+
+function getHidden(table) {
+  const arr = []
+  table.querySelectorAll('th').forEach((th,i)=>{ if (th.style.display==='none') arr.push(String(i)) })
+  return arr
+}
+
+document.addEventListener('DOMContentLoaded', setupTablePrefs)


### PR DESCRIPTION
## Summary
- add `TablePreference` model for per-table width and visibility settings
- expose `/api/table-prefs` endpoints
- create global JS to resize columns and toggle visibility
- style resizer cursor in layout CSS

## Testing
- `pytest -q` *(fails: FAILED tests/test_shutdown.py::test_background_threads_cleanup - assert 2 == 1)*

------
https://chatgpt.com/codex/tasks/task_e_684f4cd7cb448324bcfe3b63f4f85245