### PR TITLE
Add inventory tables with standard columns

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -149,6 +149,9 @@ class Device(Base):
     # Timestamp of the last successful scheduled pull
     last_config_pull = Column(DateTime, nullable=True)
 
+    # Free-form notes about the device
+    notes = Column(Text, nullable=True)
+
     vlan = relationship("VLAN", back_populates="devices")
     ssh_credential = relationship("SSHCredential", back_populates="devices")
     snmp_community = relationship("SNMPCommunity", back_populates="devices")

--- a/app/routes/devices.py
+++ b/app/routes/devices.py
@@ -385,6 +385,7 @@ async def create_device(
     ssh_credential_id: str = Form(None),
     snmp_community_id: str = Form(None),
     detected_platform: str = Form(None),
+    notes: str = Form(None),
     tag_names: str = Form(""),
     db: Session = Depends(get_db),
     current_user=Depends(require_role("editor")),
@@ -406,6 +407,7 @@ async def create_device(
         priority=bool(priority),
         site_id=int(site_id) if site_id else None,
         config_pull_interval=config_pull_interval,
+        notes=notes or None,
         ssh_credential_id=int(ssh_credential_id) if ssh_credential_id else None,
         snmp_community_id=int(snmp_community_id) if snmp_community_id else None,
         created_by_id=current_user.id,
@@ -506,6 +508,7 @@ async def update_device(
     vlan_id: str = Form(None),
     ssh_credential_id: str = Form(None),
     snmp_community_id: str = Form(None),
+    notes: str = Form(None),
     tag_names: str = Form(""),
     db: Session = Depends(get_db),
     current_user=Depends(require_role("editor")),
@@ -534,6 +537,7 @@ async def update_device(
         "vlan_id": device.vlan_id,
         "ssh_credential_id": device.ssh_credential_id,
         "snmp_community_id": device.snmp_community_id,
+        "notes": device.notes,
         "detected_platform": device.detected_platform,
         "ssh_profile_is_default": device.ssh_profile_is_default,
     }
@@ -552,6 +556,7 @@ async def update_device(
     device.priority = bool(priority)
     device.site_id = int(site_id) if site_id else None
     device.config_pull_interval = config_pull_interval
+    device.notes = notes or None
     device.status = status or None
     device.vlan_id = int(vlan_id) if vlan_id else None
     old_cred = device.ssh_credential_id

--- a/app/routes/inventory.py
+++ b/app/routes/inventory.py
@@ -1,8 +1,35 @@
 from fastapi import APIRouter, Request, Depends
+from sqlalchemy.orm import Session
 from app.utils.templates import templates
 from app.utils.auth import require_role
+from app.utils.db_session import get_db
+from app.models.models import Device, DeviceType
 
 router = APIRouter()
+
+
+def _render_inventory(request: Request, current_user, db: Session, device_type: str | None = None, title: str | None = None, show_r1: bool = False):
+    query = db.query(Device)
+    if device_type:
+        dtype = db.query(DeviceType).filter(DeviceType.name == device_type).first()
+        if dtype:
+            query = query.filter(Device.device_type_id == dtype.id)
+    if show_r1:
+        query = query.filter(Device.manufacturer.ilike("ruckus"))
+    devices = query.all()
+    if show_r1 and not device_type:
+        # ensure only ruckus APs trigger column
+        show_r1 = bool(devices)
+    if device_type == "AP":
+        show_r1 = any(d.manufacturer and d.manufacturer.lower() == "ruckus" for d in devices)
+    context = {
+        "request": request,
+        "current_user": current_user,
+        "devices": devices,
+        "title": title or device_type or "Inventory",
+        "show_r1": show_r1,
+    }
+    return templates.TemplateResponse("inventory_table.html", context)
 
 @router.get('/inventory/audit')
 async def inventory_audit(request: Request, current_user=Depends(require_role("viewer"))):
@@ -21,3 +48,63 @@ async def inventory_sites(request: Request, current_user=Depends(require_role("v
     """Placeholder page for site inventory."""
     context = {"request": request, "current_user": current_user}
     return templates.TemplateResponse('inventory_site.html', context)
+
+
+@router.get('/inventory/new-product')
+async def inventory_new_product(request: Request, current_user=Depends(require_role("viewer"))):
+    """Blank table for new products."""
+    context = {"request": request, "current_user": current_user, "devices": [], "title": "New Product Blank Template", "show_r1": False}
+    return templates.TemplateResponse('inventory_table.html', context)
+
+
+@router.get('/inventory/new-camera')
+async def inventory_new_camera(request: Request, current_user=Depends(require_role("viewer"))):
+    """Blank table for new cameras."""
+    context = {"request": request, "current_user": current_user, "devices": [], "title": "New Camera Blank Template", "show_r1": False}
+    return templates.TemplateResponse('inventory_table.html', context)
+
+
+@router.get('/inventory/new-ruckus-ap')
+async def inventory_new_ruckus_ap(request: Request, current_user=Depends(require_role("viewer")), db: Session = Depends(get_db)):
+    """Blank table for new Ruckus APs."""
+    return _render_inventory(request, current_user, db, device_type="AP", title="New Ruckus AP Blank Template", show_r1=True)
+
+
+@router.get('/inventory/switches')
+async def inventory_switches(request: Request, current_user=Depends(require_role("viewer")), db: Session = Depends(get_db)):
+    return _render_inventory(request, current_user, db, device_type="Switch", title="Switches")
+
+
+@router.get('/inventory/ptp')
+async def inventory_ptp(request: Request, current_user=Depends(require_role("viewer")), db: Session = Depends(get_db)):
+    return _render_inventory(request, current_user, db, device_type="PTP", title="PTP")
+
+
+@router.get('/inventory/ptmp')
+async def inventory_ptmp(request: Request, current_user=Depends(require_role("viewer")), db: Session = Depends(get_db)):
+    return _render_inventory(request, current_user, db, device_type="PTMP", title="PTMP")
+
+
+@router.get("/inventory/aps")
+async def inventory_aps(request: Request, current_user=Depends(require_role("viewer")), db: Session = Depends(get_db)):
+    return _render_inventory(request, current_user, db, device_type="AP", title="AP's")
+
+
+@router.get('/inventory/iptv')
+async def inventory_iptv(request: Request, current_user=Depends(require_role("viewer")), db: Session = Depends(get_db)):
+    return _render_inventory(request, current_user, db, device_type="IPTV", title="IPTV")
+
+
+@router.get('/inventory/vog')
+async def inventory_vog(request: Request, current_user=Depends(require_role("viewer")), db: Session = Depends(get_db)):
+    return _render_inventory(request, current_user, db, device_type="VOG", title="VOG")
+
+
+@router.get('/inventory/ip-cameras')
+async def inventory_ip_cameras(request: Request, current_user=Depends(require_role("viewer")), db: Session = Depends(get_db)):
+    return _render_inventory(request, current_user, db, device_type="IP Camera", title="IP Cameras")
+
+
+@router.get('/inventory/iot-devices')
+async def inventory_iot_devices(request: Request, current_user=Depends(require_role("viewer")), db: Session = Depends(get_db)):
+    return _render_inventory(request, current_user, db, device_type="IoT Device", title="IoT Devices")

--- a/app/templates/device_form.html
+++ b/app/templates/device_form.html
@@ -132,6 +132,10 @@
     </select>
   </div>
   <div class="md:col-span-2">
+    <label for="notes" class="block">Notes</label>
+    <textarea id="notes" name="notes" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">{{ device.notes if device else '' }}</textarea>
+  </div>
+  <div class="md:col-span-2">
     <label for="tag_names" class="block">Tags</label>
     <input id="tag_names" type="text" name="tag_names" list="tag-list" value="{{ device.tags | rejectattr('name', 'in', ['complete','incomplete']) | map(attribute='name') | join(', ') if device else '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
     <datalist id="tag-list">

--- a/app/templates/inventory_table.html
+++ b/app/templates/inventory_table.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">{{ title }}</h1>
+<div class="w-full overflow-auto">
+<table class="min-w-full table-fixed text-left">
+  <thead>
+    <tr>
+      <th class="px-4 py-2 text-left">Model</th>
+      <th class="px-4 py-2 text-left">Barcode</th>
+      <th class="px-4 py-2 text-left">MAC ADDRESS</th>
+      <th class="px-4 py-2 text-left">IP ADDRESS</th>
+      <th class="px-4 py-2 text-left">Serial Number</th>
+      <th class="px-4 py-2 text-left">Location</th>
+      <th class="px-4 py-2 text-left">On Lasso</th>
+      {% if show_r1 %}<th class="px-4 py-2 text-left">IN R1 MSP</th>{% endif %}
+      <th class="px-4 py-2 text-left">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for d in devices %}
+    <tr class="border-t border-gray-700">
+      <td class="px-4 py-2">{{ d.model or '' }}</td>
+      <td class="px-4 py-2">{{ d.asset_tag or '' }}</td>
+      <td class="px-4 py-2">{{ d.mac or '' }}</td>
+      <td class="px-4 py-2">{{ d.ip }}</td>
+      <td class="px-4 py-2">{{ d.serial_number or '' }}</td>
+      <td class="px-4 py-2">{{ d.location_ref.name if d.location_ref else '' }}</td>
+      <td class="px-4 py-2">{{ '✔' if d.on_lasso else '' }}</td>
+      {% if show_r1 %}<td class="px-4 py-2">{{ '✔' if d.on_r1 else '' }}</td>{% endif %}
+      <td class="px-4 py-2">{{ d.notes or '' }}</td>
+    </tr>
+  {% endfor %}
+  {% if not devices %}
+    <tr class="border-t border-gray-700"><td class="px-4 py-2" colspan="{{ 8 if not show_r1 else 9 }}">No records</td></tr>
+  {% endif %}
+  </tbody>
+</table>
+</div>
+{% endblock %}

--- a/seed_data.py
+++ b/seed_data.py
@@ -56,6 +56,10 @@ def main():
         if not camera_type:
             camera_type = DeviceType(name="IP Camera")
             db.add(camera_type)
+
+        for dtype in ["PTP", "PTMP", "IPTV", "VOG", "IoT Device"]:
+            if not db.query(DeviceType).filter_by(name=dtype).first():
+                db.add(DeviceType(name=dtype))
         db.commit()
 
         # Seed sample switches if none exist


### PR DESCRIPTION
## Summary
- allow storing notes on devices
- handle notes in device forms and routes
- seed additional device types
- add inventory table view and routes for each device category
- provide reusable inventory table template

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685004aac99083249ed29bf41cdb5b2b