### PR TITLE
Fix UnoCSS builds inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,10 @@ RUN apt-get update \
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Install Node dependencies
-COPY package.json package-lock.json ./
-RUN npm install
-
 COPY . .
+
+# Install Node dependencies
+RUN npm install
 
 # Build static assets
 RUN npm run build:css

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,7 +9,7 @@
     {% set font = (current_user.font if current_user else 'sans') if current_user is defined else 'sans' %}
     <link rel="stylesheet" href="{{ request.url_for('static', path='themes/' ~ theme ~ '.css') }}">
     <link rel="stylesheet" href="{{ request.url_for('static', path='fonts/' ~ font ~ '.css') }}">
-    <link rel='stylesheet' href='{{ request.url_for('static', path='css/unocss.css') }}'>
+    <link rel="stylesheet" href="/static/css/unocss.css">
     <link rel="stylesheet" href="{{ request.url_for('static', path='css/layout.css') }}">
   </head>
   <body class="w-full h-full overflow-x-hidden">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,7 @@ services:
       ROOT_PATH: ""
     ports:
       - "8000:8000"
-    volumes:
-      - .:/app
+    # volume removed to prevent static files from being overridden in production
 
   nginx:
     image: nginx:latest


### PR DESCRIPTION
## Summary
- rebuild UnoCSS inside the container by running `npm run build:css`
- drop web volume mount so static files aren't overridden
- reference UnoCSS stylesheet via absolute path

## Testing
- `pytest -q`
- `docker compose build` *(fails: `docker: command not found`)*
- `docker compose up -d` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685016babf2c8324b4fcfa8994fb1d7f