### PR TITLE
Add submenu for tunables

### DIFF
--- a/app/templates/nav_dropdown.html
+++ b/app/templates/nav_dropdown.html
@@ -36,9 +36,15 @@
         <a href="/ssh/bulk-port-update" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Bulk Port Update</a>
         <a href="/bulk/vlan-push" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">VLAN Bulk Push</a>
         {% if current_user.role in ['admin','superadmin'] %}
+        <span class="mt-2 font-bold">Tunables</span>
+        {% for cat in get_tunable_categories() %}
+        <a href="/tunables?category={{ cat | urlencode }}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">{{ cat }}</a>
+        {% endfor %}
+        <a href="/admin/logo" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Upload Logo</a>
+        {% endif %}
+        {% if current_user.role in ['admin','superadmin'] %}
           {% if current_user.role == 'superadmin' %}
           {% set admin_items = [
-            {'label':'Tunables','href':'/tunables'},
             {'label':'SSH Credentials','href':'/admin/ssh'},
             {'label':'SNMP Credentials','href':'/admin/snmp'},
             {'label':'Tag Manager','href':'/admin/tags'},

--- a/app/templates/nav_tabbed.html
+++ b/app/templates/nav_tabbed.html
@@ -18,9 +18,9 @@
             <button @click="activeTopMenu = 'tasks'; submenuAlign = $event.target.dataset.align" data-align="right" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Tasks</button>
             <button @click="activeTopMenu = 'netdev'; submenuAlign = $event.target.dataset.align" data-align="right" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Network Devices</button>
             {% if current_user.role in ['admin','superadmin'] %}
+            <button @click="activeTopMenu = 'tunables'; submenuAlign = $event.target.dataset.align" data-align="right" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Tunables</button>
             {% if current_user.role == 'superadmin' %}
             {% set admin_items = [
-              {'label':'Tunables','href':'/tunables'},
               {'label':'SSH Credentials','href':'/admin/ssh'},
               {'label':'SNMP Credentials','href':'/admin/snmp'},
               {'label':'Tag Manager','href':'/admin/tags'},
@@ -99,6 +99,16 @@
           <a href="/bulk/vlan-push" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">VLAN Bulk Push</a>
         </div>
       </div>
+      {% if current_user.role in ['admin','superadmin'] %}
+      <div x-show="ready && activeTopMenu == 'tunables'" x-transition.opacity.duration.150ms :class="(submenuAlign === 'right' ? 'ml-auto text-right ' : '') + 'border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3'" x-cloak>
+        <div :class="mobile ? 'flex flex-col space-y-2' : 'flex space-x-2'">
+          {% for cat in get_tunable_categories() %}
+          <a href="/tunables?category={{ cat | urlencode }}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">{{ cat }}</a>
+          {% endfor %}
+          <a href="/admin/logo" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Upload Logo</a>
+        </div>
+      </div>
+      {% endif %}
       {% if current_user.role in ['admin','superadmin'] %}
       <div x-show="ready && activeTopMenu == 'admin'" x-transition.opacity.duration.150ms :class="(submenuAlign === 'right' ? 'ml-auto text-right ' : '') + 'border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3'" x-cloak>
         <div :class="mobile ? 'flex flex-col space-y-2' : 'flex space-x-2'">

--- a/app/templates/tunables.html
+++ b/app/templates/tunables.html
@@ -3,53 +3,36 @@
 {% block content %}
 <h1 class="text-xl mb-4">System Tunables</h1>
 <p class="mb-3 text-base text-[var(--card-text)]">Current Version: <span class="fw-bold">{{ version }}</span></p>
-{% if current_user and current_user.role == 'superadmin' %}
-<p class="mb-3"><a href="/admin/logo" class="underline">Upload Logo</a></p>
-{% endif %}
 
-<div x-data="{tab:0, ready:false}" x-init="setTimeout(() => ready = true, 50)">
-  <ul class="flex border-b" >
-    {% for function in groups.keys() %}
-    <li class="mr-2">
-      <button @click="tab={{ loop.index0 }}" :class="{'border-b-2': tab==={{ loop.index0 }} }" class="px-3 py-2">{{ function }}</button>
-    </li>
-    {% endfor %}
-  </ul>
-
-  {% for function, files in groups.items() %}
-  <div x-show="ready && tab==={{ loop.index0 }}" x-transition.opacity.duration.150ms class="mt-3" x-cloak>
-    {% for file, tunables in files.items() %}
-    <h3 class="mt-2">{{ file }}</h3>
-    <form method="post" action="/tunables/group" class="mb-3 p-3 border rounded">
-      <div class="flex flex-wrap gap-4 items-start">
-        {% for tunable in tunables %}
-        <div class="flex flex-col flex-1 min-w-[280px]">
-          <label class="mb-1 fw-bold block">{{ tunable.name }}</label>
-          {% if tunable.description %}
-          <p class="text-sm text-gray-400">{{ tunable.description }}</p>
-          {% endif %}
-          {% if tunable.options and tunable.data_type == 'choice' %}
-          <p class="text-sm text-gray-400">Options: {{ tunable.options }}</p>
-          {% endif %}
-          {% if tunable.data_type == 'bool' %}
-          <input type="checkbox" name="tunable_{{ tunable.id }}" value="true" {% if tunable.value == 'true' %}checked{% endif %}>
-          {% elif tunable.data_type == 'choice' %}
-          <select name="tunable_{{ tunable.id }}" class="rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
-            {% for opt in tunable.options.split(',') %}
-            <option value="{{ opt }}" {% if tunable.value == opt %}selected{% endif %}>{{ opt }}</option>
-            {% endfor %}
-          </select>
-          {% else %}
-          <input type="text" name="tunable_{{ tunable.id }}" value="{{ tunable.value }}" class="rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
-          {% endif %}
-        </div>
+{% for file, tunables in groups.items() %}
+<h3 class="mt-2">{{ file }}</h3>
+<form method="post" action="/tunables/group" class="mb-3 p-3 border rounded">
+  <div class="flex flex-wrap gap-4 items-start">
+    {% for tunable in tunables %}
+    <div class="flex flex-col flex-1 min-w-[280px]">
+      <label class="mb-1 fw-bold block">{{ tunable.name }}</label>
+      {% if tunable.description %}
+      <p class="text-sm text-gray-400">{{ tunable.description }}</p>
+      {% endif %}
+      {% if tunable.options and tunable.data_type == 'choice' %}
+      <p class="text-sm text-gray-400">Options: {{ tunable.options }}</p>
+      {% endif %}
+      {% if tunable.data_type == 'bool' %}
+      <input type="checkbox" name="tunable_{{ tunable.id }}" value="true" {% if tunable.value == 'true' %}checked{% endif %}>
+      {% elif tunable.data_type == 'choice' %}
+      <select name="tunable_{{ tunable.id }}" class="rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
+        {% for opt in tunable.options.split(',') %}
+        <option value="{{ opt }}" {% if tunable.value == opt %}selected{% endif %}>{{ opt }}</option>
         {% endfor %}
-      </div>
-      <button type="submit" class="mt-3 btn">Save</button>
-    </form>
+      </select>
+      {% else %}
+      <input type="text" name="tunable_{{ tunable.id }}" value="{{ tunable.value }}" class="rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
+      {% endif %}
+    </div>
     {% endfor %}
   </div>
-  {% endfor %}
-</div>
+  <button type="submit" class="mt-3 btn">Save</button>
+</form>
+{% endfor %}
 
 {% endblock %}

--- a/app/utils/templates.py
+++ b/app/utils/templates.py
@@ -1,6 +1,6 @@
 from fastapi.templating import Jinja2Templates
 from app.utils.db_session import SessionLocal
-from app.models.models import DeviceType, Tag
+from app.models.models import DeviceType, Tag, SystemTunable
 
 templates = Jinja2Templates(directory="app/templates")
 
@@ -102,3 +102,13 @@ def include_icon(ctx, name: str, color: str | None = None, size: str | int = "3"
 
 
 templates.env.globals["include_icon"] = include_icon
+
+
+def get_tunable_categories():
+    db = SessionLocal()
+    rows = db.query(SystemTunable.function).distinct().order_by(SystemTunable.function).all()
+    db.close()
+    return [r[0] for r in rows]
+
+
+templates.env.globals["get_tunable_categories"] = get_tunable_categories


### PR DESCRIPTION
## Summary
- refactor tunables view to show a single category
- add Tunables dropdown in nav
- list categories dynamically via helper
- update dropdown navigation similarly

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501b100a988324a97f2bfeb166b162