### PR TITLE
Update device table link styles

### DIFF
--- a/app/templates/config_list.html
+++ b/app/templates/config_list.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">Config Backups for {{ device.hostname }}</h1>
-<p class="text-base text-[var(--card-text)]"><a href="/compare-configs?device_id={{ device.id }}" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Compare</a></p>
+<p class="text-base text-[var(--card-text)]"><a href="/compare-configs?device_id={{ device.id }}" class="inline-block px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)]">Compare</a></p>
 {% if device.last_snmp_check %}
 <p class="mb-4 text-base text-[var(--card-text)]">
   {% if device.snmp_reachable %}
@@ -47,13 +47,13 @@
       </td>
       <td class="px-4 py-2">
         {% if not loop.last %}
-        <a href="/configs/{{ backup.id }}/diff" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">View Diff</a>
+        <a href="/configs/{{ backup.id }}/diff" class="inline-block px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)]">View Diff</a>
         {% else %}
         N/A
         {% endif %}
       </td>
       <td class="px-4 py-2" x-data="{open:false, ready:false}" x-init="setTimeout(() => ready = true, 50)">
-        <button class="px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition" @click="open = true">View Config</button>
+        <button class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)]" @click="open = true">View Config</button>
         <div x-show="ready && open" x-transition.opacity.duration.150ms class="fixed inset-0 bg-[var(--card-bg)] bg-opacity-50 flex justify-end" x-cloak>
           <div class="bg-[var(--card-bg)] w-1/2 p-4">
             <div class="flex justify-between items-center border-b border-gray-700 pb-2">

--- a/app/templates/device_list.html
+++ b/app/templates/device_list.html
@@ -114,9 +114,9 @@
     {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
     <tr class="border-b border-gray-700">
       <td colspan="{{ column_count }}" class="px-4 py-2 text-right">
-        <a href="/devices/{{ device.id }}/edit" aria-label="Edit" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
+        <a href="/devices/{{ device.id }}/edit" aria-label="Edit" class="inline-block px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)] mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         <form method="post" action="/devices/{{ device.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="p-2 mr-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" onclick="return confirm('Delete device?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+          <button type="submit" aria-label="Delete" class="px-2 mr-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)]" onclick="return confirm('Delete device?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
         </form>
       </td>
     </tr>
@@ -133,7 +133,7 @@
   </div>
 </div>
 </div>
-<button type="submit" aria-label="Delete Selected" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mt-2">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+<button type="submit" aria-label="Delete Selected" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)] mt-2">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
 </form>
 <script>
 document.getElementById('select-all').addEventListener('change', function(e){

--- a/app/templates/device_type_list.html
+++ b/app/templates/device_type_list.html
@@ -32,9 +32,9 @@
       <td class="table-cell">{{ dt.name }}</td>
       <td class="text-center w-[10rem] whitespace-nowrap">
         <div class="flex justify-center flex-wrap gap-1">
-          <a href="/device-types/{{ dt.id }}/edit" aria-label="Edit" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
+          <a href="/device-types/{{ dt.id }}/edit" aria-label="Edit" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)]">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
           <form method="post" action="/device-types/{{ dt.id }}/delete" class="inline">
-            <button type="submit" aria-label="Delete" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded" onclick="return confirm('Delete type?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+            <button type="submit" aria-label="Delete" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)]" onclick="return confirm('Delete type?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
           </form>
         </div>
       </td>
@@ -50,7 +50,7 @@
   </div>
 </div>
 </div>
-<button type="submit" aria-label="Delete Selected" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition mt-2">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+<button type="submit" aria-label="Delete Selected" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)] mt-2">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
 </form>
 <script>
 document.getElementById('select-all').addEventListener('change', function(e){

--- a/app/templates/devices_by_tag.html
+++ b/app/templates/devices_by_tag.html
@@ -14,7 +14,7 @@
   <tbody>
   {% for dev in devices %}
     <tr class="border-t border-gray-700">
-      <td class="px-4 py-2"><a href="/devices/{{ dev.id }}/edit" class="inline-block p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ dev.hostname }}</a></td>
+      <td class="px-4 py-2"><a href="/devices/{{ dev.id }}/edit" class="inline-block px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)]">{{ dev.hostname }}</a></td>
       <td class="px-4 py-2">{{ dev.ip }}</td>
       <td class="px-4 py-2">{{ dev.tags | map(attribute='name') | join(', ') }}</td>
     </tr>

--- a/app/templates/port_config_template_list.html
+++ b/app/templates/port_config_template_list.html
@@ -20,9 +20,9 @@
       <td class="px-4 py-2">{{ tpl.last_edited.strftime('%Y-%m-%d %H:%M:%S') if tpl.last_edited else '' }}</td>
       <td class="px-4 py-2">{{ tpl.edited_by.email if tpl.edited_by else '' }}</td>
       <td class="px-4 py-2">
-        <a href="/network/port-configs/{{ tpl.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
+        <a href="/network/port-configs/{{ tpl.id }}/edit" aria-label="Edit" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)] mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         <form method="post" action="/network/port-configs/{{ tpl.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="p-2 rounded transition" onclick="return confirm('Delete template?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+          <button type="submit" aria-label="Delete" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)]" onclick="return confirm('Delete template?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
         </form>
       </td>
     </tr>

--- a/app/templates/port_status.html
+++ b/app/templates/port_status.html
@@ -105,8 +105,8 @@
       </td>
       <td class="px-4 py-2">{{ port.alias or '' }}</td>
       <td class="px-4 py-2">
-        <a href="/devices/{{ device.id }}/ports/{{ port.name }}/config" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Config</a>
-        <a href="/devices/{{ device.id }}/ports/{{ port.name }}/apply-template" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition ml-2">Template</a>
+        <a href="/devices/{{ device.id }}/ports/{{ port.name }}/config" class="inline-block px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)]">Config</a>
+        <a href="/devices/{{ device.id }}/ports/{{ port.name }}/apply-template" class="inline-block px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)] ml-2">Template</a>
       </td>
     </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- convert device list action buttons to text links
- restyle action links on config lists and port tables
- adjust device type and port template actions
- update devices by tag display

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68502e44d1608324b34d560ff2ee6e2b