### PR TITLE
Improve theme consistency

### DIFF
--- a/static/themes/apple_glass.css
+++ b/static/themes/apple_glass.css
@@ -9,7 +9,9 @@
   --tab-text: #ffffff;
   --submenu-bg: rgba(255, 255, 255, 0.08);
   --submenu-text: #ffffff;
+  --submenu-hover-bg: rgba(255, 255, 255, 0.15);
   --border-color: rgba(255, 255, 255, 0.2);
+  --alert-bg: rgba(255, 255, 255, 0.15);
   --card-bg: rgba(255, 255, 255, 0.05);
   --card-text: #ffffff;
   --code-bg: rgba(0, 0, 0, 0.5);

--- a/static/themes/blue.css
+++ b/static/themes/blue.css
@@ -4,16 +4,16 @@ body {
 }
 
 :root {
-  --nav-bg: #001a33;
+  --nav-bg: #0f172a;
   --nav-text: #ffffff;
   --submenu-bg: #1f2937;
   --submenu-text: #e5e7eb;
-  --submenu-hover-bg: #003366;
-  --tab-bg: #1e3a8a;
-  --tab-hover: #1d4ed8;
+  --submenu-hover-bg: #164e63;
+  --tab-bg: #0ea5e9;
+  --tab-hover: #38bdf8;
   --tab-text: #ffffff;
-  --btn-bg:        #1e3a8a;
-  --btn-hover:     #1d4ed8;
+  --btn-bg:        #0ea5e9;
+  --btn-hover:     #38bdf8;
   --btn-text:      #ffffff;
   --btn-hover-text: #ffffff;
   --card-bg:       #1e293b;
@@ -23,8 +23,8 @@ body {
   --table-bg:      #1f2937;
   --code-text: #f1f5f9;
   --code-bg: #1e293b;
-  --alert-bg:      #334155;
-  --border-color:  #475569;
+  --alert-bg:      #0284c7;
+  --border-color:  #075985;
   --hover-muted:   #374151;
 }
 
@@ -33,11 +33,11 @@ body {
 }
 
 .bg-black {
-  background-color: #001a33 !important;
+  background-color: var(--card-bg) !important;
 }
 
 .border-gray-700 {
-  border-color: #444 !important;
+  border-color: var(--border-color) !important;
 }
 
 

--- a/static/themes/bw.css
+++ b/static/themes/bw.css
@@ -6,14 +6,14 @@ body {
 :root {
   --nav-bg: #000000;
   --nav-text: #ffffff;
-  --submenu-bg: #1a1a1a;
-  --submenu-text: #e5e7eb;
+  --submenu-bg: #000000;
+  --submenu-text: #ffffff;
   --submenu-hover-bg: #333333;
-  --tab-bg: #333333;
+  --tab-bg: #000000;
   --tab-hover: #444444;
   --tab-text: #ffffff;
-  --btn-bg:        #333333;
-  --btn-hover:     #555555;
+  --btn-bg:        #000000;
+  --btn-hover:     #444444;
   --btn-text:      #ffffff;
   --btn-hover-text: #ffffff;
   --card-bg:       #111111;
@@ -23,8 +23,8 @@ body {
   --table-bg:      #1a1a1a;
   --code-text: #f1f5f9;
   --code-bg: #111111;
-  --alert-bg:      #333333;
-  --border-color:  #444444;
+  --alert-bg:      #222222;
+  --border-color:  #666666;
   --hover-muted:   #222222;
 }
 
@@ -33,15 +33,15 @@ body {
 }
 
 nav.bg-gray-800 {
-  background-color: #000000 !important;
+  background-color: var(--nav-bg) !important;
 }
 
 .bg-black {
-  background-color: #000000 !important;
+  background-color: var(--card-bg) !important;
 }
 
 .border-gray-700 {
-  border-color: #333333 !important;
+  border-color: var(--border-color) !important;
 }
 
 

--- a/static/themes/dark.css
+++ b/static/themes/dark.css
@@ -9,11 +9,11 @@ body {
   --submenu-bg: #1f2937;
   --submenu-text: #e5e7eb;
   --submenu-hover-bg: #44475a;
-  --tab-bg: #1e3a8a;
-  --tab-hover: #1d4ed8;
+  --tab-bg: #4b5563;
+  --tab-hover: #6b7280;
   --tab-text: #ffffff;
-  --btn-bg:        #1e3a8a;
-  --btn-hover:     #1d4ed8;
+  --btn-bg:        #6b7280;
+  --btn-hover:     #9ca3af;
   --btn-text:      #ffffff;
   --btn-hover-text: #ffffff;
   --card-bg:       #1e293b;
@@ -23,8 +23,8 @@ body {
   --table-bg:      #1f2937;
   --code-text: #f1f5f9;
   --code-bg: #1e293b;
-  --alert-bg:      #334155;
-  --border-color:  #475569;
+  --alert-bg:      #4b5563;
+  --border-color:  #6b7280;
   --hover-muted:   #374151;
 }
 
@@ -34,15 +34,15 @@ body {
 
 /* Match navigation background to dark theme */
 nav.bg-gray-800 {
-  background-color: #222034 !important;
+  background-color: var(--nav-bg) !important;
 }
 
 .bg-black {
-  background-color: #1f1f1f !important;
+  background-color: var(--card-bg) !important;
 }
 
 .border-gray-700 {
-  border-color: #444 !important;
+  border-color: var(--border-color) !important;
 }
 
 

--- a/static/themes/dark_colourful.css
+++ b/static/themes/dark_colourful.css
@@ -11,11 +11,11 @@ body {
   --submenu-bg: #1f2937;
   --submenu-text: #e5e7eb;
   --submenu-hover-bg: #4b5563;
-  --tab-bg: #7c3aed;
-  --tab-hover: #a855f7;
+  --tab-bg: #06b6d4;      /* cyan */
+  --tab-hover: #22d3ee;   /* lighter cyan */
   --tab-text: #ffffff;
-  --btn-bg:        #7c3aed;
-  --btn-hover:     #a855f7;
+  --btn-bg:        #f97316; /* orange */
+  --btn-hover:     #fb923c; /* lighter orange */
   --btn-text:      #ffffff;
   --btn-hover-text: #ffffff;
   --card-bg:       #1e293b;
@@ -25,8 +25,8 @@ body {
   --table-bg:      #1f2937;
   --code-text: #f1f5f9;
   --code-bg: #1e293b;
-  --alert-bg:      #be123c;
-  --border-color:  #475569;
+  --alert-bg:      #ec4899; /* pink */
+  --border-color:  #14b8a6; /* teal */
   --hover-muted:   #374151;
 }
 
@@ -35,11 +35,11 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 nav.bg-gray-800 {
-  background-color: #1f2937 !important; /* bg-gray-800 */
+  background-color: var(--nav-bg) !important;
 }
 
 .card, .bg-gray-800 {
-  background-color: #1f2937; /* bg-gray-800 */
+  background-color: var(--card-bg);
   border-radius: 0.75rem;
   overflow: hidden;
 }
@@ -51,8 +51,8 @@ table {
 }
 
 table thead th {
-  background-color: #1f2937; /* bg-gray-800 */
-  color: #ffffff;
+  background-color: var(--nav-bg);
+  color: var(--nav-text);
   font-weight: bold;
   padding: 0.5rem 1rem;
 }
@@ -67,7 +67,7 @@ table tbody tr:nth-child(odd) {
 
 table td {
   padding: 0.5rem 1rem;      /* px-4 py-2 */
-  border-bottom: 1px solid #374151; /* border-gray-700 */
+  border-bottom: 1px solid var(--border-color);
 }
 
 .logged-in {


### PR DESCRIPTION
## Summary
- refine color variables across all themes
- add vibrant palette to `dark_colourful`
- unify nav overrides to use CSS variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503b2659308324b7c7e2932935c13a