### PR TITLE
Improve dark theme contrast

### DIFF
--- a/static/themes/dark.css
+++ b/static/themes/dark.css
@@ -1,31 +1,31 @@
 body {
-  background-color: #1a1a2e;
+  background-color: #000000;
   color: #f8f9fa;
 }
 
 :root {
-  --nav-bg: #222034;
+  --nav-bg: #000000;
   --nav-text: #ffffff;
-  --submenu-bg: #1f2937;
+  --submenu-bg: #121212;
   --submenu-text: #e5e7eb;
-  --submenu-hover-bg: #44475a;
-  --tab-bg: #4b5563;
-  --tab-hover: #6b7280;
+  --submenu-hover-bg: #1a1a1a;
+  --tab-bg: #333333;
+  --tab-hover: #444444;
   --tab-text: #ffffff;
-  --btn-bg:        #6b7280;
-  --btn-hover:     #9ca3af;
+  --btn-bg:        #333333;
+  --btn-hover:     #444444;
   --btn-text:      #ffffff;
   --btn-hover-text: #ffffff;
-  --card-bg:       #1e293b;
+  --card-bg:       #121212;
   --card-text:     #f1f5f9;
-  --input-bg:      #1f2937;
+  --input-bg:      #121212;
   --input-text:    #f9fafb;
-  --table-bg:      #1f2937;
+  --table-bg:      #121212;
   --code-text: #f1f5f9;
-  --code-bg: #1e293b;
-  --alert-bg:      #4b5563;
-  --border-color:  #6b7280;
-  --hover-muted:   #374151;
+  --code-bg: #121212;
+  --alert-bg:      #222222;
+  --border-color:  #333333;
+  --hover-muted:   #1a1a1a;
 }
 
 .duplicate {
@@ -50,5 +50,32 @@ nav.bg-gray-800 {
 .diff_chg { background-color: #6b21a8; }
 .diff_sub { background-color: #7f1d1d; }
 table.diff { width: 100%; }
+
+.card,
+.table,
+.form-control,
+.dropdown-menu {
+  background-color: var(--card-bg);
+  color: var(--card-text);
+  border: 1px solid var(--border-color);
+}
+
+.table tbody tr {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.table tbody tr:nth-child(even) {
+  background-color: #121212;
+}
+
+.table tbody tr:nth-child(odd) {
+  background-color: #161616;
+}
+
+.table tbody tr:hover,
+.dropdown-menu .active,
+.dropdown-menu .dropdown-item:hover {
+  background-color: var(--hover-muted);
+}
 
 /* Theme-aware button colours */


### PR DESCRIPTION
## Summary
- adjust dark theme variables for deeper blacks
- apply dark grey background & borders to cards, tables and forms
- style dropdown and table hover states with dark grey contrast

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850452eac808324948f63e3e4e6a610