### PR TITLE
Add login geolocation map

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
     DateTime,
     Text,
     Boolean,
+    Float,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy import Table
@@ -206,6 +207,9 @@ class User(Base):
     font = Column(String, nullable=False, default="sans")
     menu_style = Column(String, nullable=False, default="tabbed")
     created_at = Column(DateTime, default=datetime.utcnow)
+    last_login = Column(DateTime, nullable=True)
+    last_location_lat = Column(Float, nullable=True)
+    last_location_lon = Column(Float, nullable=True)
 
     site_memberships = relationship("SiteMembership", back_populates="user")
 

--- a/app/templates/user_detail.html
+++ b/app/templates/user_detail.html
@@ -2,7 +2,8 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">User Details</h1>
-<div class="w-full overflow-auto">
+<div class="flex flex-wrap gap-4 items-start">
+<div class="flex-1 min-w-[200px] overflow-auto">
 <table class="min-w-full table-fixed text-left">
   <tbody>
     <tr class="border-t border-gray-700">
@@ -24,7 +25,31 @@
   </tbody>
 </table>
 </div>
+<div class="w-96 h-64 rounded overflow-hidden" id="map-container">
+  {% if user.last_location_lat and user.last_location_lon and api_key %}
+  <div id="map" class="w-full h-full rounded"></div>
+  {% else %}
+  <div class="w-full h-full flex items-center justify-center bg-[var(--card-bg)] text-[var(--card-text)] rounded">Login location unavailable</div>
+  {% endif %}
+</div>
+</div>
 {% if current_user and current_user.id == user.id %}
-<a href="/users/me/edit" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Edit Profile</a>
+<a href="/users/me/edit" class="block px-4 py-2 mt-4 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition">Edit Profile</a>
+{% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+{% if user.last_location_lat and user.last_location_lon and api_key %}
+<script>
+function initMap() {
+  const loc = { lat: parseFloat("{{ user.last_location_lat }}"), lng: parseFloat("{{ user.last_location_lon }}") };
+  const map = new google.maps.Map(document.getElementById('map'), {
+    zoom: 8,
+    center: loc,
+  });
+  new google.maps.Marker({ position: loc, map: map });
+}
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key={{ api_key }}&callback=initMap" async defer></script>
 {% endif %}
 {% endblock %}

--- a/app/utils/geolocation.py
+++ b/app/utils/geolocation.py
@@ -1,8 +1,8 @@
 import requests
 
 
-def geolocate_ip(ip: str) -> str | None:
-    """Return a simple location string for the given IP using ipapi.co."""
+def geolocate_ip(ip: str) -> tuple[str | None, float | None, float | None]:
+    """Return location text and coordinates for the given IP using ipapi.co."""
     try:
         resp = requests.get(f"https://ipapi.co/{ip}/json/", timeout=3)
         if resp.status_code == 200:
@@ -10,9 +10,11 @@ def geolocate_ip(ip: str) -> str | None:
             city = data.get("city")
             region = data.get("region")
             country = data.get("country_name")
+            lat = data.get("latitude")
+            lon = data.get("longitude")
             parts = [p for p in [city, region, country] if p]
-            if parts:
-                return ", ".join(parts)
+            location = ", ".join(parts) if parts else None
+            return location, lat, lon
     except Exception:
         pass
-    return None
+    return None, None, None

--- a/app/utils/login_events.py
+++ b/app/utils/login_events.py
@@ -12,9 +12,11 @@ def log_login_event(
     ip: str,
     user_agent: str,
     success: bool,
+    location: str | None = None,
 ) -> LoginEvent:
     """Create a LoginEvent entry and return it."""
-    location = geolocate_ip(ip)
+    if location is None:
+        location, _, _ = geolocate_ip(ip)
     event = LoginEvent(
         user_id=user.id if user else None,
         ip_address=ip,

--- a/seed_tunables.py
+++ b/seed_tunables.py
@@ -51,6 +51,14 @@ def main():
                 description="Target spreadsheet ID",
             ),
             SystemTunable(
+                name="GOOGLE_MAPS_API_KEY",
+                value="",
+                function="Google Maps",
+                file_type="application",
+                data_type="text",
+                description="API key for Google Maps JavaScript",
+            ),
+            SystemTunable(
                 name="Netbird API URL",
                 value="https://api.netbird.io/api",
                 function="Netbird",


### PR DESCRIPTION
## Summary
- store last login coordinates on User
- geolocate IP to coordinates with ipapi.co
- save coordinates on successful login and log the event
- expose Google Maps API key via System Tunables
- show login location map on user profile page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685048fb56c88324ac89c265625ed1a5