### PR TITLE
Add scroll handoff preference

### DIFF
--- a/app/models/models.py
+++ b/app/models/models.py
@@ -206,6 +206,7 @@ class User(Base):
     theme = Column(String, nullable=False, default="dark_colourful")
     font = Column(String, nullable=False, default="sans")
     menu_style = Column(String, nullable=False, default="tabbed")
+    scroll_handoff_enabled = Column(Boolean, nullable=False, default=True)
     ssh_username = Column(String, nullable=True)
     ssh_password = Column(String, nullable=True)
     ssh_port = Column(Integer, nullable=True, default=22)

--- a/app/routes/user_pages.py
+++ b/app/routes/user_pages.py
@@ -4,21 +4,22 @@ from app.utils.templates import templates
 from sqlalchemy.orm import Session
 
 from app.utils.db_session import get_db
-from app.utils.auth import get_current_user, require_role, ROLE_HIERARCHY, get_password_hash
-<<<<<<< codex/add-geolocation-with-google-maps-to-user-profile
-from app.models.models import User, SystemTunable
-=======
-from app.models.models import User, LoginEvent
->>>>>>> main
+from app.utils.auth import (
+    get_current_user,
+    require_role,
+    ROLE_HIERARCHY,
+    get_password_hash,
+)
+from app.models.models import User, SystemTunable, LoginEvent
 
 router = APIRouter()
 
-@router.get('/users/me')
+
+@router.get("/users/me")
 async def my_profile(
     request: Request,
-<<<<<<< codex/add-geolocation-with-google-maps-to-user-profile
-    current_user: User = Depends(require_role("viewer")),
     db: Session = Depends(get_db),
+    current_user: User = Depends(require_role("viewer")),
 ):
     """Display the currently logged-in user's details."""
     api_key_row = (
@@ -27,49 +28,58 @@ async def my_profile(
         .first()
     )
     api_key = api_key_row.value if api_key_row else None
-=======
-    db: Session = Depends(get_db),
-    current_user: User = Depends(require_role("viewer")),
-):
-    """Display the currently logged-in user's details."""
     last_login = (
         db.query(LoginEvent)
         .filter(LoginEvent.user_id == current_user.id, LoginEvent.success.is_(True))
         .order_by(LoginEvent.timestamp.desc())
         .first()
     )
->>>>>>> main
     context = {
         "request": request,
         "user": current_user,
         "current_user": current_user,
-<<<<<<< codex/add-geolocation-with-google-maps-to-user-profile
         "api_key": api_key,
-=======
         "last_login": last_login,
-        "themes": ["dark_colourful", "dark", "light", "blue", "bw", "homebrew", "apple_glass"],
+        "themes": [
+            "dark_colourful",
+            "dark",
+            "light",
+            "blue",
+            "bw",
+            "homebrew",
+            "apple_glass",
+        ],
         "fonts": ["sans", "serif", "mono"],
->>>>>>> main
     }
     return templates.TemplateResponse("user_detail.html", context)
 
 
-@router.get('/users/me/edit')
-async def edit_my_profile_form(request: Request, current_user: User = Depends(require_role("viewer"))):
+@router.get("/users/me/edit")
+async def edit_my_profile_form(
+    request: Request, current_user: User = Depends(require_role("viewer"))
+):
     """Render a form for the logged-in user to edit their details."""
     context = {
         "request": request,
         "user": current_user,
         "current_user": current_user,
         "error": None,
-        "themes": ["dark_colourful", "dark", "light", "blue", "bw", "homebrew", "apple_glass"],
+        "themes": [
+            "dark_colourful",
+            "dark",
+            "light",
+            "blue",
+            "bw",
+            "homebrew",
+            "apple_glass",
+        ],
         "fonts": ["sans", "serif", "mono"],
         "menu_styles": ["tabbed", "dropdown"],
     }
     return templates.TemplateResponse("user_form.html", context)
 
 
-@router.post('/users/me/edit')
+@router.post("/users/me/edit")
 async def update_my_profile(
     request: Request,
     email: str = Form(...),
@@ -77,18 +87,29 @@ async def update_my_profile(
     theme: str = Form("dark_colourful"),
     font: str = Form("sans"),
     menu_style: str = Form("tabbed"),
+    scroll_handoff_enabled: str = Form(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_role("viewer")),
 ):
     """Update the logged-in user's email and optionally their password."""
-    existing = db.query(User).filter(User.email == email, User.id != current_user.id).first()
+    existing = (
+        db.query(User).filter(User.email == email, User.id != current_user.id).first()
+    )
     if existing:
         context = {
             "request": request,
             "user": current_user,
             "current_user": current_user,
             "error": "Email already in use",
-            "themes": ["dark_colourful", "dark", "light", "blue", "bw", "homebrew", "apple_glass"],
+            "themes": [
+                "dark_colourful",
+                "dark",
+                "light",
+                "blue",
+                "bw",
+                "homebrew",
+                "apple_glass",
+            ],
             "fonts": ["sans", "serif", "mono"],
             "menu_styles": ["tabbed", "dropdown"],
         }
@@ -98,16 +119,17 @@ async def update_my_profile(
     current_user.theme = theme
     current_user.font = font
     current_user.menu_style = menu_style
+    current_user.scroll_handoff_enabled = bool(scroll_handoff_enabled)
     if password:
         current_user.hashed_password = get_password_hash(password)
     db.commit()
     return RedirectResponse(url="/users/me", status_code=302)
 
 
-@router.post('/users/me/ssh')
+@router.post("/users/me/ssh")
 async def update_my_ssh(
     ssh_username: str = Form(...),
-    ssh_password: str = Form(''),
+    ssh_password: str = Form(""),
     ssh_port: int = Form(22),
     db: Session = Depends(get_db),
     current_user: User = Depends(require_role("viewer")),
@@ -120,7 +142,7 @@ async def update_my_ssh(
     return RedirectResponse(url="/users/me", status_code=302)
 
 
-@router.post('/users/me/prefs')
+@router.post("/users/me/prefs")
 async def update_my_prefs(
     theme: str = Form("dark_colourful"),
     font: str = Form("sans"),
@@ -136,14 +158,21 @@ async def update_my_prefs(
     return RedirectResponse(url="/users/me", status_code=302)
 
 
-@router.get('/users/{user_id}')
-async def user_detail(user_id: int, request: Request, db: Session = Depends(get_db), current_user: User = Depends(require_role("viewer"))):
+@router.get("/users/{user_id}")
+async def user_detail(
+    user_id: int,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(require_role("viewer")),
+):
     """Display details for a specific user."""
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
-    if current_user.id != user.id and ROLE_HIERARCHY.index(current_user.role) < ROLE_HIERARCHY.index("admin"):
+    if current_user.id != user.id and ROLE_HIERARCHY.index(
+        current_user.role
+    ) < ROLE_HIERARCHY.index("admin"):
         raise HTTPException(status_code=403, detail="Insufficient role")
 
     api_key_row = (

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -55,7 +55,26 @@
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
     <script src="{{ request.url_for('static', path='js/alpine.min.js') }}" defer></script>
     <script src="{{ request.url_for('static', path='js/table.js') }}" defer></script>
-    {% block extra_scripts %}{% endblock %}
+    {% block extra_scripts %}
+    {% if current_user is defined and current_user and current_user.scroll_handoff_enabled %}
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('div.overflow-x-auto').forEach(wrapper => {
+          const table = wrapper.querySelector('table');
+          if (!table) return;
+          const horiz = wrapper.scrollWidth > wrapper.clientWidth;
+          const vert = wrapper.scrollHeight > wrapper.clientHeight;
+          if (horiz && !vert) {
+            wrapper.addEventListener('wheel', e => {
+              wrapper.scrollLeft += e.deltaY;
+              e.preventDefault();
+            }, { passive: false });
+          }
+        });
+      });
+    </script>
+    {% endif %}
+    {% endblock %}
     </div>
   </body>
 </html>

--- a/app/templates/user_form.html
+++ b/app/templates/user_form.html
@@ -63,6 +63,14 @@
     </div>
   </div>
   {% endif %}
+  <div class="form-row">
+    <div class="form-item">
+      <label for="scroll_handoff_enabled" class="inline-flex items-center">
+        <input id="scroll_handoff_enabled" type="checkbox" name="scroll_handoff_enabled" value="1" class="mr-2" {% if user and user.scroll_handoff_enabled %}checked{% endif %}>
+        Enable Vertical-to-Horizontal Scroll Handoff for Tables
+      </label>
+    </div>
+  </div>
   {% if show_active %}
   <div class="form-row">
     <div class="form-item">


### PR DESCRIPTION
## Summary
- add scroll_handoff_enabled column to User
- allow updating scroll handoff setting in profile form
- save the new preference in profile update route
- enable scroll-handoff script when user setting is active

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504d7a1c488324809763c490881939