### PR TITLE
Refactor background workers into individual modules

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,21 +1,3 @@
 from dotenv import load_dotenv
-import types
 
 load_dotenv()
-
-try:
-    # Import heavy task utilities when available
-    from . import tasks  # type: ignore  # noqa: F401
-except Exception:  # pragma: no cover - optional deps may be missing during tests
-    # Provide lightweight stubs so patching works without optional deps
-    tasks = types.ModuleType("tasks")
-
-    def _noop(*_, **__):
-        pass
-
-    tasks.start_queue_worker = _noop
-    tasks.start_config_scheduler = _noop
-    tasks.stop_queue_worker = _noop
-    tasks.stop_config_scheduler = _noop
-    tasks.setup_trap_listener = _noop
-    tasks.setup_syslog_listener = _noop

--- a/server/main.py
+++ b/server/main.py
@@ -51,14 +51,10 @@ from server.websockets.editor import shell_ws
 from server.websockets.terminal import router as terminal_ws_router
 from server.routes.ui.welcome import router as welcome_router, WELCOME_TEXT, INVENTORY_TEXT
 from core.utils.auth import get_current_user
-from server.tasks import (
-    start_queue_worker,
-    start_config_scheduler,
-    stop_queue_worker,
-    stop_config_scheduler,
-    setup_trap_listener,
-    setup_syslog_listener,
-)
+from server.workers.queue_worker import start_queue_worker, stop_queue_worker
+from server.workers.config_scheduler import start_config_scheduler, stop_config_scheduler
+from server.workers.trap_listener import setup_trap_listener
+from server.workers.syslog_listener import setup_syslog_listener
 from core.utils.templates import templates
 
 # Allow deploying the app under a URL prefix by setting ROOT_PATH.

--- a/server/routes/ui/admin.py
+++ b/server/routes/ui/admin.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
 from core.utils.auth import require_role
-from server.tasks import run_push_queue_once
+from server.workers.queue_worker import run_push_queue_once
 
 router = APIRouter()
 

--- a/server/routes/ui/admin_debug.py
+++ b/server/routes/ui/admin_debug.py
@@ -7,11 +7,13 @@ from typing import Optional
 from core.utils.db_session import get_db
 from core.utils.auth import require_role
 from core.models.models import AuditLog, User, Device
-from server.tasks import (
+from server.workers.trap_listener import (
     start_trap_listener,
     stop_trap_listener,
     trap_listener_running,
     TRAP_PORT,
+)
+from server.workers.syslog_listener import (
     start_syslog_listener,
     stop_syslog_listener,
     syslog_listener_running,

--- a/server/routes/ui/admin_site.py
+++ b/server/routes/ui/admin_site.py
@@ -6,7 +6,10 @@ from core.utils.db_session import get_db
 from core.utils.auth import require_role, user_in_site, ROLE_HIERARCHY
 from core.models.models import Site, User, Device, SiteMembership
 from core.utils.templates import templates
-from server.tasks import schedule_device_config_pull, unschedule_device_config_pull
+from server.workers.config_scheduler import (
+    schedule_device_config_pull,
+    unschedule_device_config_pull,
+)
 from core.utils.dashboard import DEFAULT_WIDGETS, WIDGET_LABELS
 from core.models.models import SiteDashboardWidget
 

--- a/server/routes/ui/devices.py
+++ b/server/routes/ui/devices.py
@@ -57,7 +57,10 @@ from datetime import datetime
 from puresnmp import Client, PyWrapper, V2C
 from puresnmp.exc import SnmpError
 import re
-from server.tasks import schedule_device_config_pull, unschedule_device_config_pull
+from server.workers.config_scheduler import (
+    schedule_device_config_pull,
+    unschedule_device_config_pull,
+)
 from core.utils.paths import STATIC_DIR
 
 

--- a/server/workers/queue_worker.py
+++ b/server/workers/queue_worker.py
@@ -1,0 +1,74 @@
+import asyncio
+from datetime import datetime
+import asyncssh
+import os
+
+from core.utils.ssh import build_conn_kwargs
+from core.utils.device_detect import detect_ssh_platform
+from core.utils.db_session import SessionLocal
+from core.models.models import ConfigBackup
+from core.utils.audit import log_audit
+
+QUEUE_INTERVAL = int(os.environ.get("QUEUE_INTERVAL", "60"))
+
+
+async def run_push_queue_once():
+    db = SessionLocal()
+    queued = db.query(ConfigBackup).filter(ConfigBackup.queued.is_(True)).all()
+    for backup in queued:
+        device = backup.device
+        cred = device.ssh_credential
+        if not cred:
+            backup.status = "failed"
+            backup.queued = False
+            db.commit()
+            continue
+        conn_kwargs = build_conn_kwargs(cred)
+        try:
+            async with asyncssh.connect(device.ip, **conn_kwargs) as conn:
+                await detect_ssh_platform(db, device, conn)
+                _, session = await conn.create_session(asyncssh.SSHClientProcess)
+                for line in backup.config_text.splitlines():
+                    session.stdin.write(line + "\n")
+                session.stdin.write("exit\n")
+                await session.wait_closed()
+            backup.queued = False
+            backup.status = "pushed"
+            backup.created_at = datetime.utcnow()
+            log_audit(db, None, "push", device, f"Queued config pushed to {device.ip}")
+        except Exception as exc:
+            backup.status = "pending"
+            log_audit(db, None, "debug", device, f"Queue push error: {exc}")
+        db.commit()
+    db.close()
+
+
+_queue_worker_task: asyncio.Task | None = None
+
+
+async def queue_worker():
+    while True:
+        await run_push_queue_once()
+        await asyncio.sleep(QUEUE_INTERVAL)
+
+
+def start_queue_worker(app):
+    @app.on_event("startup")
+    async def start_worker():
+        global _queue_worker_task
+        _queue_worker_task = asyncio.create_task(queue_worker())
+
+
+async def stop_queue_worker():
+    global _queue_worker_task
+    if _queue_worker_task:
+        _queue_worker_task.cancel()
+        try:
+            await _queue_worker_task
+        except asyncio.CancelledError:
+            pass
+        _queue_worker_task = None
+
+
+if __name__ == "__main__":
+    asyncio.run(queue_worker())

--- a/server/workers/syslog_listener.py
+++ b/server/workers/syslog_listener.py
@@ -1,0 +1,102 @@
+import asyncio
+from datetime import datetime
+import os
+from syslog_rfc5424_parser import SyslogMessage
+import syslogmp
+
+from core.utils.db_session import SessionLocal
+
+SYSLOG_PORT = int(os.environ.get("SYSLOG_PORT", "514"))
+
+_syslog_transport = None
+_syslog_running = False
+
+
+class _SyslogProtocol(asyncio.DatagramProtocol):
+    def datagram_received(self, data, addr):
+        try:
+            text = data.decode().strip()
+        except Exception:
+            return
+
+        timestamp = datetime.utcnow()
+        severity = None
+        facility = None
+        message = text
+        try:
+            msg = SyslogMessage.parse(text)
+            timestamp = msg.timestamp or timestamp
+            severity = str(msg.severity)
+            facility = str(msg.facility)
+            message = msg.msg
+        except Exception:
+            try:
+                m = syslogmp.parse(text)
+                timestamp = m.timestamp or timestamp
+                severity = str(m.severity)
+                facility = str(m.facility)
+                message = m.message
+            except Exception:
+                pass
+
+        db = SessionLocal()
+        from core.models.models import SyslogEntry, Device
+
+        device = db.query(Device).filter(Device.ip == addr[0]).first()
+        log = SyslogEntry(
+            timestamp=timestamp,
+            source_ip=addr[0],
+            severity=severity,
+            facility=facility,
+            message=message,
+            device_id=device.id if device else None,
+            site_id=device.site_id if device else None,
+        )
+        db.add(log)
+        db.commit()
+        db.close()
+
+
+async def start_syslog_listener():
+    global _syslog_transport, _syslog_running
+    if _syslog_running:
+        return
+    loop = asyncio.get_running_loop()
+    _syslog_transport, _ = await loop.create_datagram_endpoint(
+        _SyslogProtocol, local_addr=("0.0.0.0", SYSLOG_PORT)
+    )
+    _syslog_running = True
+
+
+async def stop_syslog_listener():
+    global _syslog_transport, _syslog_running
+    if _syslog_transport:
+        _syslog_transport.close()
+        _syslog_transport = None
+    _syslog_running = False
+
+
+def syslog_listener_running() -> bool:
+    return _syslog_running
+
+
+def setup_syslog_listener(app):
+    @app.on_event("startup")
+    async def _start_syslog():
+        if os.environ.get("ENABLE_SYSLOG_LISTENER") == "1":
+            await start_syslog_listener()
+
+
+async def main():
+    await start_syslog_listener()
+    try:
+        while True:
+            await asyncio.sleep(3600)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await stop_syslog_listener()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/workers/trap_listener.py
+++ b/server/workers/trap_listener.py
@@ -1,0 +1,94 @@
+import asyncio
+from datetime import datetime
+import os
+from aiosnmp import SnmpV2TrapServer
+from aiosnmp.snmp import SnmpMessage
+
+from core.utils.db_session import SessionLocal
+
+TRAP_PORT = int(os.environ.get("SNMP_TRAP_PORT", "162"))
+
+_trap_transport = None
+_trap_server = None
+_trap_running = False
+
+
+async def _trap_handler(host, port, message):
+    from core.models.models import SNMPTrapLog, Device
+
+    trap_oid = None
+    parts = []
+    for vb in message.data.varbinds:
+        val = vb.value
+        if vb.oid == "1.3.6.1.6.3.1.1.4.1.0":
+            trap_oid = val.decode() if isinstance(val, (bytes, bytearray)) else str(val)
+        if isinstance(val, (bytes, bytearray)):
+            try:
+                parts.append(val.decode())
+            except Exception:
+                parts.append(val.hex())
+        else:
+            parts.append(str(val))
+    text = "; ".join(parts)
+    if not text:
+        raw = SnmpMessage(message.version, message.community, message.data).encode()
+        text = raw.hex()
+
+    db = SessionLocal()
+    device = db.query(Device).filter(Device.ip == host).first()
+    log = SNMPTrapLog(
+        timestamp=datetime.utcnow(),
+        source_ip=host,
+        trap_oid=trap_oid,
+        message=text,
+        device_id=device.id if device else None,
+        site_id=device.site_id if device else None,
+    )
+    db.add(log)
+    db.commit()
+    db.close()
+
+
+async def start_trap_listener():
+    global _trap_transport, _trap_server, _trap_running
+    if _trap_running:
+        return
+    server = SnmpV2TrapServer(port=TRAP_PORT, handler=_trap_handler)
+    _trap_transport, _ = await server.run()
+    _trap_server = server
+    _trap_running = True
+
+
+async def stop_trap_listener():
+    global _trap_transport, _trap_server, _trap_running
+    if _trap_transport:
+        _trap_transport.close()
+        _trap_transport = None
+    _trap_server = None
+    _trap_running = False
+
+
+def trap_listener_running() -> bool:
+    return _trap_running
+
+
+def setup_trap_listener(app):
+    @app.on_event("startup")
+    async def _start():
+        if os.environ.get("ENABLE_TRAP_LISTENER") == "1":
+            await start_trap_listener()
+
+
+async def main():
+    await start_trap_listener()
+    try:
+        while True:
+            await asyncio.sleep(3600)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await stop_trap_listener()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_admin_nav.py
+++ b/tests/test_admin_nav.py
@@ -13,10 +13,10 @@ def get_test_app():
             del sys.modules[m]
     with mock.patch("sqlalchemy.create_engine"), \
          mock.patch("sqlalchemy.schema.MetaData.create_all"), \
-         mock.patch("server.tasks.start_queue_worker"), \
-         mock.patch("server.tasks.start_config_scheduler"), \
-         mock.patch("server.tasks.setup_trap_listener"), \
-         mock.patch("server.tasks.setup_syslog_listener"):
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"):
         return importlib.import_module("server.main").app
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,10 +12,10 @@ def get_test_app():
             del sys.modules[m]
     with mock.patch("sqlalchemy.create_engine"), \
          mock.patch("sqlalchemy.schema.MetaData.create_all"), \
-         mock.patch("server.tasks.start_queue_worker"), \
-         mock.patch("server.tasks.start_config_scheduler"), \
-         mock.patch("server.tasks.setup_trap_listener"), \
-         mock.patch("server.tasks.setup_syslog_listener"):
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"):
         return importlib.import_module("server.main").app
 
 

--- a/tests/test_damage_upload.py
+++ b/tests/test_damage_upload.py
@@ -16,10 +16,10 @@ def get_test_app():
             del sys.modules[m]
     with mock.patch("sqlalchemy.create_engine"), \
          mock.patch("sqlalchemy.schema.MetaData.create_all"), \
-         mock.patch("server.tasks.start_queue_worker"), \
-         mock.patch("server.tasks.start_config_scheduler"), \
-         mock.patch("server.tasks.setup_trap_listener"), \
-         mock.patch("server.tasks.setup_syslog_listener"):
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"):
         return importlib.import_module("server.main").app
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -13,10 +13,10 @@ def get_test_app():
             del sys.modules[m]
     with mock.patch("sqlalchemy.create_engine"), \
          mock.patch("sqlalchemy.schema.MetaData.create_all"), \
-         mock.patch("server.tasks.start_queue_worker"), \
-         mock.patch("server.tasks.start_config_scheduler"), \
-         mock.patch("server.tasks.setup_trap_listener"), \
-         mock.patch("server.tasks.setup_syslog_listener"):
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"):
         return importlib.import_module("server.main").app
 
 

--- a/tests/test_root_path_static.py
+++ b/tests/test_root_path_static.py
@@ -13,10 +13,10 @@ def get_test_app():
             del sys.modules[m]
     with mock.patch("sqlalchemy.create_engine"), \
          mock.patch("sqlalchemy.schema.MetaData.create_all"), \
-         mock.patch("server.tasks.start_queue_worker"), \
-         mock.patch("server.tasks.start_config_scheduler"), \
-         mock.patch("server.tasks.setup_trap_listener"), \
-         mock.patch("server.tasks.setup_syslog_listener"):
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"):
         return importlib.import_module("server.main").app
 
 

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -17,7 +17,7 @@ def get_app_for_shutdown():
         await asyncio.sleep(0)
 
     def simple_config_scheduler(app):
-        from server.tasks import scheduler
+        from server.workers.config_scheduler import scheduler
 
         @app.on_event("startup")
         async def start_sched():
@@ -26,13 +26,13 @@ def get_app_for_shutdown():
     with mock.patch("sqlalchemy.create_engine"), mock.patch(
         "sqlalchemy.schema.MetaData.create_all"
     ), mock.patch(
-        "server.tasks.run_push_queue_once", dummy_run_push_queue_once
+        "server.workers.queue_worker.run_push_queue_once", dummy_run_push_queue_once
     ), mock.patch(
-        "server.tasks.start_config_scheduler", simple_config_scheduler
+        "server.workers.config_scheduler.start_config_scheduler", simple_config_scheduler
     ), mock.patch(
-        "server.tasks.setup_trap_listener"
+        "server.workers.trap_listener.setup_trap_listener"
     ), mock.patch(
-        "server.tasks.setup_syslog_listener"
+        "server.workers.syslog_listener.setup_syslog_listener"
     ):
         return importlib.import_module("server.main").app
 


### PR DESCRIPTION
## Summary
- move queue worker, config scheduler, trap listener and syslog listener into `server/workers/`
- update `server/main.py` and routes to import from new worker modules
- allow workers to run standalone
- adjust tests to mock new locations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505e3050a88324b33dc48ea039f35f