### PR TITLE
Start Phase 6 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,11 @@ Two front-end clients are shipped with the repository.
 ```bash
 npm run build:web
 ```
-- `mobile-client/` is currently just a scaffold. A future release will contain a React Native or Flutter application.
+- `mobile-client/` is currently just a scaffold. Phase 6 introduces a real mobile application that communicates with local or cloud servers.
+
+## Cloud & Mobile Integration
+
+The [cloud architecture](docs/cloud_architecture.md) document describes the planned replication model for running multiple sites with a central server. Docker Compose examples for both roles will be added as the implementation progresses. The mobile client will authenticate against either the local site or the cloud depending on connectivity.
 
 ## Interface Themes
 

--- a/Tasks.txt
+++ b/Tasks.txt
@@ -39,7 +39,7 @@ PHASE 5: THEME CLEANUP
 
 PHASE 6: CLOUD & MOBILE INTEGRATION
 
-[ ] Design architecture for cloud server with site-level replicas
+[x] Design architecture for cloud server with site-level replicas
 [ ] Implement record versioning and conflict resolution fields
 [ ] Add sync endpoints and background jobs for local/cloud replication
 [ ] Provide configuration options for cloud vs. local deployment

--- a/docs/cloud_architecture.md
+++ b/docs/cloud_architecture.md
@@ -1,0 +1,23 @@
+# Cloud Architecture Overview
+
+This document outlines the proposed design for Phase 6 of the project. The goal is to support optional cloud replication so that multiple sites can synchronize their data with a central server.
+
+## Components
+
+- **Local Servers** – instances of the FastAPI application running on-premises. Each manages devices for a single site.
+- **Cloud Server** – a public instance that aggregates data from many local servers.
+- **Background Sync Jobs** – workers that push changes from local sites to the cloud and pull updates down.
+- **Versioned Records** – database rows contain a monotonically increasing `version` field. Updates increment the version so conflicts can be detected.
+
+## Data Flow
+
+1. Local servers operate independently and queue outgoing changes.
+2. A periodic job posts batched updates to the cloud `/sync` API.
+3. The cloud server stores updates and responds with any newer records for the site.
+4. When conflicts occur (matching IDs with different versions), the cloud marks the record as needing manual resolution.
+5. Mobile clients communicate with either the local or cloud server depending on connectivity.
+
+## Deployment
+
+Docker Compose files will be provided for both local and cloud roles. Kubernetes manifests will follow the same pattern with dedicated deployments for the database and web application.
+

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,3 +1,7 @@
 from dotenv import load_dotenv
 
 load_dotenv()
+
+from . import workers  # expose workers package for tests
+
+__all__ = ["workers"]

--- a/server/workers/__init__.py
+++ b/server/workers/__init__.py
@@ -1,0 +1,8 @@
+from . import queue_worker, config_scheduler, trap_listener, syslog_listener
+
+__all__ = [
+    "queue_worker",
+    "config_scheduler",
+    "trap_listener",
+    "syslog_listener",
+]


### PR DESCRIPTION
## Summary
- document proposed cloud replication architecture
- link new document from README with a section on cloud & mobile integration
- expose workers package for tests and add package init file
- mark Phase 6 architecture task as complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685070e677788324840664a9bd4ca5bb