### PR TITLE
Add Phase 6 sync scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ npm run build:web
 ## Cloud & Mobile Integration
 
 The [cloud architecture](docs/cloud_architecture.md) document describes the planned replication model for running multiple sites with a central server. Docker Compose examples for both roles will be added as the implementation progresses. The mobile client will authenticate against either the local site or the cloud depending on connectivity.
+Set `ENABLE_CLOUD_SYNC=1` on local servers to activate the placeholder sync worker. Future releases will also respect a `ROLE` variable (`cloud` or `local`) to toggle behaviour.
 
 ## Interface Themes
 

--- a/Tasks.txt
+++ b/Tasks.txt
@@ -41,9 +41,23 @@ PHASE 6: CLOUD & MOBILE INTEGRATION
 
 [x] Design architecture for cloud server with site-level replicas
 [ ] Implement record versioning and conflict resolution fields
+  - [ ] Add version columns to models and schemas
+  - [ ] Track unresolved conflicts in a dedicated field
+  - [ ] Generate Alembic migration scripts
 [ ] Add sync endpoints and background jobs for local/cloud replication
+  - [ ] POST `/api/v1/sync` to accept batched updates
+  - [ ] Background worker to push local changes
+  - [ ] Background worker to pull updates from cloud
 [ ] Provide configuration options for cloud vs. local deployment
+  - [ ] `ROLE` environment variable controls cloud or local behaviour
+  - [ ] Conditional startup of cloud sync components
 [ ] Expand mobile-client folder into functional app connecting to local servers
+  - [ ] Scaffold React Native project with authentication
+  - [ ] Implement device list view backed by REST API
 [ ] Supply Docker/Kubernetes configs for cloud and local roles
+  - [ ] `docker-compose.cloud.yml` for the central server
+  - [ ] Kubernetes manifests under `k8s/`
 [ ] Write tests for synchronization and mobile interactions
+  - [ ] Unit tests for sync worker and API endpoints
+  - [ ] Integration tests simulating mobile app requests
 [ ] Update README with setup instructions for cloud/local servers and mobile app

--- a/server/main.py
+++ b/server/main.py
@@ -44,6 +44,7 @@ from server.routes import (
     api_users_router,
     api_vlans_router,
     api_ssh_credentials_router,
+    api_sync_router,
 )
 from server.routes.ui.tunables import router as tunables_router
 from server.routes.ui.editor import router as editor_router
@@ -55,6 +56,7 @@ from server.workers.queue_worker import start_queue_worker, stop_queue_worker
 from server.workers.config_scheduler import start_config_scheduler, stop_config_scheduler
 from server.workers.trap_listener import setup_trap_listener
 from server.workers.syslog_listener import setup_syslog_listener
+from server.workers.cloud_sync import start_cloud_sync, stop_cloud_sync
 from core.utils.templates import templates
 
 # Allow deploying the app under a URL prefix by setting ROOT_PATH.
@@ -66,12 +68,14 @@ start_queue_worker(app)
 start_config_scheduler(app)
 setup_trap_listener(app)
 setup_syslog_listener(app)
+start_cloud_sync(app)
 
 
 @app.on_event("shutdown")
 async def shutdown_cleanup():
     await stop_queue_worker()
     stop_config_scheduler()
+    await stop_cloud_sync()
 
 
 # Path to the ``static`` directory under ``web-client``
@@ -106,6 +110,7 @@ app.include_router(api_devices_router)
 app.include_router(api_users_router)
 app.include_router(api_vlans_router)
 app.include_router(api_ssh_credentials_router)
+app.include_router(api_sync_router)
 app.include_router(admin_profiles_router)
 app.include_router(configs_router)
 app.include_router(admin_router)

--- a/server/routes/__init__.py
+++ b/server/routes/__init__.py
@@ -36,6 +36,7 @@ from .api.devices import router as api_devices_router
 from .api.users import router as api_users_router
 from .api.vlans import router as api_vlans_router
 from .api.ssh_credentials import router as api_ssh_credentials_router
+from .api.sync import router as api_sync_router
 
 __all__ = [
     "auth_router",
@@ -76,4 +77,5 @@ __all__ = [
     "api_users_router",
     "api_vlans_router",
     "api_ssh_credentials_router",
+    "api_sync_router",
 ]

--- a/server/routes/api/__init__.py
+++ b/server/routes/api/__init__.py
@@ -3,6 +3,7 @@ from .devices import router as devices_router
 from .users import router as users_router
 from .vlans import router as vlans_router
 from .ssh_credentials import router as ssh_credentials_router
+from .sync import router as sync_router
 
 __all__ = [
     "api_router",
@@ -10,4 +11,5 @@ __all__ = [
     "users_router",
     "vlans_router",
     "ssh_credentials_router",
+    "sync_router",
 ]

--- a/server/routes/api/sync.py
+++ b/server/routes/api/sync.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/v1/sync", tags=["sync"])
+
+@router.post("/")
+async def sync_payload():
+    """Placeholder endpoint for syncing records between sites."""
+    return {"detail": "sync not implemented"}

--- a/server/workers/__init__.py
+++ b/server/workers/__init__.py
@@ -1,8 +1,9 @@
-from . import queue_worker, config_scheduler, trap_listener, syslog_listener
+from . import queue_worker, config_scheduler, trap_listener, syslog_listener, cloud_sync
 
 __all__ = [
     "queue_worker",
     "config_scheduler",
     "trap_listener",
     "syslog_listener",
+    "cloud_sync",
 ]

--- a/server/workers/cloud_sync.py
+++ b/server/workers/cloud_sync.py
@@ -1,0 +1,32 @@
+import asyncio
+import os
+
+SYNC_INTERVAL = int(os.environ.get("SYNC_INTERVAL", "300"))
+
+async def run_sync_once() -> None:
+    """Placeholder for a single sync iteration."""
+    await asyncio.sleep(0)
+
+async def _sync_loop() -> None:
+    while True:
+        await run_sync_once()
+        await asyncio.sleep(SYNC_INTERVAL)
+
+_sync_task: asyncio.Task | None = None
+
+def start_cloud_sync(app):
+    @app.on_event("startup")
+    async def start_worker():
+        if os.environ.get("ENABLE_CLOUD_SYNC") == "1":
+            global _sync_task
+            _sync_task = asyncio.create_task(_sync_loop())
+
+async def stop_cloud_sync() -> None:
+    global _sync_task
+    if _sync_task:
+        _sync_task.cancel()
+        try:
+            await _sync_task
+        except asyncio.CancelledError:
+            pass
+        _sync_task = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,8 @@ def get_test_app():
          mock.patch("server.workers.queue_worker.start_queue_worker"), \
          mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
          mock.patch("server.workers.trap_listener.setup_trap_listener"), \
-         mock.patch("server.workers.syslog_listener.setup_syslog_listener"):
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.cloud_sync.start_cloud_sync"):
         return importlib.import_module("server.main").app
 
 

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -33,6 +33,8 @@ def get_app_for_shutdown():
         "server.workers.trap_listener.setup_trap_listener"
     ), mock.patch(
         "server.workers.syslog_listener.setup_syslog_listener"
+    ), mock.patch(
+        "server.workers.cloud_sync.start_cloud_sync"
     ):
         return importlib.import_module("server.main").app
 


### PR DESCRIPTION
## Summary
- expand Phase 6 todo list with detailed subtasks
- add placeholder `/api/v1/sync` endpoint
- add cloud sync worker and start/stop hooks
- wire new router and worker into the app
- patch tests to mock the new worker
- document `ENABLE_CLOUD_SYNC` in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507255a2688324aa63bd9dbb502b3f