### PR TITLE
Implement version and conflict tracking

### DIFF
--- a/core/models/models.py
+++ b/core/models/models.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     Text,
     Boolean,
     Float,
+    JSON,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy import Table
@@ -20,7 +21,7 @@ class VLAN(Base):
 
     id = Column(Integer, primary_key=True)
     version = Column(Integer, default=1)
-    has_conflict = Column(Boolean, default=False)
+    conflict_data = Column(JSON, nullable=True)
     tag = Column(Integer, unique=True, nullable=False)
     description = Column(String, nullable=True)
 
@@ -32,7 +33,7 @@ class SSHCredential(Base):
 
     id = Column(Integer, primary_key=True)
     version = Column(Integer, default=1)
-    has_conflict = Column(Boolean, default=False)
+    conflict_data = Column(JSON, nullable=True)
     name = Column(String, unique=True, nullable=False)
     username = Column(String, nullable=False)
     password = Column(String, nullable=True)
@@ -117,7 +118,7 @@ class Device(Base):
 
     id = Column(Integer, primary_key=True)
     version = Column(Integer, default=1)
-    has_conflict = Column(Boolean, default=False)
+    conflict_data = Column(JSON, nullable=True)
     hostname = Column(String, unique=True, nullable=False)
     ip = Column(String, nullable=False)
     mac = Column(String, nullable=True)
@@ -206,7 +207,7 @@ class User(Base):
 
     id = Column(Integer, primary_key=True)
     version = Column(Integer, default=1)
-    has_conflict = Column(Boolean, default=False)
+    conflict_data = Column(JSON, nullable=True)
     email = Column(String, unique=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     role = Column(String, nullable=False, default="viewer")

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -11,7 +11,7 @@ class VLANBase(BaseModel):
     tag: int
     description: str | None = None
     version: int | None = 1
-    has_conflict: bool | None = False
+    conflict_data: dict | None = None
 
 
 class VLANCreate(VLANBase):
@@ -37,7 +37,7 @@ class DeviceBase(BaseModel):
     manufacturer: str | None = None
     model: str | None = None
     version: int | None = 1
-    has_conflict: bool | None = False
+    conflict_data: dict | None = None
 
 
 class DeviceCreate(DeviceBase):
@@ -65,7 +65,7 @@ class SSHCredentialBase(BaseModel):
     password: str | None = None
     private_key: str | None = None
     version: int | None = 1
-    has_conflict: bool | None = False
+    conflict_data: dict | None = None
 
 
 class SSHCredentialCreate(SSHCredentialBase):
@@ -91,7 +91,7 @@ class UserBase(BaseModel):
     role: str = "viewer"
     is_active: bool = True
     version: int | None = 1
-    has_conflict: bool | None = False
+    conflict_data: dict | None = None
 
 
 class UserCreate(UserBase):

--- a/core/utils/versioning.py
+++ b/core/utils/versioning.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+
+def apply_update(obj, update_data: dict, incoming_version: int | None = None, source: str = "api"):
+    """Apply updates to an ORM object with version increment and optional conflict detection."""
+    for key, value in update_data.items():
+        setattr(obj, key, value)
+
+    current_version = getattr(obj, "version", 0) or 0
+    conflict = None
+    if incoming_version is not None and incoming_version != current_version:
+        conflict = {
+            "source": source,
+            "timestamp": datetime.utcnow().isoformat(),
+            "conflicting_fields": list(update_data.keys()),
+        }
+    obj.version = current_version + 1
+    obj.conflict_data = conflict
+    return conflict

--- a/migrations/versions/0002_add_conflict_data.py
+++ b/migrations/versions/0002_add_conflict_data.py
@@ -1,0 +1,23 @@
+"""add conflict_data json fields"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('devices', sa.Column('conflict_data', sa.JSON(), nullable=True))
+    op.add_column('vlans', sa.Column('conflict_data', sa.JSON(), nullable=True))
+    op.add_column('ssh_credentials', sa.Column('conflict_data', sa.JSON(), nullable=True))
+    op.add_column('users', sa.Column('conflict_data', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'conflict_data')
+    op.drop_column('ssh_credentials', 'conflict_data')
+    op.drop_column('vlans', 'conflict_data')
+    op.drop_column('devices', 'conflict_data')

--- a/server/routes/api/devices.py
+++ b/server/routes/api/devices.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from core.utils.db_session import get_db
 from core.models.models import Device
 from core import schemas
+from core.utils.versioning import apply_update
 from core.utils import auth as auth_utils
 
 router = APIRouter(prefix="/api/v1/devices", tags=["devices"])
@@ -54,8 +55,8 @@ def update_device(
     obj = db.query(Device).filter_by(id=device_id).first()
     if not obj:
         raise HTTPException(status_code=404, detail="Device not found")
-    for key, value in update.dict(exclude_unset=True).items():
-        setattr(obj, key, value)
+    update_data = update.dict(exclude_unset=True)
+    apply_update(obj, update_data)
     db.commit()
     db.refresh(obj)
     return obj

--- a/server/routes/api/ssh_credentials.py
+++ b/server/routes/api/ssh_credentials.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from core.utils.db_session import get_db
 from core.models.models import SSHCredential
 from core import schemas
+from core.utils.versioning import apply_update
 from core.utils import auth as auth_utils
 
 router = APIRouter(prefix="/api/v1/ssh-credentials", tags=["ssh_credentials"])
@@ -54,8 +55,8 @@ def update_cred(
     obj = db.query(SSHCredential).filter_by(id=cred_id).first()
     if not obj:
         raise HTTPException(status_code=404, detail="Credential not found")
-    for key, value in update.dict(exclude_unset=True).items():
-        setattr(obj, key, value)
+    update_data = update.dict(exclude_unset=True)
+    apply_update(obj, update_data)
     db.commit()
     db.refresh(obj)
     return obj

--- a/server/routes/api/users.py
+++ b/server/routes/api/users.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from core.utils.db_session import get_db
 from core.models.models import User
 from core import schemas
+from core.utils.versioning import apply_update
 from core.utils import auth as auth_utils
 
 router = APIRouter(prefix="/api/v1/users", tags=["users"])
@@ -54,8 +55,8 @@ def update_user(
     obj = db.query(User).filter_by(id=user_id).first()
     if not obj:
         raise HTTPException(status_code=404, detail="User not found")
-    for key, value in update.dict(exclude_unset=True).items():
-        setattr(obj, key, value)
+    update_data = update.dict(exclude_unset=True)
+    apply_update(obj, update_data)
     db.commit()
     db.refresh(obj)
     return obj

--- a/server/routes/api/vlans.py
+++ b/server/routes/api/vlans.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from core.utils.db_session import get_db
 from core.models.models import VLAN
 from core import schemas
+from core.utils.versioning import apply_update
 from core.utils import auth as auth_utils
 
 router = APIRouter(prefix="/api/v1/vlans", tags=["vlans"])
@@ -54,8 +55,8 @@ def update_vlan(
     obj = db.query(VLAN).filter_by(id=vlan_id).first()
     if not obj:
         raise HTTPException(status_code=404, detail="VLAN not found")
-    for key, value in update.dict(exclude_unset=True).items():
-        setattr(obj, key, value)
+    update_data = update.dict(exclude_unset=True)
+    apply_update(obj, update_data)
     db.commit()
     db.refresh(obj)
     return obj

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,23 @@
+from core.utils.versioning import apply_update
+
+class Dummy:
+    def __init__(self):
+        self.version = 1
+        self.conflict_data = None
+
+
+def test_apply_update_increments_version():
+    d = Dummy()
+    apply_update(d, {"name": "x"}, incoming_version=1, source="test")
+    assert d.version == 2
+    assert d.conflict_data is None
+    assert d.name == "x"
+
+
+def test_apply_update_conflict():
+    d = Dummy()
+    apply_update(d, {"name": "x"}, incoming_version=0, source="test")
+    assert d.version == 2
+    assert d.conflict_data is not None
+    assert d.conflict_data["source"] == "test"
+    assert "name" in d.conflict_data["conflicting_fields"]

--- a/web-client/templates/device_list.html
+++ b/web-client/templates/device_list.html
@@ -57,12 +57,13 @@
       {% if column_prefs.snmp_profile %}<th class="table-cell table-header">{{ column_labels['snmp_profile'] }}</th>{% endif %}
       {% if column_prefs.status %}<th class="table-cell table-header">{{ column_labels['status'] }}</th>{% endif %}
       {% if column_prefs.tags %}<th class="table-cell table-header">{{ column_labels['tags'] }}</th>{% endif %}
+      <th class="table-cell table-header">Ver</th>
       <th class="text-right w-[10rem]">Actions</th>
     </tr>
   </thead>
   <tbody>
   {% for device in devices %}
-    <tr>
+    <tr {% if device.conflict_data %}style="background-color:#7f1d1d"{% endif %}>
       <td class="table-cell"><input type="checkbox" name="selected" value="{{ device.id }}"></td>
       {% if column_prefs.hostname %}<td class="table-cell">{{ device.hostname }}</td>{% endif %}
       {% if column_prefs.ip %}<td class="table-cell {% if device.ip and duplicate_ips.get(device.ip) %}duplicate{% endif %}" title="{{ duplicate_ips.get(device.ip)|join(', ') if duplicate_ips.get(device.ip) }}">{{ device.ip }}</td>{% endif %}
@@ -95,6 +96,7 @@
         {{ device.uptime_seconds | format_uptime }}
       </td>{% endif %}
       {% if column_prefs.tags %}<td class="table-cell">{{ device.tags | map(attribute='name') | join(', ') }}</td>{% endif %}
+      <td class="table-cell">{{ device.version }}</td>
       <td class="text-right w-[10rem] whitespace-nowrap">
         <div class="flex justify-end flex-wrap gap-1">
           {% if device.ssh_credential or personal_creds.get(device.id) %}

--- a/web-client/templates/ssh_list.html
+++ b/web-client/templates/ssh_list.html
@@ -11,15 +11,17 @@
       <th class="px-2"><input type="checkbox" id="select-all"></th>
       <th class="px-4 py-2 text-left">Name</th>
       <th class="px-4 py-2 text-left">Username</th>
+      <th class="px-4 py-2 text-left">Version</th>
       <th></th>
     </tr>
   </thead>
   <tbody>
   {% for cred in creds %}
-    <tr class="border-t border-gray-700">
+    <tr class="border-t border-gray-700" {% if cred.conflict_data %}style="background-color:#7f1d1d"{% endif %}>
       <td class="px-2"><input type="checkbox" name="selected" value="{{ cred.id }}"></td>
       <td class="px-4 py-2">{{ cred.name }}</td>
       <td class="px-4 py-2">{{ cred.username }}</td>
+      <td class="px-4 py-2">{{ cred.version }}</td>
       <td class="px-4 py-2">
         <a href="/admin/ssh/{{ cred.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         <form method="post" action="/admin/ssh/{{ cred.id }}/delete" class="inline">

--- a/web-client/templates/user_list.html
+++ b/web-client/templates/user_list.html
@@ -10,16 +10,18 @@
       <th class="px-4 py-2 text-left">Email</th>
       <th class="px-4 py-2 text-left">Role</th>
       <th class="px-4 py-2 text-left">Status</th>
+      <th class="px-4 py-2 text-left">Version</th>
       <th class="px-4 py-2 text-left">Created</th>
       <th></th>
     </tr>
   </thead>
   <tbody>
     {% for user in users %}
-    <tr class="border-t border-gray-700 {% if not user.is_active %}opacity-50{% endif %}">
+    <tr class="border-t border-gray-700 {% if not user.is_active %}opacity-50{% endif %}" {% if user.conflict_data %}style="background-color:#7f1d1d"{% endif %}>
       <td class="px-4 py-2">{{ user.email }}</td>
       <td class="px-4 py-2">{{ user.role }}</td>
       <td class="px-4 py-2">{{ 'active' if user.is_active else 'inactive' }}</td>
+      <td class="px-4 py-2">{{ user.version }}</td>
       <td class="px-4 py-2">{{ user.created_at }}</td>
       <td class="px-4 py-2">
         <a href="/admin/users/{{ user.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>

--- a/web-client/templates/vlan_list.html
+++ b/web-client/templates/vlan_list.html
@@ -11,15 +11,17 @@
       <th class="px-2"><input type="checkbox" id="select-all"></th>
       <th class="px-4 py-2 text-left">Tag</th>
       <th class="px-4 py-2 text-left">Description</th>
+      <th class="px-4 py-2 text-left">Version</th>
       <th></th>
     </tr>
   </thead>
   <tbody>
   {% for vlan in vlans %}
-    <tr class="border-t border-gray-700">
+    <tr class="border-t border-gray-700" {% if vlan.conflict_data %}style="background-color:#7f1d1d"{% endif %}>
       <td class="px-2"><input type="checkbox" name="selected" value="{{ vlan.id }}"></td>
       <td class="px-4 py-2">{{ vlan.tag }}</td>
       <td class="px-4 py-2">{{ vlan.description or '' }}</td>
+      <td class="px-4 py-2">{{ vlan.version }}</td>
       <td class="px-4 py-2">
         <a href="/vlans/{{ vlan.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         <form method="post" action="/vlans/{{ vlan.id }}/delete" class="inline">


### PR DESCRIPTION
## Summary
- add `conflict_data` JSON field to versioned models
- expose version and conflict fields through schemas
- auto-increment version and record conflicts via `apply_update`
- display version and highlight conflicts in admin tables
- provide Alembic migration for new field
- add utility tests for versioning

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685080d7d06c8324a6f081dee31b887c