### PR TITLE
Add version column support

### DIFF
--- a/core/models/models.py
+++ b/core/models/models.py
@@ -20,7 +20,7 @@ class VLAN(Base):
     __tablename__ = "vlans"
 
     id = Column(Integer, primary_key=True)
-    version = Column(Integer, default=1)
+    version = Column(Integer, default=1, nullable=False)
     conflict_data = Column(JSON, nullable=True)
     tag = Column(Integer, unique=True, nullable=False)
     description = Column(String, nullable=True)
@@ -32,7 +32,7 @@ class SSHCredential(Base):
     __tablename__ = "ssh_credentials"
 
     id = Column(Integer, primary_key=True)
-    version = Column(Integer, default=1)
+    version = Column(Integer, default=1, nullable=False)
     conflict_data = Column(JSON, nullable=True)
     name = Column(String, unique=True, nullable=False)
     username = Column(String, nullable=False)
@@ -117,7 +117,7 @@ class Device(Base):
     __tablename__ = "devices"
 
     id = Column(Integer, primary_key=True)
-    version = Column(Integer, default=1)
+    version = Column(Integer, default=1, nullable=False)
     conflict_data = Column(JSON, nullable=True)
     hostname = Column(String, unique=True, nullable=False)
     ip = Column(String, nullable=False)
@@ -206,7 +206,7 @@ class User(Base):
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True)
-    version = Column(Integer, default=1)
+    version = Column(Integer, default=1, nullable=False)
     conflict_data = Column(JSON, nullable=True)
     email = Column(String, unique=True, nullable=False)
     hashed_password = Column(String, nullable=False)

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -10,7 +10,7 @@ class ColumnSelection(BaseModel):
 class VLANBase(BaseModel):
     tag: int
     description: str | None = None
-    version: int | None = 1
+    version: int = 1
     conflict_data: dict | None = None
 
 
@@ -28,6 +28,7 @@ class VLANRead(VLANBase):
 class VLANUpdate(BaseModel):
     tag: int | None = None
     description: str | None = None
+    version: int | None = None
 
 
 class DeviceBase(BaseModel):
@@ -36,7 +37,7 @@ class DeviceBase(BaseModel):
     vlan_id: int | None = None
     manufacturer: str | None = None
     model: str | None = None
-    version: int | None = 1
+    version: int = 1
     conflict_data: dict | None = None
 
 
@@ -57,6 +58,7 @@ class DeviceUpdate(BaseModel):
     vlan_id: int | None = None
     manufacturer: str | None = None
     model: str | None = None
+    version: int | None = None
 
 
 class SSHCredentialBase(BaseModel):
@@ -64,7 +66,7 @@ class SSHCredentialBase(BaseModel):
     username: str
     password: str | None = None
     private_key: str | None = None
-    version: int | None = 1
+    version: int = 1
     conflict_data: dict | None = None
 
 
@@ -84,13 +86,14 @@ class SSHCredentialUpdate(BaseModel):
     username: str | None = None
     password: str | None = None
     private_key: str | None = None
+    version: int | None = None
 
 
 class UserBase(BaseModel):
     email: str
     role: str = "viewer"
     is_active: bool = True
-    version: int | None = 1
+    version: int = 1
     conflict_data: dict | None = None
 
 
@@ -110,3 +113,4 @@ class UserUpdate(BaseModel):
     hashed_password: str | None = None
     role: str | None = None
     is_active: bool | None = None
+    version: int | None = None

--- a/migrations/versions/0003_make_version_not_null.py
+++ b/migrations/versions/0003_make_version_not_null.py
@@ -1,0 +1,21 @@
+"""make version columns non-nullable"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0003'
+down_revision = '0002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    tables = ['devices', 'vlans', 'ssh_credentials', 'users']
+    for table in tables:
+        op.alter_column(table, 'version', existing_type=sa.Integer(), nullable=False, server_default='1')
+
+
+def downgrade() -> None:
+    tables = ['devices', 'vlans', 'ssh_credentials', 'users']
+    for table in tables:
+        op.alter_column(table, 'version', existing_type=sa.Integer(), nullable=True)

--- a/server/routes/api/devices.py
+++ b/server/routes/api/devices.py
@@ -28,7 +28,8 @@ def create_device(
     db: Session = Depends(get_db),
     current_user: Device = Depends(auth_utils.require_role("editor")),
 ):
-    obj = Device(**device.dict())
+    obj = Device(**device.dict(exclude={"version"}))
+    obj.version = 1
     db.add(obj)
     db.commit()
     db.refresh(obj)
@@ -55,8 +56,8 @@ def update_device(
     obj = db.query(Device).filter_by(id=device_id).first()
     if not obj:
         raise HTTPException(status_code=404, detail="Device not found")
-    update_data = update.dict(exclude_unset=True)
-    apply_update(obj, update_data)
+    update_data = update.dict(exclude_unset=True, exclude={"version"})
+    apply_update(obj, update_data, incoming_version=update.version)
     db.commit()
     db.refresh(obj)
     return obj

--- a/server/routes/api/ssh_credentials.py
+++ b/server/routes/api/ssh_credentials.py
@@ -28,7 +28,8 @@ def create_cred(
     db: Session = Depends(get_db),
     current_user: SSHCredential = Depends(auth_utils.require_role("admin")),
 ):
-    obj = SSHCredential(**cred.dict())
+    obj = SSHCredential(**cred.dict(exclude={"version"}))
+    obj.version = 1
     db.add(obj)
     db.commit()
     db.refresh(obj)
@@ -55,8 +56,8 @@ def update_cred(
     obj = db.query(SSHCredential).filter_by(id=cred_id).first()
     if not obj:
         raise HTTPException(status_code=404, detail="Credential not found")
-    update_data = update.dict(exclude_unset=True)
-    apply_update(obj, update_data)
+    update_data = update.dict(exclude_unset=True, exclude={"version"})
+    apply_update(obj, update_data, incoming_version=update.version)
     db.commit()
     db.refresh(obj)
     return obj

--- a/server/routes/api/users.py
+++ b/server/routes/api/users.py
@@ -28,7 +28,8 @@ def create_user(
     db: Session = Depends(get_db),
     current_user: User = Depends(auth_utils.require_role("admin")),
 ):
-    obj = User(**user.dict())
+    obj = User(**user.dict(exclude={"version"}))
+    obj.version = 1
     db.add(obj)
     db.commit()
     db.refresh(obj)
@@ -55,8 +56,8 @@ def update_user(
     obj = db.query(User).filter_by(id=user_id).first()
     if not obj:
         raise HTTPException(status_code=404, detail="User not found")
-    update_data = update.dict(exclude_unset=True)
-    apply_update(obj, update_data)
+    update_data = update.dict(exclude_unset=True, exclude={"version"})
+    apply_update(obj, update_data, incoming_version=update.version)
     db.commit()
     db.refresh(obj)
     return obj

--- a/server/routes/api/vlans.py
+++ b/server/routes/api/vlans.py
@@ -28,7 +28,8 @@ def create_vlan(
     db: Session = Depends(get_db),
     current_user: VLAN = Depends(auth_utils.require_role("editor")),
 ):
-    obj = VLAN(**vlan.dict())
+    obj = VLAN(**vlan.dict(exclude={"version"}))
+    obj.version = 1
     db.add(obj)
     db.commit()
     db.refresh(obj)
@@ -55,8 +56,8 @@ def update_vlan(
     obj = db.query(VLAN).filter_by(id=vlan_id).first()
     if not obj:
         raise HTTPException(status_code=404, detail="VLAN not found")
-    update_data = update.dict(exclude_unset=True)
-    apply_update(obj, update_data)
+    update_data = update.dict(exclude_unset=True, exclude={"version"})
+    apply_update(obj, update_data, incoming_version=update.version)
     db.commit()
     db.refresh(obj)
     return obj

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,19 +64,19 @@ class DummyDB:
         self.models = models
         self.data = {
             models.User: [
-            models.User(id=1, email="admin@example.com", hashed_password="x", role="admin", is_active=True),
-            models.User(id=2, email="viewer@example.com", hashed_password="x", role="viewer", is_active=True),
+            models.User(id=1, email="admin@example.com", hashed_password="x", role="admin", is_active=True, version=1),
+            models.User(id=2, email="viewer@example.com", hashed_password="x", role="viewer", is_active=True, version=1),
             ],
             models.Device: [
-                models.Device(id=1, hostname="switch1", ip="1.1.1.1", manufacturer="cisco", model="x"),
-                models.Device(id=2, hostname="router2", ip="2.2.2.2", manufacturer="juniper", model="y"),
+                models.Device(id=1, hostname="switch1", ip="1.1.1.1", manufacturer="cisco", model="x", version=1),
+                models.Device(id=2, hostname="router2", ip="2.2.2.2", manufacturer="juniper", model="y", version=1),
             ],
             models.VLAN: [
-                models.VLAN(id=1, tag=10, description="office"),
-                models.VLAN(id=2, tag=20, description="lab"),
+                models.VLAN(id=1, tag=10, description="office", version=1),
+                models.VLAN(id=2, tag=20, description="lab", version=1),
             ],
             models.SSHCredential: [
-                models.SSHCredential(id=1, name="main", username="root", password="pw"),
+                models.SSHCredential(id=1, name="main", username="root", password="pw", version=1),
             ],
         }
 
@@ -138,3 +138,16 @@ def test_vlans_filter():
     data = resp.json()
     assert len(data) == 1
     assert data[0]["tag"] == 10
+
+
+def test_device_update_increments_version():
+    token = _token()
+    resp = client.put(
+        "/api/v1/devices/1",
+        json={"hostname": "switch-one", "version": 1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["version"] == 2
+    assert data["hostname"] == "switch-one"


### PR DESCRIPTION
## Summary
- ensure sync models have non-null version field
- expose version handling in API schemas
- default version values during create
- increment version on updates
- add migration for version constraints
- test version auto-increment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685083803e9083248c5e010c8dd1603e