### PR TITLE
Add batched sync push endpoint

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5,6 +5,58 @@ from unittest import mock
 from fastapi.testclient import TestClient
 
 
+class DummyQuery:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def filter_by(self, **kw):
+        for k, v in kw.items():
+            self.items = [i for i in self.items if getattr(i, k) == v]
+        return self
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+    def all(self):
+        return list(self.items)
+
+
+class DummyDB:
+    def __init__(self):
+        with mock.patch("sqlalchemy.create_engine"), \
+             mock.patch("sqlalchemy.schema.MetaData.create_all"):
+            models = importlib.import_module("core.models.models")
+        self.models = models
+        self.data = {
+            models.User: [
+                models.User(id=1, email="admin@example.com", hashed_password="x", role="admin", is_active=True, version=1),
+            ],
+        }
+
+    def query(self, model):
+        return DummyQuery(self.data.get(model, []))
+
+    def add(self, obj):
+        self.data.setdefault(type(obj), []).append(obj)
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+    def rollback(self):
+        pass
+
+
+def override_get_db():
+    db = DummyDB()
+    try:
+        yield db
+    finally:
+        pass
+
+
 def get_test_app():
     os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
     for m in list(sys.modules):
@@ -21,6 +73,7 @@ def get_test_app():
 
 
 app = get_test_app()
+app.dependency_overrides[importlib.import_module("core.utils.db_session").get_db] = override_get_db
 client = TestClient(app)
 
 
@@ -31,9 +84,33 @@ def test_sync_endpoint_accepts_payload():
 
 
 def test_sync_push_endpoint():
-    resp = client.post("/api/v1/sync/push", json={"devices": []})
+    payload = {
+        "model": "users",
+        "records": [
+            {
+                "id": 2,
+                "email": "new@example.com",
+                "hashed_password": "x",
+                "role": "viewer",
+                "is_active": True,
+                "version": 1,
+            },
+            {
+                "id": 1,
+                "email": "admin@example.com",
+                "hashed_password": "x",
+                "role": "admin",
+                "is_active": True,
+                "version": 0,
+            },
+        ],
+    }
+    resp = client.post("/api/v1/sync/push", json=payload)
     assert resp.status_code == 200
-    assert resp.json()["status"] == "pushed"
+    data = resp.json()
+    assert data["accepted"] == 1
+    assert data["conflicts"] == 1
+    assert data["skipped"] == 0
 
 
 def test_sync_pull_endpoint():


### PR DESCRIPTION
## Summary
- implement `/api/v1/sync/push` for batched updates
- log conflicts and handle record creation or update
- expand sync tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508e15114883248c967b2714f95a39