### PR TITLE
Implement sync push worker

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -57,6 +57,7 @@ from server.workers.config_scheduler import start_config_scheduler, stop_config_
 from server.workers.trap_listener import setup_trap_listener
 from server.workers.syslog_listener import setup_syslog_listener
 from server.workers.cloud_sync import start_cloud_sync, stop_cloud_sync
+from server.workers.sync_push_worker import start_sync_push_worker, stop_sync_push_worker
 from core.utils.templates import templates
 
 # Allow deploying the app under a URL prefix by setting ROOT_PATH.
@@ -69,6 +70,7 @@ start_config_scheduler(app)
 setup_trap_listener(app)
 setup_syslog_listener(app)
 start_cloud_sync(app)
+start_sync_push_worker(app)
 
 
 @app.on_event("shutdown")
@@ -76,6 +78,7 @@ async def shutdown_cleanup():
     await stop_queue_worker()
     stop_config_scheduler()
     await stop_cloud_sync()
+    await stop_sync_push_worker()
 
 
 # Path to the ``static`` directory under ``web-client``

--- a/server/workers/__init__.py
+++ b/server/workers/__init__.py
@@ -1,4 +1,11 @@
-from . import queue_worker, config_scheduler, trap_listener, syslog_listener, cloud_sync
+from . import (
+    queue_worker,
+    config_scheduler,
+    trap_listener,
+    syslog_listener,
+    cloud_sync,
+    sync_push_worker,
+)
 
 __all__ = [
     "queue_worker",
@@ -6,4 +13,5 @@ __all__ = [
     "trap_listener",
     "syslog_listener",
     "cloud_sync",
+    "sync_push_worker",
 ]

--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -1,0 +1,106 @@
+import asyncio
+import logging
+import os
+from datetime import datetime
+from typing import Any
+
+import httpx
+from sqlalchemy import inspect, or_
+
+from core.utils.db_session import SessionLocal
+from core.models.models import Device, SystemTunable
+from .cloud_sync import _request_with_retry
+
+SYNC_PUSH_URL = os.environ.get("SYNC_PUSH_URL", "http://cloud/api/v1/sync/push")
+SYNC_PUSH_INTERVAL = int(os.environ.get("SYNC_PUSH_INTERVAL", "60"))
+SYNC_TIMEOUT = int(os.environ.get("SYNC_TIMEOUT", "10"))
+
+
+def _serialize(obj: Any) -> dict[str, Any]:
+    insp = inspect(obj)
+    return {c.key: getattr(obj, c.key) for c in insp.mapper.column_attrs}
+
+
+def _load_last_sync(db) -> datetime:
+    entry = db.query(SystemTunable).filter(SystemTunable.name == "Last Sync Push Worker").first()
+    if entry:
+        try:
+            return datetime.fromisoformat(entry.value)
+        except Exception:
+            pass
+    return datetime.fromtimestamp(0)
+
+
+def _update_last_sync(db) -> None:
+    now = datetime.utcnow().isoformat()
+    entry = db.query(SystemTunable).filter(SystemTunable.name == "Last Sync Push Worker").first()
+    if entry:
+        entry.value = now
+    else:
+        db.add(
+            SystemTunable(
+                name="Last Sync Push Worker",
+                value=now,
+                function="Sync",
+                file_type="application",
+                data_type="text",
+            )
+        )
+    db.commit()
+
+
+async def push_once(log: logging.Logger) -> None:
+    db = SessionLocal()
+    try:
+        since = _load_last_sync(db)
+        records = (
+            db.query(Device)
+            .filter(or_(Device.created_at > since, Device.updated_at > since))
+            .all()
+        )
+        if not records:
+            return
+        payload = {"model": Device.__tablename__, "records": [_serialize(r) for r in records]}
+        await _request_with_retry("POST", SYNC_PUSH_URL, payload, log)
+        _update_last_sync(db)
+    finally:
+        db.close()
+
+
+async def _push_loop() -> None:
+    log = logging.getLogger(__name__)
+    delay = SYNC_PUSH_INTERVAL
+    while True:
+        try:
+            await push_once(log)
+            delay = SYNC_PUSH_INTERVAL
+        except Exception as exc:
+            log.error("Sync push failed: %s", exc)
+            delay = min(delay * 2, 3600)
+        await asyncio.sleep(delay)
+
+
+_sync_task: asyncio.Task | None = None
+
+
+def start_sync_push_worker(app):
+    @app.on_event("startup")
+    async def start_worker():
+        if os.environ.get("ENABLE_SYNC_PUSH_WORKER") != "1":
+            return
+        role = os.environ.get("ROLE", "local")
+        if role == "cloud":
+            return
+        global _sync_task
+        _sync_task = asyncio.create_task(_push_loop())
+
+
+async def stop_sync_push_worker() -> None:
+    global _sync_task
+    if _sync_task:
+        _sync_task.cancel()
+        try:
+            await _sync_task
+        except asyncio.CancelledError:
+            pass
+        _sync_task = None

--- a/tests/test_admin_nav.py
+++ b/tests/test_admin_nav.py
@@ -16,7 +16,8 @@ def get_test_app():
          mock.patch("server.workers.queue_worker.start_queue_worker"), \
          mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
          mock.patch("server.workers.trap_listener.setup_trap_listener"), \
-         mock.patch("server.workers.syslog_listener.setup_syslog_listener"):
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"):
         return importlib.import_module("server.main").app
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ def get_test_app():
          mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
          mock.patch("server.workers.trap_listener.setup_trap_listener"), \
          mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"), \
          mock.patch("server.workers.cloud_sync.start_cloud_sync"):
         return importlib.import_module("server.main").app
 

--- a/tests/test_damage_upload.py
+++ b/tests/test_damage_upload.py
@@ -19,7 +19,8 @@ def get_test_app():
          mock.patch("server.workers.queue_worker.start_queue_worker"), \
          mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
          mock.patch("server.workers.trap_listener.setup_trap_listener"), \
-         mock.patch("server.workers.syslog_listener.setup_syslog_listener"):
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"):
         return importlib.import_module("server.main").app
 
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -16,7 +16,8 @@ def get_test_app():
          mock.patch("server.workers.queue_worker.start_queue_worker"), \
          mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
          mock.patch("server.workers.trap_listener.setup_trap_listener"), \
-         mock.patch("server.workers.syslog_listener.setup_syslog_listener"):
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"):
         return importlib.import_module("server.main").app
 
 

--- a/tests/test_root_path_static.py
+++ b/tests/test_root_path_static.py
@@ -16,7 +16,8 @@ def get_test_app():
          mock.patch("server.workers.queue_worker.start_queue_worker"), \
          mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
          mock.patch("server.workers.trap_listener.setup_trap_listener"), \
-         mock.patch("server.workers.syslog_listener.setup_syslog_listener"):
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"):
         return importlib.import_module("server.main").app
 
 

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -35,6 +35,8 @@ def get_app_for_shutdown():
         "server.workers.syslog_listener.setup_syslog_listener"
     ), mock.patch(
         "server.workers.cloud_sync.start_cloud_sync"
+    ), mock.patch(
+        "server.workers.sync_push_worker.start_sync_push_worker"
     ):
         return importlib.import_module("server.main").app
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -68,6 +68,7 @@ def get_test_app():
          mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
          mock.patch("server.workers.trap_listener.setup_trap_listener"), \
          mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"), \
          mock.patch("server.workers.cloud_sync.start_cloud_sync"):
         return importlib.import_module("server.main").app
 


### PR DESCRIPTION
## Summary
- add background `sync_push_worker` for periodic push of changed devices
- integrate worker startup and shutdown
- expose worker module through workers package
- patch tests to disable the new worker during testing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508f56e510832490b434fe1d81f382