### PR TITLE
Add ROLE env var for deployment modes

### DIFF
--- a/.env.cloud
+++ b/.env.cloud
@@ -1,5 +1,5 @@
 # Example configuration for the central cloud server
-APP_ROLE=cloud
+ROLE=cloud
 DATABASE_URL=postgresql://masteruser:masterpass@db:5432/master_ip_cloud
 ENABLE_BACKGROUND_WORKERS=0
 ENABLE_CLOUD_SYNC=0

--- a/.env.local
+++ b/.env.local
@@ -1,5 +1,5 @@
 # Example configuration for a local site deployment
-APP_ROLE=local
+ROLE=local
 DATABASE_URL=postgresql://masteruser:masterpass@db:5432/master_ip_db
 ENABLE_BACKGROUND_WORKERS=1
 ENABLE_CLOUD_SYNC=1

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ npm run build:web
 
 The [cloud architecture](docs/cloud-architecture.md) document describes the planned replication model for running multiple sites with a central server. Configuration differences between the modes are covered in [docs/deployment_modes.md](docs/deployment_modes.md). Two compose files are now provided:
 
-- `docker-compose.yml` – run a **local** instance with `APP_ROLE=local`.
-- `docker-compose.cloud.yml` – run the **cloud** server with `APP_ROLE=cloud`.
+- `docker-compose.yml` – run a **local** instance with `ROLE=local`.
+- `docker-compose.cloud.yml` – run the **cloud** server with `ROLE=cloud`.
 
 Kubernetes manifests under `k8s/` mirror this setup. Set `ENABLE_CLOUD_SYNC=1` on local servers to start the background worker that pushes updates to the cloud.
 
@@ -224,8 +224,8 @@ The application reads several options from the environment. Important variables 
 - `ENABLE_TRAP_LISTENER` and `SNMP_TRAP_PORT` – enable and configure the trap listener.
 - `ENABLE_SYSLOG_LISTENER` and `SYSLOG_PORT` – enable and configure the syslog listener.
 - `QUEUE_INTERVAL` and `PORT_HISTORY_RETENTION_DAYS` – worker scheduling values.
-- `WORKERS`, `TIMEOUT`, `PORT` and `AUTO_SEED` – options used by `start.sh`.
-- `APP_ROLE` – set to `local` or `cloud` to control sync behaviour.
+ - `WORKERS`, `TIMEOUT`, `PORT` and `AUTO_SEED` – options used by `start.sh`.
+ - `ROLE` – set to `local` or `cloud` to control sync behaviour.
 - `ENABLE_CLOUD_SYNC` – when `1`, start the background sync worker (local role).
 - `ENABLE_SYNC_PUSH_WORKER` – start the worker that pushes local changes.
 - `ENABLE_SYNC_PULL_WORKER` – start the worker that pulls updates from the cloud.

--- a/core/utils/templates.py
+++ b/core/utils/templates.py
@@ -116,4 +116,4 @@ templates.env.globals["get_tunable_categories"] = get_tunable_categories
 
 from settings import settings
 
-templates.env.globals["app_role"] = settings.app_role
+templates.env.globals["app_role"] = settings.role

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -16,7 +16,7 @@ services:
       - db
     environment:
       DATABASE_URL: postgresql://masteruser:masterpass@db:5432/master_ip_cloud
-      APP_ROLE: cloud
+      ROLE: cloud
     ports:
       - "8000:8000"
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     environment:
       DATABASE_URL: postgresql://masteruser:masterpass@db:5432/master_ip_db
       ROOT_PATH: ""
-      APP_ROLE: local
+      ROLE: local
     ports:
       - "8000:8000"
     # volume removed to prevent static files from being overridden in production

--- a/docs/deployment_modes.md
+++ b/docs/deployment_modes.md
@@ -1,10 +1,10 @@
 # Deployment Modes
 
-The application can run in one of two roles controlled by the `APP_ROLE` environment variable.
+The application can run in one of two roles controlled by the `ROLE` environment variable.
 
 ## Local Mode
 
-Local mode is the default when `APP_ROLE` is omitted or set to `local`.
+Local mode is the default when `ROLE` is omitted or set to `local`.
 Background workers such as the configuration scheduler and queue processor start
 up automatically.  These workers handle SNMP polling, scheduled config pulls and
 other tasks.  When `ENABLE_CLOUD_SYNC=1` the local instance pushes updates to the
@@ -13,7 +13,7 @@ corresponding workers are enabled.
 
 ## Cloud Mode
 
-When `APP_ROLE=cloud` the server exposes REST endpoints for local sites to
+When `ROLE=cloud` the server exposes REST endpoints for local sites to
 synchronize with but does not start the heavy background workers.  Use this mode
 for the central replication point.  The sync endpoints under `/api/v1/sync` are
 only mounted in this mode.

--- a/k8s/deployment-cloud.yaml
+++ b/k8s/deployment-cloud.yaml
@@ -16,7 +16,7 @@ spec:
       - name: web
         image: master-ip:latest
         env:
-        - name: APP_ROLE
+        - name: ROLE
           value: "cloud"
         ports:
         - containerPort: 8000

--- a/k8s/deployment-local.yaml
+++ b/k8s/deployment-local.yaml
@@ -16,7 +16,7 @@ spec:
       - name: web
         image: master-ip:latest
         env:
-        - name: APP_ROLE
+        - name: ROLE
           value: "local"
         - name: ENABLE_CLOUD_SYNC
           value: "1"

--- a/server/main.py
+++ b/server/main.py
@@ -68,7 +68,7 @@ app = FastAPI()
 # correct scheme when behind a reverse proxy.
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 
-if settings.app_role == "local":
+if settings.role == "local":
     if settings.enable_background_workers:
         start_queue_worker(app)
         start_config_scheduler(app)
@@ -84,7 +84,7 @@ if settings.app_role == "local":
 
 @app.on_event("shutdown")
 async def shutdown_cleanup():
-    if settings.app_role == "local":
+    if settings.role == "local":
         await stop_queue_worker()
         stop_config_scheduler()
         await stop_cloud_sync()
@@ -103,6 +103,7 @@ os.makedirs(STATIC_DIR, exist_ok=True)
 # Provide visibility into where static assets are expected.  This helps with
 # debugging misconfigured deployments where files may not be found.
 print(f"Serving static files from: {STATIC_DIR}")
+print(f"Application role: {settings.role}")
 
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
@@ -124,7 +125,7 @@ app.include_router(api_devices_router)
 app.include_router(api_users_router)
 app.include_router(api_vlans_router)
 app.include_router(api_ssh_credentials_router)
-if settings.app_role == "cloud":
+if settings.role == "cloud":
     app.include_router(api_sync_router)
 app.include_router(admin_profiles_router)
 app.include_router(configs_router)

--- a/server/workers/cloud_sync.py
+++ b/server/workers/cloud_sync.py
@@ -93,7 +93,7 @@ _sync_task: asyncio.Task | None = None
 def start_cloud_sync(app):
     @app.on_event("startup")
     async def start_worker():
-        role = os.environ.get("APP_ROLE", "local")
+        role = os.environ.get("ROLE", "local")
         if os.environ.get("ENABLE_CLOUD_SYNC") == "1" and role != "cloud":
             global _sync_task
             _sync_task = asyncio.create_task(_sync_loop())

--- a/server/workers/sync_pull_worker.py
+++ b/server/workers/sync_pull_worker.py
@@ -131,7 +131,7 @@ def start_sync_pull_worker(app):
     async def start_worker():
         if os.environ.get("ENABLE_SYNC_PULL_WORKER") != "1":
             return
-        role = os.environ.get("APP_ROLE", "local")
+        role = os.environ.get("ROLE", "local")
         if role == "cloud":
             return
         global _sync_task

--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -88,7 +88,7 @@ def start_sync_push_worker(app):
     async def start_worker():
         if os.environ.get("ENABLE_SYNC_PUSH_WORKER") != "1":
             return
-        role = os.environ.get("APP_ROLE", "local")
+        role = os.environ.get("ROLE", "local")
         if role == "cloud":
             return
         global _sync_task

--- a/settings.py
+++ b/settings.py
@@ -1,22 +1,29 @@
 from functools import lru_cache
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 import os
 
 class Settings(BaseModel):
     """Application configuration loaded from environment."""
 
-    app_role: str = "local"
+    role: str = "local"
     enable_cloud_sync: bool = False
     enable_sync_push_worker: bool = False
     enable_sync_pull_worker: bool = False
     enable_background_workers: bool = True
 
 
+    @validator("role")
+    def validate_role(cls, value: str) -> str:
+        if value not in {"local", "cloud"}:
+            raise ValueError("ROLE must be 'local' or 'cloud'")
+        return value
+
+
 @lru_cache()
 def get_settings() -> Settings:
     env = os.environ.get
     return Settings(
-        app_role=env("APP_ROLE", "local"),
+        role=env("ROLE", "local"),
         enable_cloud_sync=env("ENABLE_CLOUD_SYNC", "0") == "1",
         enable_sync_push_worker=env("ENABLE_SYNC_PUSH_WORKER", "0") == "1",
         enable_sync_pull_worker=env("ENABLE_SYNC_PULL_WORKER", "0") == "1",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -59,7 +59,7 @@ def override_get_db():
 
 def get_test_app():
     os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
-    os.environ["APP_ROLE"] = "cloud"
+    os.environ["ROLE"] = "cloud"
     if "settings" in sys.modules:
         del sys.modules["settings"]
     for m in list(sys.modules):


### PR DESCRIPTION
## Summary
- replace `APP_ROLE` with `ROLE`
- validate `ROLE` in settings and expose as `settings.role`
- start workers and routes based on `settings.role`
- log role at startup
- update compose files, k8s manifests, env examples and docs
- adapt tests to new variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685095c92e48832485b42191d9175434