### PR TITLE
Implement conditional sync startup

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -47,6 +47,7 @@ from server.routes import (
     api_ssh_credentials_router,
 )
 from server.routes.api.sync import router as api_sync_router
+from server.routes.ui.sync_diagnostics import router as sync_diagnostics_router
 from server.routes.ui.tunables import router as tunables_router
 from server.routes.ui.editor import router as editor_router
 from server.websockets.editor import shell_ws
@@ -104,6 +105,13 @@ os.makedirs(STATIC_DIR, exist_ok=True)
 # debugging misconfigured deployments where files may not be found.
 print(f"Serving static files from: {STATIC_DIR}")
 print(f"Application role: {settings.role}")
+if settings.role == "cloud":
+    print("Cloud mode: sync API routes enabled")
+else:
+    print(f"Background workers enabled: {settings.enable_background_workers}")
+    print(f"Cloud sync worker enabled: {settings.enable_cloud_sync}")
+    print(f"Sync push worker enabled: {settings.enable_sync_push_worker}")
+    print(f"Sync pull worker enabled: {settings.enable_sync_pull_worker}")
 
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
@@ -127,6 +135,7 @@ app.include_router(api_vlans_router)
 app.include_router(api_ssh_credentials_router)
 if settings.role == "cloud":
     app.include_router(api_sync_router)
+    app.include_router(sync_diagnostics_router)
 app.include_router(admin_profiles_router)
 app.include_router(configs_router)
 app.include_router(admin_router)

--- a/server/routes/__init__.py
+++ b/server/routes/__init__.py
@@ -10,6 +10,7 @@ from .ui.configs import router as configs_router
 from .ui.admin import router as admin_router
 from .ui.audit import router as audit_router
 from .ui.admin_debug import router as admin_debug_router
+from .ui.sync_diagnostics import router as sync_diagnostics_router
 from .ui.welcome import router as welcome_router
 from .ui.device_types import router as device_types_router
 from .ui.network import router as network_router
@@ -51,6 +52,7 @@ __all__ = [
     "admin_router",
     "audit_router",
     "admin_debug_router",
+    "sync_diagnostics_router",
     "welcome_router",
     "device_types_router",
     "network_router",

--- a/server/routes/ui/sync_diagnostics.py
+++ b/server/routes/ui/sync_diagnostics.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Request, Depends
+from sqlalchemy.orm import Session
+
+from core.utils.auth import require_role
+from core.utils.db_session import get_db
+from core.models.models import SystemTunable
+from core.utils.templates import templates
+
+router = APIRouter()
+
+
+@router.get("/admin/sync")
+async def sync_diagnostics(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    tunables = {t.name: t.value for t in db.query(SystemTunable).all()}
+    context = {
+        "request": request,
+        "tunables": tunables,
+        "current_user": current_user,
+    }
+    return templates.TemplateResponse("sync_diagnostics.html", context)

--- a/server/workers/cloud_sync.py
+++ b/server/workers/cloud_sync.py
@@ -94,9 +94,15 @@ def start_cloud_sync(app):
     @app.on_event("startup")
     async def start_worker():
         role = os.environ.get("ROLE", "local")
-        if os.environ.get("ENABLE_CLOUD_SYNC") == "1" and role != "cloud":
+        enabled = os.environ.get("ENABLE_CLOUD_SYNC") == "1"
+        if enabled and role == "cloud":
+            raise RuntimeError("cloud_sync worker should not run in cloud role")
+        if enabled and role != "cloud":
+            print("Starting cloud sync worker")
             global _sync_task
             _sync_task = asyncio.create_task(_sync_loop())
+        else:
+            print("Cloud sync worker disabled")
 
 
 async def stop_cloud_sync() -> None:

--- a/server/workers/sync_pull_worker.py
+++ b/server/workers/sync_pull_worker.py
@@ -129,11 +129,15 @@ _sync_task: asyncio.Task | None = None
 def start_sync_pull_worker(app):
     @app.on_event("startup")
     async def start_worker():
-        if os.environ.get("ENABLE_SYNC_PULL_WORKER") != "1":
-            return
+        enabled = os.environ.get("ENABLE_SYNC_PULL_WORKER") == "1"
         role = os.environ.get("ROLE", "local")
-        if role == "cloud":
+        if not enabled:
+            print("Sync pull worker disabled")
             return
+        if role == "cloud":
+            print("Sync pull worker not started in cloud role")
+            return
+        print("Starting sync pull worker")
         global _sync_task
         _sync_task = asyncio.create_task(_pull_loop())
 

--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -86,11 +86,15 @@ _sync_task: asyncio.Task | None = None
 def start_sync_push_worker(app):
     @app.on_event("startup")
     async def start_worker():
-        if os.environ.get("ENABLE_SYNC_PUSH_WORKER") != "1":
-            return
+        enabled = os.environ.get("ENABLE_SYNC_PUSH_WORKER") == "1"
         role = os.environ.get("ROLE", "local")
-        if role == "cloud":
+        if not enabled:
+            print("Sync push worker disabled")
             return
+        if role == "cloud":
+            print("Sync push worker not started in cloud role")
+            return
+        print("Starting sync push worker")
         global _sync_task
         _sync_task = asyncio.create_task(_push_loop())
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import importlib
+from unittest import mock
+from fastapi.testclient import TestClient
+
+
+def get_app(role: str):
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    os.environ["ROLE"] = role
+    os.environ["ENABLE_SYNC_PUSH_WORKER"] = "1"
+    os.environ["ENABLE_SYNC_PULL_WORKER"] = "1"
+    for m in list(sys.modules):
+        if m.startswith("server"):
+            del sys.modules[m]
+    if "settings" in sys.modules:
+        del sys.modules["settings"]
+    with mock.patch("sqlalchemy.create_engine"), \
+         mock.patch("sqlalchemy.schema.MetaData.create_all"), \
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.cloud_sync.start_cloud_sync"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker") as start_push, \
+         mock.patch("server.workers.sync_pull_worker.start_sync_pull_worker") as start_pull:
+        app = importlib.import_module("server.main").app
+        return app, start_push, start_pull
+
+
+def test_cloud_role_disables_workers_and_mounts_routes():
+    app, start_push, start_pull = get_app("cloud")
+    assert start_push.call_count == 0
+    assert start_pull.call_count == 0
+    client = TestClient(app)
+    resp = client.post("/api/v1/sync/pull", json={"since": "now"})
+    assert resp.status_code == 200
+
+
+def test_local_role_starts_workers_and_hides_sync_routes():
+    app, start_push, start_pull = get_app("local")
+    assert start_push.called
+    assert start_pull.called
+    client = TestClient(app)
+    resp = client.post("/api/v1/sync/pull", json={"since": "now"})
+    assert resp.status_code == 404

--- a/web-client/templates/sync_diagnostics.html
+++ b/web-client/templates/sync_diagnostics.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Sync Diagnostics</h1>
+<ul class="list-disc ml-6">
+  <li>Last Push: {{ tunables.get('Last Sync Push', 'never') }}</li>
+  <li>Last Pull: {{ tunables.get('Last Sync Pull', 'never') }}</li>
+  <li>Last Push Worker: {{ tunables.get('Last Sync Push Worker', 'never') }}</li>
+  <li>Last Pull Worker: {{ tunables.get('Last Sync Pull Worker', 'never') }}</li>
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add sync diagnostics UI
- register diagnostics and sync API only in cloud mode
- log enabled components on startup
- guard sync workers from running in wrong role
- test role-based startup behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685097366aa08324986842cb346c15dd