### PR TITLE
Add device list screen to mobile app

### DIFF
--- a/mobile-client/App.tsx
+++ b/mobile-client/App.tsx
@@ -5,6 +5,7 @@ import HomeScreen from './screens/HomeScreen';
 import LoginScreen from './screens/LoginScreen';
 import RegisterScreen from './screens/RegisterScreen';
 import ProfileScreen from './screens/ProfileScreen';
+import DeviceListScreen from './screens/DeviceListScreen';
 import { AuthProvider } from './context/AuthContext';
 import AuthContext from './context/AuthContext';
 
@@ -28,6 +29,7 @@ function AppNavigator() {
         ) : (
           <>
             <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen name="Devices" component={DeviceListScreen} />
             <Stack.Screen name="Profile" component={ProfileScreen} />
           </>
         )}

--- a/mobile-client/screens/DeviceListScreen.tsx
+++ b/mobile-client/screens/DeviceListScreen.tsx
@@ -1,0 +1,130 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  ActivityIndicator,
+  StyleSheet,
+  RefreshControl,
+  TextInput,
+} from 'react-native';
+import { fetchDevices, Device } from '../services/devices';
+
+export default function DeviceListScreen() {
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [search, setSearch] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await fetchDevices();
+      setDevices(data);
+    } catch (err) {
+      console.error('Device fetch failed', err);
+      setError('Failed to load devices');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    try {
+      const data = await fetchDevices();
+      setDevices(data);
+    } catch (err) {
+      console.error('Device fetch failed', err);
+      setError('Failed to load devices');
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const filtered = devices.filter((d) =>
+    d.hostname.toLowerCase().includes(search.toLowerCase())
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Text>{error}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        style={styles.search}
+        placeholder="Search"
+        value={search}
+        onChangeText={setSearch}
+      />
+      <FlatList
+        data={filtered}
+        keyExtractor={(item) => String(item.id)}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }
+        renderItem={({ item }) => (
+          <View style={styles.card}>
+            <Text style={styles.host}>{item.hostname}</Text>
+            <Text style={styles.detail}>{item.ip}</Text>
+            {item.device_type && (
+              <Text style={styles.detail}>{item.device_type}</Text>
+            )}
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  card: {
+    padding: 12,
+    marginBottom: 8,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#ccc',
+  },
+  host: {
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  detail: {
+    color: '#555',
+  },
+  search: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
+  },
+});

--- a/mobile-client/screens/HomeScreen.tsx
+++ b/mobile-client/screens/HomeScreen.tsx
@@ -17,6 +17,10 @@ export default function HomeScreen() {
   return (
     <View style={{ flex: 1 }}>
       <StatusMessage status={status} />
+      <Button
+        title="Devices"
+        onPress={() => navigation.navigate('Devices' as never)}
+      />
       <Button title="Profile" onPress={() => navigation.navigate('Profile' as never)} />
     </View>
   );

--- a/mobile-client/services/devices.ts
+++ b/mobile-client/services/devices.ts
@@ -1,0 +1,17 @@
+import { apiGet } from './api';
+
+export interface Device {
+  id: number;
+  hostname: string;
+  ip: string;
+  device_type?: string;
+}
+
+export async function fetchDevices(search?: string): Promise<Device[]> {
+  let path = '/api/devices';
+  if (search) {
+    const params = new URLSearchParams({ search });
+    path += `?${params.toString()}`;
+  }
+  return apiGet(path);
+}


### PR DESCRIPTION
## Summary
- enable navigation to new Devices screen in the mobile app
- list devices from `/api/devices` with refresh and search
- provide a small service helper for fetching devices
- link to the new screen from the Home page

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509c38ee7c8324a1f714687b932578