### PR TITLE
Add cloud compose setup

### DIFF
--- a/deploy/docker/.env.cloud
+++ b/deploy/docker/.env.cloud
@@ -1,0 +1,8 @@
+# Example configuration for the central cloud server
+ROLE=cloud
+DATABASE_URL=postgresql://masteruser:masterpass@db:5432/master_ip_cloud
+SECRET_KEY=change-me
+ENABLE_BACKGROUND_WORKERS=0
+ENABLE_CLOUD_SYNC=0
+ENABLE_SYNC_PUSH_WORKER=0
+ENABLE_SYNC_PULL_WORKER=0

--- a/deploy/docker/docker-compose.cloud.yml
+++ b/deploy/docker/docker-compose.cloud.yml
@@ -9,30 +9,35 @@ services:
       POSTGRES_PASSWORD: masterpass
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
+    expose:
+      - "5432"
 
-  web:
+  app:
     build:
       context: ../..
     command: ./start.sh
+    env_file:
+      - .env.cloud
+    environment:
+      ROLE: cloud
     depends_on:
       - db
-    environment:
-      DATABASE_URL: postgresql://masteruser:masterpass@db:5432/master_ip_cloud
-      ROLE: cloud
-    ports:
-      - "8000:8000"
+    volumes:
+      - ../../alembic:/app/alembic
+      - logs:/app/logs
+    expose:
+      - "8000"
 
   nginx:
     image: nginx:latest
     ports:
       - "443:443"
     volumes:
-      - ../../nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ../../nginx/cloud.conf:/etc/nginx/conf.d/default.conf:ro
       - ../../nginx/certs:/etc/nginx/certs:ro
     depends_on:
-      - web
+      - app
 
 volumes:
   postgres_data:
+  logs:

--- a/nginx/cloud.conf
+++ b/nginx/cloud.conf
@@ -1,0 +1,24 @@
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate /etc/nginx/certs/selfsigned.crt;
+    ssl_certificate_key /etc/nginx/certs/selfsigned.key;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    location / {
+        proxy_pass http://app:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /static/ {
+        proxy_pass http://app:8000/static/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- create docker compose stack for cloud role
- add sample `.env.cloud`
- add nginx config referencing `app` service

## Testing
- `pytest -q`
- `docker compose -f deploy/docker/docker-compose.cloud.yml config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509e7344b083249707a23078524e50