### PR TITLE
Add sync and mobile API tests

### DIFF
--- a/tests/mobile/test_device_api.py
+++ b/tests/mobile/test_device_api.py
@@ -1,0 +1,137 @@
+import os
+import sys
+import importlib
+from unittest import mock
+
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class DummyQuery:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def filter_by(self, **kw):
+        for k, v in kw.items():
+            self.items = [i for i in self.items if getattr(i, k) == v]
+        return self
+
+    def offset(self, n):
+        self.items = self.items[n:]
+        return self
+
+    def limit(self, n):
+        self.items = self.items[:n]
+        return self
+
+    def all(self):
+        return list(self.items)
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+
+class DummyDB:
+    def __init__(self, devices=True):
+        with mock.patch("sqlalchemy.create_engine"), \
+             mock.patch("sqlalchemy.schema.MetaData.create_all"):
+            models = importlib.import_module("core.models.models")
+            import bcrypt
+        self.models = models
+        device_list = []
+        if devices:
+            device_list = [
+                models.Device(id=1, hostname="s1", ip="1.1.1.1", manufacturer="cisco", model="x", version=1),
+                models.Device(id=2, hostname="s2", ip="2.2.2.2", manufacturer="juniper", model="y", version=1),
+            ]
+        self.data = {
+            models.User: [
+                models.User(
+                    id=1,
+                    email="viewer@example.com",
+                    hashed_password=bcrypt.hashpw(b"secret", bcrypt.gensalt()).decode(),
+                    role="viewer",
+                    is_active=True,
+                    version=1,
+                )
+            ],
+            models.Device: device_list,
+        }
+
+    def query(self, model):
+        return DummyQuery(self.data.get(model, []))
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+    def add(self, obj):
+        self.data.setdefault(type(obj), []).append(obj)
+
+
+def override_get_db(db):
+    def _override():
+        try:
+            yield db
+        finally:
+            pass
+    return _override
+
+
+def get_app(role: str, db: DummyDB):
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    os.environ["ROLE"] = role
+    if "settings" in sys.modules:
+        del sys.modules["settings"]
+    for m in list(sys.modules):
+        if m.startswith("server"):
+            del sys.modules[m]
+    with mock.patch("sqlalchemy.create_engine"), \
+         mock.patch("sqlalchemy.schema.MetaData.create_all"), \
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"), \
+         mock.patch("server.workers.sync_pull_worker.start_sync_pull_worker"), \
+         mock.patch("server.workers.cloud_sync.start_cloud_sync"):
+        app = importlib.import_module("server.main").app
+    app.dependency_overrides[importlib.import_module("core.utils.db_session").get_db] = override_get_db(db)
+    return app
+
+
+@pytest.mark.parametrize("role", ["local", "cloud"])
+def test_mobile_login_and_fetch_devices(role):
+    db = DummyDB(devices=True)
+    app = get_app(role, db)
+    client = TestClient(app)
+    resp = client.post("/auth/token", data={"email": "viewer@example.com", "password": "secret"})
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    resp = client.get("/api/v1/devices", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+
+def test_mobile_fetch_devices_empty():
+    db = DummyDB(devices=False)
+    app = get_app("local", db)
+    client = TestClient(app)
+    resp = client.post("/auth/token", data={"email": "viewer@example.com", "password": "secret"})
+    token = resp.json()["access_token"]
+    resp = client.get("/api/v1/devices", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_mobile_unauthenticated():
+    db = DummyDB(devices=True)
+    app = get_app("local", db)
+    client = TestClient(app)
+    resp = client.get("/api/v1/devices")
+    assert resp.status_code == 401

--- a/tests/test_sync_logic.py
+++ b/tests/test_sync_logic.py
@@ -1,0 +1,178 @@
+import os
+import sys
+import importlib
+from unittest import mock
+
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class DummyQuery:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def filter_by(self, **kw):
+        for k, v in kw.items():
+            self.items = [i for i in self.items if getattr(i, k) == v]
+        return self
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+    def all(self):
+        return list(self.items)
+
+
+class DummyDB:
+    def __init__(self):
+        with mock.patch("sqlalchemy.create_engine"), \
+             mock.patch("sqlalchemy.schema.MetaData.create_all"):
+            models = importlib.import_module("core.models.models")
+            import bcrypt
+        self.models = models
+        self.data = {
+            models.User: [
+                models.User(
+                    id=1,
+                    email="viewer@example.com",
+                    hashed_password=bcrypt.hashpw(b"secret", bcrypt.gensalt()).decode(),
+                    role="viewer",
+                    is_active=True,
+                    version=1,
+                ),
+            ],
+        }
+
+    def query(self, model):
+        return DummyQuery(self.data.get(model, []))
+
+    def add(self, obj):
+        self.data.setdefault(type(obj), []).append(obj)
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+    def rollback(self):
+        pass
+
+
+def override_get_db(db):
+    def _override():
+        try:
+            yield db
+        finally:
+            pass
+    return _override
+
+
+def get_app(role: str, db: DummyDB):
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    os.environ["ROLE"] = role
+    if "settings" in sys.modules:
+        del sys.modules["settings"]
+    for m in list(sys.modules):
+        if m.startswith("server"):
+            del sys.modules[m]
+    with mock.patch("sqlalchemy.create_engine"), \
+         mock.patch("sqlalchemy.schema.MetaData.create_all"), \
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"), \
+         mock.patch("server.workers.sync_pull_worker.start_sync_pull_worker"), \
+         mock.patch("server.workers.cloud_sync.start_cloud_sync"):
+        app = importlib.import_module("server.main").app
+    app.dependency_overrides[importlib.import_module("core.utils.db_session").get_db] = override_get_db(db)
+    return app
+
+
+@pytest.fixture
+def client_cloud():
+    db = DummyDB()
+    app = get_app("cloud", db)
+    client = TestClient(app)
+    client.db = db
+    return client
+
+
+@pytest.fixture
+def client_local():
+    db = DummyDB()
+    app = get_app("local", db)
+    client = TestClient(app)
+    client.db = db
+    return client
+
+
+def test_push_updates_version_and_records(client_cloud):
+    payload = {
+        "model": "users",
+        "records": [
+            {
+                "id": 1,
+                "email": "viewer@example.com",
+                "hashed_password": "x",
+                "role": "viewer",
+                "is_active": True,
+                "version": 1,
+            }
+        ],
+    }
+    resp = client_cloud.post("/api/v1/sync/push", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["accepted"] == 1
+    assert data["conflicts"] == 0
+    assert data["skipped"] == 0
+    user = client_cloud.db.data[client_cloud.db.models.User][0]
+    assert user.version == 2
+
+
+def test_push_conflict_and_skip(client_cloud):
+    payload = {
+        "model": "users",
+        "records": [
+            {
+                "id": 1,
+                "email": "changed@example.com",
+                "hashed_password": "x",
+                "role": "viewer",
+                "is_active": True,
+                "version": 0,
+            },
+            {
+                "id": 2,
+                "role": "viewer",
+                "hashed_password": "x",
+                "is_active": True,
+                "version": 1,
+            },
+        ],
+    }
+    resp = client_cloud.post("/api/v1/sync/push", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["accepted"] == 0
+    assert data["conflicts"] == 1
+    assert data["skipped"] == 1
+    user = client_cloud.db.data[client_cloud.db.models.User][0]
+    assert user.version == 2
+    assert user.conflict_data is not None
+
+
+def test_pull_endpoint_cloud(client_cloud):
+    resp = client_cloud.post("/api/v1/sync/pull", json={"since": "now"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pulled"
+
+
+def test_pull_endpoint_hidden_in_local_role(client_local):
+    resp = client_local.post("/api/v1/sync/pull", json={"since": "now"})
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add comprehensive tests for sync logic covering push & pull endpoints
- add mobile interaction tests for auth flow and device retrieval
- ensure DATABASE_URL for tests and patch environment

## Testing
- `pytest -q`
- `pytest --cov=server.routes.api.sync -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a175505c8324b5c8bd7b0f22837c