### PR TITLE
Add sync worker and API tests

### DIFF
--- a/tests/api/test_sync_endpoints.py
+++ b/tests/api/test_sync_endpoints.py
@@ -1,0 +1,178 @@
+import os
+import sys
+import importlib
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class DummyQuery:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def filter_by(self, **kw):
+        for k, v in kw.items():
+            self.items = [i for i in self.items if getattr(i, k) == v]
+        return self
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+    def all(self):
+        return list(self.items)
+
+
+class DummyDB:
+    def __init__(self):
+        with mock.patch("sqlalchemy.create_engine"), mock.patch(
+            "sqlalchemy.schema.MetaData.create_all"
+        ):
+            models = importlib.import_module("core.models.models")
+            import bcrypt
+        self.models = models
+        self.data = {
+            models.User: [
+                models.User(
+                    id=1,
+                    email="viewer@example.com",
+                    hashed_password=bcrypt.hashpw(b"secret", bcrypt.gensalt()).decode(),
+                    role="viewer",
+                    is_active=True,
+                    version=1,
+                )
+            ],
+        }
+
+    def query(self, model):
+        return DummyQuery(self.data.get(model, []))
+
+    def add(self, obj):
+        self.data.setdefault(type(obj), []).append(obj)
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+    def rollback(self):
+        pass
+
+
+def override_get_db(db):
+    def _override():
+        try:
+            yield db
+        finally:
+            pass
+
+    return _override
+
+
+def get_app(role: str, db: DummyDB):
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    os.environ["ROLE"] = role
+    if "settings" in sys.modules:
+        del sys.modules["settings"]
+    for m in list(sys.modules):
+        if m.startswith("server"):
+            del sys.modules[m]
+    with mock.patch("sqlalchemy.create_engine"), mock.patch(
+        "sqlalchemy.schema.MetaData.create_all"
+    ), mock.patch("server.workers.queue_worker.start_queue_worker"), mock.patch(
+        "server.workers.config_scheduler.start_config_scheduler"
+    ), mock.patch(
+        "server.workers.trap_listener.setup_trap_listener"
+    ), mock.patch(
+        "server.workers.syslog_listener.setup_syslog_listener"
+    ), mock.patch(
+        "server.workers.sync_push_worker.start_sync_push_worker"
+    ), mock.patch(
+        "server.workers.sync_pull_worker.start_sync_pull_worker"
+    ), mock.patch(
+        "server.workers.cloud_sync.start_cloud_sync"
+    ):
+        app = importlib.import_module("server.main").app
+    app.dependency_overrides[importlib.import_module("core.utils.db_session").get_db] = override_get_db(db)
+    return app
+
+
+@pytest.fixture
+def client_cloud():
+    db = DummyDB()
+    app = get_app("cloud", db)
+    client = TestClient(app)
+    client.db = db
+    return client
+
+
+@pytest.fixture
+def client_local():
+    db = DummyDB()
+    app = get_app("local", db)
+    client = TestClient(app)
+    client.db = db
+    return client
+
+
+@pytest.mark.integration
+def test_push_valid_update_and_conflict(client_cloud):
+    models = client_cloud.db.models
+    payload = {
+        "model": models.User.__tablename__,
+        "records": [
+            {
+                "id": 1,
+                "email": "viewer2@example.com",
+                "hashed_password": "x",
+                "role": "viewer",
+                "is_active": True,
+                "version": 1,
+            },
+            {
+                "id": 2,
+                "email": "new@example.com",
+                "hashed_password": "x",
+                "role": "viewer",
+                "is_active": True,
+                "version": 0,
+            },
+        ],
+    }
+    resp = client_cloud.post("/api/v1/sync/push", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["accepted"] == 2
+    assert data["conflicts"] == 0
+    assert data["skipped"] == 0
+    user = client_cloud.db.data[models.User][0]
+    assert user.email == "viewer2@example.com"
+    assert user.version == 2
+
+
+@pytest.mark.integration
+def test_push_missing_fields(client_cloud):
+    payload = {"model": client_cloud.db.models.User.__tablename__, "records": [{"id": 1}]}
+    resp = client_cloud.post("/api/v1/sync/push", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["skipped"] == 1
+
+
+@pytest.mark.integration
+def test_push_invalid_model(client_cloud):
+    resp = client_cloud.post("/api/v1/sync/push", json={"model": "bad", "records": []})
+    assert resp.status_code == 400
+
+
+@pytest.mark.integration
+def test_pull_endpoint_cloud(client_cloud):
+    resp = client_cloud.post("/api/v1/sync/pull", json={"since": "now"})
+    assert resp.status_code == 200
+
+
+@pytest.mark.integration
+@pytest.mark.cloud_only
+def test_pull_endpoint_hidden_in_local_role(client_local):
+    resp = client_local.post("/api/v1/sync/pull", json={"since": "now"})
+    assert resp.status_code == 404

--- a/tests/workers/test_sync_pull_worker.py
+++ b/tests/workers/test_sync_pull_worker.py
@@ -1,0 +1,134 @@
+import asyncio
+import importlib
+from unittest import mock
+from datetime import datetime, timedelta
+
+import pytest
+
+from server.workers import sync_pull_worker
+
+
+class DummyQuery:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def filter_by(self, **kw):
+        for k, v in kw.items():
+            self.items = [i for i in self.items if getattr(i, k) == v]
+        return self
+
+    def filter(self, expr):
+        from sqlalchemy.sql import operators
+        col = expr.left.key
+        val = expr.right.value
+        if expr.operator == operators.eq:
+            self.items = [i for i in self.items if getattr(i, col) == val]
+        return self
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+    def all(self):
+        return list(self.items)
+
+
+class DummyDB:
+    def __init__(self):
+        with mock.patch("sqlalchemy.create_engine"), mock.patch(
+            "sqlalchemy.schema.MetaData.create_all"
+        ):
+            models = importlib.import_module("core.models.models")
+            import bcrypt
+        self.models = models
+        self.data = {
+            models.User: [
+                models.User(
+                    id=1,
+                    email="viewer@example.com",
+                    hashed_password=bcrypt.hashpw(b"secret", bcrypt.gensalt()).decode(),
+                    role="viewer",
+                    is_active=True,
+                    version=1,
+                )
+            ],
+            models.SystemTunable: [
+                models.SystemTunable(
+                    name="Last Sync Pull Worker",
+                    value=(datetime.utcnow() - timedelta(days=1)).isoformat(),
+                    function="Sync",
+                    file_type="application",
+                    data_type="text",
+                )
+            ],
+        }
+
+    def query(self, model):
+        return DummyQuery(self.data.get(model, []))
+
+    def add(self, obj):
+        self.data.setdefault(type(obj), []).append(obj)
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.mark.unit
+def test_pull_once_updates_and_inserts(monkeypatch):
+    db = DummyDB()
+    models = db.models
+    old_value = db.data[models.SystemTunable][0].value
+
+    sample = [
+        {
+            "model": models.User.__tablename__,
+            "id": 1,
+            "email": "changed@example.com",
+            "hashed_password": "x",
+            "role": "viewer",
+            "is_active": True,
+            "version": 1,
+        },
+        {
+            "model": models.User.__tablename__,
+            "id": 2,
+            "email": "new@example.com",
+            "hashed_password": "x",
+            "role": "viewer",
+            "is_active": True,
+            "version": 1,
+        },
+        {
+            "model": models.User.__tablename__,
+            "id": 1,
+            "email": "conflict@example.com",
+            "hashed_password": "x",
+            "role": "viewer",
+            "is_active": True,
+            "version": 0,
+        },
+    ]
+
+    monkeypatch.setattr(sync_pull_worker, "SessionLocal", lambda: db)
+
+    async def fake_fetch(url, payload, log):
+        return sample
+
+    monkeypatch.setattr(sync_pull_worker, "_fetch_with_retry", fake_fetch)
+
+    asyncio.run(sync_pull_worker.pull_once(mock.Mock()))
+
+    assert len(db.data[models.User]) == 2
+    user = db.data[models.User][0]
+    assert user.email == "changed@example.com"
+    assert user.version == 3
+    assert user.conflict_data is not None
+    assert db.data[models.SystemTunable][0].value != old_value

--- a/tests/workers/test_sync_push_worker.py
+++ b/tests/workers/test_sync_push_worker.py
@@ -1,0 +1,146 @@
+import asyncio
+import importlib
+from unittest import mock
+from datetime import datetime, timedelta
+
+import httpx
+import pytest
+
+from server.workers import sync_push_worker
+from server.workers import cloud_sync
+
+
+class DummyQuery:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def filter(self, expr):
+        from sqlalchemy.sql import operators
+        if hasattr(expr, "clauses"):
+            clauses = list(expr.clauses)
+        else:
+            clauses = [expr]
+
+        def matches(obj, clause):
+            col = clause.left.key
+            val = clause.right.value
+            if clause.operator == operators.gt:
+                return getattr(obj, col) > val
+            if clause.operator == operators.eq:
+                return getattr(obj, col) == val
+            return False
+
+        self.items = [i for i in self.items if any(matches(i, c) for c in clauses)]
+        return self
+
+    def filter_by(self, **kw):
+        for k, v in kw.items():
+            self.items = [i for i in self.items if getattr(i, k) == v]
+        return self
+
+    def all(self):
+        return list(self.items)
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+
+class DummyDB:
+    def __init__(self):
+        with mock.patch("sqlalchemy.create_engine"), mock.patch(
+            "sqlalchemy.schema.MetaData.create_all"
+        ):
+            models = importlib.import_module("core.models.models")
+        self.models = models
+        self.data = {
+            models.Device: [],
+            models.SystemTunable: [
+                models.SystemTunable(
+                    name="Last Sync Push Worker",
+                    value=(datetime.utcnow() - timedelta(days=1)).isoformat(),
+                    function="Sync",
+                    file_type="application",
+                    data_type="text",
+                )
+            ],
+        }
+
+    def query(self, model):
+        return DummyQuery(self.data.get(model, []))
+
+    def add(self, obj):
+        self.data.setdefault(type(obj), []).append(obj)
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.mark.unit
+def test_push_once_sends_unsynced_records(monkeypatch):
+    db = DummyDB()
+    models = db.models
+    now = datetime.utcnow()
+    dev = models.Device(
+        id=1,
+        hostname="dev",
+        ip="1.1.1.1",
+        manufacturer="cisco",
+        device_type_id=1,
+        created_at=now,
+        updated_at=now,
+        version=1,
+    )
+    db.data[models.Device].append(dev)
+    old_value = db.data[models.SystemTunable][0].value
+
+    monkeypatch.setattr(sync_push_worker, "SessionLocal", lambda: db)
+    sent = {}
+
+    async def fake_request(method, url, payload, log):
+        sent["payload"] = payload
+
+    monkeypatch.setattr(sync_push_worker, "_request_with_retry", fake_request)
+
+    asyncio.run(sync_push_worker.push_once(mock.Mock()))
+
+    assert sent["payload"]["model"] == models.Device.__tablename__
+    assert len(sent["payload"]["records"]) == 1
+    assert db.data[models.SystemTunable][0].value != old_value
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_request_with_retry_retries(monkeypatch):
+    calls = []
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def request(self, method, url, json=None, headers=None):
+            calls.append(1)
+            if len(calls) == 1:
+                raise httpx.HTTPError("fail")
+
+            class R:
+                def raise_for_status(self2):
+                    pass
+
+            return R()
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=None: FakeClient())
+    log = mock.Mock()
+    await cloud_sync._request_with_retry("POST", "http://example", {}, log)
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- add unit tests for sync push/pull workers
- cover sync API endpoints with more scenarios
- separate test markers for unit, integration and cloud-only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a45b8e788324b0cd43024a28f986