### PR TITLE
Implement phase 6 sync improvements

### DIFF
--- a/alembic/versions/0005_add_more_version_fields.py
+++ b/alembic/versions/0005_add_more_version_fields.py
@@ -1,0 +1,24 @@
+"""add version/conflict fields to more tables"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0005'
+down_revision = '0004'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    tables = ['locations', 'device_types', 'sites', 'tags']
+    for table in tables:
+        op.add_column(table, sa.Column('version', sa.Integer(), nullable=False, server_default='1'))
+        op.add_column(table, sa.Column('conflict_data', postgresql.JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    tables = ['locations', 'device_types', 'sites', 'tags']
+    for table in tables:
+        op.drop_column(table, 'conflict_data')
+        op.drop_column(table, 'version')

--- a/core/models/models.py
+++ b/core/models/models.py
@@ -57,6 +57,8 @@ class Location(Base):
     __tablename__ = "locations"
 
     id = Column(Integer, primary_key=True)
+    version = Column(Integer, default=1, nullable=False)
+    conflict_data = Column(JSON, nullable=True)
     name = Column(String, unique=True, nullable=False)
     location_type = Column(String, nullable=False, default="Fixed")
 
@@ -67,6 +69,8 @@ class DeviceType(Base):
     __tablename__ = "device_types"
 
     id = Column(Integer, primary_key=True)
+    version = Column(Integer, default=1, nullable=False)
+    conflict_data = Column(JSON, nullable=True)
     name = Column(String, unique=True, nullable=False)
 
     devices = relationship("Device", back_populates="device_type")
@@ -76,6 +80,8 @@ class Site(Base):
     __tablename__ = "sites"
 
     id = Column(Integer, primary_key=True)
+    version = Column(Integer, default=1, nullable=False)
+    conflict_data = Column(JSON, nullable=True)
     name = Column(String, unique=True, nullable=False)
     description = Column(Text, nullable=True)
     created_by_id = Column(Integer, ForeignKey("users.id"), nullable=True)
@@ -108,6 +114,8 @@ class Tag(Base):
     __tablename__ = "tags"
 
     id = Column(Integer, primary_key=True)
+    version = Column(Integer, default=1, nullable=False)
+    conflict_data = Column(JSON, nullable=True)
     name = Column(String, unique=True, nullable=False)
 
     devices = relationship("Device", secondary=device_tags, back_populates="tags")

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -139,3 +139,89 @@ class UserUpdate(BaseModel):
     role: str | None = None
     is_active: bool | None = None
     version: int | None = None
+
+
+class TagBase(BaseSchema):
+    name: str
+
+
+class TagCreate(BaseModel):
+    name: str
+
+
+class TagRead(TagBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class TagUpdate(BaseModel):
+    name: str | None = None
+    version: int | None = None
+
+
+class DeviceTypeBase(BaseSchema):
+    name: str
+
+
+class DeviceTypeCreate(BaseModel):
+    name: str
+
+
+class DeviceTypeRead(DeviceTypeBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class DeviceTypeUpdate(BaseModel):
+    name: str | None = None
+    version: int | None = None
+
+
+class LocationBase(BaseSchema):
+    name: str
+    location_type: str = "Fixed"
+
+
+class LocationCreate(BaseModel):
+    name: str
+    location_type: str = "Fixed"
+
+
+class LocationRead(LocationBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class LocationUpdate(BaseModel):
+    name: str | None = None
+    location_type: str | None = None
+    version: int | None = None
+
+
+class SiteBase(BaseSchema):
+    name: str
+    description: str | None = None
+
+
+class SiteCreate(BaseModel):
+    name: str
+    description: str | None = None
+
+
+class SiteRead(SiteBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class SiteUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    version: int | None = None

--- a/mobile-client/README.md
+++ b/mobile-client/README.md
@@ -1,6 +1,6 @@
 # Mobile Client
 
-This directory contains a lightweight React Native application using Expo. It performs a simple health check against the FastAPI server on launch.
+This directory contains a lightweight React Native application built with Expo. It allows logging in to the API server and viewing devices.
 
 ## Setup
 
@@ -18,4 +18,4 @@ This directory contains a lightweight React Native application using Expo. It pe
    npm start
    ```
 
-Use an Android or iOS emulator, or the Expo Go app on a device connected to the same LAN, to open the project. The home screen will display whether the API server responded to `/api/ping`.
+Use an Android or iOS emulator, or the Expo Go app on a device connected to the same LAN, to open the project. After logging in you can browse the device list which is loaded from the FastAPI `/api/v1/devices` endpoint.

--- a/mobile-client/services/devices.ts
+++ b/mobile-client/services/devices.ts
@@ -8,7 +8,7 @@ export interface Device {
 }
 
 export async function fetchDevices(search?: string): Promise<Device[]> {
-  let path = '/api/devices';
+  let path = '/api/v1/devices';
   if (search) {
     const params = new URLSearchParams({ search });
     path += `?${params.toString()}`;

--- a/server/routes/api/sync.py
+++ b/server/routes/api/sync.py
@@ -16,9 +16,56 @@ async def sync_payload(
     payload: dict[str, Any] = Body(...),
     db: Session = Depends(get_db),
 ):
-    """Accept a batch of updates from another site and return success."""
-    # Real conflict resolution will be added in future versions.
-    return {"status": "received", "count": len(payload)}
+    """Accept a batch of updates for multiple models."""
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Invalid payload")
+
+    model_map = {cls.__tablename__: cls for cls in model_module.Base.__subclasses__()}
+    accepted = 0
+    skipped = 0
+    conflicts = 0
+
+    for model_name, records in payload.items():
+        model_cls = model_map.get(model_name)
+        if not model_cls or not isinstance(records, list):
+            skipped += len(records) if isinstance(records, list) else 1
+            continue
+
+        insp = inspect(model_cls)
+        required_cols = [
+            c.key
+            for c in insp.columns
+            if not c.nullable and not c.primary_key and c.default is None and c.server_default is None
+        ]
+
+        for rec in records:
+            if not isinstance(rec, dict) or "id" not in rec or "version" not in rec:
+                skipped += 1
+                continue
+            try:
+                obj = db.query(model_cls).filter_by(id=rec["id"]).first()
+                if obj:
+                    update = {k: v for k, v in rec.items() if k not in {"id", "version"}}
+                    conf = apply_update(obj, update, incoming_version=rec["version"])
+                    if conf:
+                        conflicts += 1
+                    else:
+                        accepted += 1
+                else:
+                    if any(field not in rec for field in required_cols):
+                        skipped += 1
+                        continue
+                    obj = model_cls(**rec)
+                    db.add(obj)
+                    accepted += 1
+                db.commit()
+                db.refresh(obj)
+            except Exception as exc:  # pragma: no cover - safety
+                db.rollback()
+                logging.getLogger(__name__).error("Error processing %s id %s: %s", model_name, rec.get("id"), exc)
+                skipped += 1
+
+    return {"accepted": accepted, "conflicts": conflicts, "skipped": skipped}
 
 
 @router.post("/push")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -82,10 +82,33 @@ app.dependency_overrides[importlib.import_module("core.utils.db_session").get_db
 client = TestClient(app)
 
 
-def test_sync_endpoint_accepts_payload():
-    resp = client.post("/api/v1/sync", json={"devices": []})
+def test_sync_endpoint_processes_payload():
+    payload = {
+        "users": [
+            {
+                "id": 2,
+                "email": "new@example.com",
+                "hashed_password": "x",
+                "role": "viewer",
+                "is_active": True,
+                "version": 1,
+            },
+            {
+                "id": 1,
+                "email": "admin@example.com",
+                "hashed_password": "x",
+                "role": "admin",
+                "is_active": True,
+                "version": 0,
+            },
+        ]
+    }
+    resp = client.post("/api/v1/sync", json=payload)
     assert resp.status_code == 200
-    assert resp.json()["status"] == "received"
+    data = resp.json()
+    assert data["accepted"] == 1
+    assert data["conflicts"] == 1
+    assert data["skipped"] == 0
 
 
 def test_sync_push_endpoint():


### PR DESCRIPTION
## Summary
- add version/conflict columns to more models
- expand schemas for new versioned models
- handle multi-model payloads in `/api/v1/sync`
- correct mobile device API path and update README
- create alembic migration for new columns
- adjust sync tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850b51fed6883248289a8089c544f8a