### PR TITLE
Implement sync push/pull endpoints

### DIFF
--- a/server/routes/api/sync.py
+++ b/server/routes/api/sync.py
@@ -2,7 +2,8 @@ from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import Any
 import logging
-from sqlalchemy import inspect
+from sqlalchemy import inspect, or_
+from datetime import datetime
 
 from core.models import models as model_module
 from core.utils.versioning import apply_update
@@ -79,56 +80,76 @@ async def push_changes(
     if not isinstance(payload, dict):
         raise HTTPException(status_code=400, detail="Invalid payload")
 
-    model_name: str | None = payload.get("model")
-    records: list[dict[str, Any]] | None = payload.get("records")
-
-    if not model_name or not isinstance(records, list):
-        raise HTTPException(status_code=400, detail="Missing model or records")
-
     model_map = {cls.__tablename__: cls for cls in model_module.Base.__subclasses__()}
-    model_cls = model_map.get(model_name)
-    if not model_cls:
-        raise HTTPException(status_code=400, detail="Unknown model")
 
-    insp = inspect(model_cls)
-    required_cols = [
-        c.key
-        for c in insp.columns
-        if not c.nullable and not c.primary_key and c.default is None and c.server_default is None
-    ]
+    # Support multiple payload formats for backward compatibility
+    records_by_model: dict[str, list[dict[str, Any]]] = {}
+
+    if "records" in payload and isinstance(payload["records"], list):
+        # Either {"model": "name", "records": [...]} or {"records": [{"model": ..}]}
+        if isinstance(payload.get("model"), str):
+            records_by_model[payload["model"]] = payload["records"]
+        else:
+            for rec in payload["records"]:
+                if not isinstance(rec, dict):
+                    continue
+                model_name = rec.get("model")
+                if not model_name or model_name not in model_map:
+                    continue
+                records_by_model.setdefault(model_name, []).append(rec)
+    else:
+        # Legacy style: {"devices": [...], "users": [...], ...}
+        for model_name, records in payload.items():
+            if model_name in model_map and isinstance(records, list):
+                records_by_model[model_name] = records
+
+    if not records_by_model:
+        raise HTTPException(status_code=400, detail="Missing model or records")
 
     accepted = 0
     skipped = 0
     conflicts = 0
 
-    for rec in records:
-        if not isinstance(rec, dict) or "id" not in rec or "version" not in rec:
-            skipped += 1
+    for model_name, records in records_by_model.items():
+        model_cls = model_map.get(model_name)
+        if not model_cls:
+            skipped += len(records)
             continue
+        insp = inspect(model_cls)
+        required_cols = [
+            c.key
+            for c in insp.columns
+            if not c.nullable and not c.primary_key and c.default is None and c.server_default is None
+        ]
 
-        try:
-            obj = db.query(model_cls).filter_by(id=rec["id"]).first()
-            if obj:
-                update = {k: v for k, v in rec.items() if k not in {"id", "version"}}
-                conf = apply_update(obj, update, incoming_version=rec["version"])
-                if conf:
-                    conflicts += 1
-                    log.warning("Conflict on %s id %s", model_name, rec["id"])
+        for rec in records:
+            if not isinstance(rec, dict) or "id" not in rec or "version" not in rec:
+                skipped += 1
+                continue
+
+            try:
+                obj = db.query(model_cls).filter_by(id=rec["id"]).first()
+                if obj:
+                    update = {k: v for k, v in rec.items() if k not in {"id", "version", "model"}}
+                    conf = apply_update(obj, update, incoming_version=rec["version"], source="sync_push")
+                    if conf:
+                        conflicts += 1
+                        log.warning("Conflict on %s id %s", model_name, rec["id"])
+                    else:
+                        accepted += 1
                 else:
+                    if any(field not in rec for field in required_cols):
+                        skipped += 1
+                        continue
+                    obj = model_cls(**{k: v for k, v in rec.items() if k != "model"})
+                    db.add(obj)
                     accepted += 1
-            else:
-                if any(field not in rec for field in required_cols):
-                    skipped += 1
-                    continue
-                obj = model_cls(**{k: v for k, v in rec.items()})
-                db.add(obj)
-                accepted += 1
-            db.commit()
-            db.refresh(obj)
-        except Exception as exc:
-            db.rollback()
-            log.error("Error processing %s id %s: %s", model_name, rec.get("id"), exc)
-            skipped += 1
+                db.commit()
+                db.refresh(obj)
+            except Exception as exc:  # pragma: no cover - safety
+                db.rollback()
+                log.error("Error processing %s id %s: %s", model_name, rec.get("id"), exc)
+                skipped += 1
 
     return {"accepted": accepted, "conflicts": conflicts, "skipped": skipped}
 
@@ -138,7 +159,54 @@ async def pull_changes(
     payload: dict[str, Any] = Body(...),
     db: Session = Depends(get_db),
 ):
-    """Accept a request for updates from the cloud."""
+    """Return records updated since the provided timestamp."""
     log = logging.getLogger(__name__)
-    log.info("Received pull request: %s", list(payload.keys()))
-    return {"status": "pulled", "count": len(payload)}
+
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Invalid payload")
+
+    since_str = payload.get("since")
+    models = payload.get("models")
+    site_id = payload.get("site_id")
+
+    if not since_str or not isinstance(models, list):
+        raise HTTPException(status_code=400, detail="Missing since or models")
+
+    try:
+        since = datetime.fromisoformat(since_str)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid since timestamp")
+
+    model_map = {cls.__tablename__: cls for cls in model_module.Base.__subclasses__()}
+    results: list[dict[str, Any]] = []
+
+    for model_name in models:
+        model_cls = model_map.get(model_name)
+        if not model_cls:
+            log.warning("Unknown model requested: %s", model_name)
+            continue
+
+        insp = inspect(model_cls)
+        cols = insp.columns
+        query = db.query(model_cls)
+
+        created_col = getattr(model_cls, "created_at", None)
+        updated_col = getattr(model_cls, "updated_at", None)
+
+        if created_col is not None and updated_col is not None:
+            query = query.filter(or_(created_col > since, updated_col > since))
+        elif updated_col is not None:
+            query = query.filter(updated_col > since)
+        elif created_col is not None:
+            query = query.filter(created_col > since)
+        else:
+            continue  # no timestamp columns to filter
+
+        if site_id is not None and hasattr(model_cls, "site_id"):
+            query = query.filter(getattr(model_cls, "site_id") == site_id)
+
+        for obj in query.all():
+            data = {c.key: getattr(obj, c.key) for c in insp.mapper.column_attrs}
+            results.append({"model": model_name, **data})
+
+    return results

--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -60,7 +60,11 @@ async def push_once(log: logging.Logger) -> None:
         )
         if not records:
             return
-        payload = {"model": Device.__tablename__, "records": [_serialize(r) for r in records]}
+        payload = {
+            "records": [
+                {**_serialize(r), "model": Device.__tablename__} for r in records
+            ]
+        }
         await _request_with_retry("POST", SYNC_PUSH_URL, payload, log)
         _update_last_sync(db)
     finally:

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -3,6 +3,7 @@ import sys
 import importlib
 from unittest import mock
 from fastapi.testclient import TestClient
+from datetime import datetime
 
 
 def get_app(role: str):
@@ -33,7 +34,11 @@ def test_cloud_role_disables_workers_and_mounts_routes():
     assert start_push.call_count == 0
     assert start_pull.call_count == 0
     client = TestClient(app)
-    resp = client.post("/api/v1/sync/pull", json={"since": "now"})
+    ts = datetime.utcnow().isoformat()
+    resp = client.post(
+        "/api/v1/sync/pull",
+        json={"since": ts, "models": ["users"]},
+    )
     assert resp.status_code == 200
 
 
@@ -42,5 +47,6 @@ def test_local_role_starts_workers_and_hides_sync_routes():
     assert start_push.called
     assert start_pull.called
     client = TestClient(app)
-    resp = client.post("/api/v1/sync/pull", json={"since": "now"})
+    ts = datetime.utcnow().isoformat()
+    resp = client.post("/api/v1/sync/pull", json={"since": ts, "models": ["users"]})
     assert resp.status_code == 404

--- a/tests/workers/test_sync_push_worker.py
+++ b/tests/workers/test_sync_push_worker.py
@@ -112,8 +112,8 @@ def test_push_once_sends_unsynced_records(monkeypatch):
 
     asyncio.run(sync_push_worker.push_once(mock.Mock()))
 
-    assert sent["payload"]["model"] == models.Device.__tablename__
     assert len(sent["payload"]["records"]) == 1
+    assert sent["payload"]["records"][0]["model"] == models.Device.__tablename__
     assert db.data[models.SystemTunable][0].value != old_value
 
 


### PR DESCRIPTION
## Summary
- finish sync push implementation and support batched payloads
- implement pull endpoint to return changed records
- update sync push worker to send model names with records
- adjust unit tests for new sync API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685129b64fb8832488bf0b90f25c278f