### PR TITLE
Add UnoCSS template extraction

### DIFF
--- a/uno.config.ts
+++ b/uno.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
   presets: [
     presetUno(),
   ],
+  extract: {
+    include: ['web-client/templates/**/*.html'],
+  },
   // Semantic shortcuts used throughout the templates
   shortcuts: {
     'table-cell': 'px-4 py-2 border-b border-gray-700',


### PR DESCRIPTION
## Summary
- allow UnoCSS to extract classes from `web-client/templates` by configuring the `extract` glob

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851476a83348324993ecda25d5c7154