### PR TITLE
Update SSL proxy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,8 @@ includes `ProxyHeadersMiddleware` in `server/main.py`, which reads that
 header. Ensure Nginx forwards it as shown above.
 
 To serve HTTPS traffic obtain a certificate with Certbot and let it configure
-Nginx automatically:
+Nginx automatically. On Debian/Ubuntu, install Certbot and the Nginx plugin
+with `sudo apt install certbot python3-certbot-nginx` (or use Snap):
 
 ```bash
 sudo certbot --nginx -d example.com


### PR DESCRIPTION
## Summary
- update docs for nginx reverse proxy w/ SSL
- describe how to install Certbot before running the command

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517465f70c832498f0b69180b8c8d0