### PR TITLE
Add sysctl category to tunables menu

### DIFF
--- a/core/utils/templates.py
+++ b/core/utils/templates.py
@@ -109,7 +109,10 @@ def get_tunable_categories():
     db = SessionLocal()
     rows = db.query(SystemTunable.function).distinct().order_by(SystemTunable.function).all()
     db.close()
-    return [r[0] for r in rows]
+    categories = [r[0] for r in rows]
+    if "sysctl" not in categories:
+        categories.append("sysctl")
+    return categories
 
 
 templates.env.globals["get_tunable_categories"] = get_tunable_categories


### PR DESCRIPTION
## Summary
- include sysctl in tunable navigation categories so kernel params show up

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851849950c88324a1d6ce11b8e1d061