### PR TITLE
Add cloud connection tunables

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,19 @@ python -m server.workers.sync_push_worker
 python -m server.workers.sync_pull_worker
 ```
 
+### Connecting a Local Site to the Cloud
+
+After installation you can configure cloud sync parameters using the
+`setup_cloud_connection.py` helper. This stores the cloud URL and API key in the
+`system_tunables` table and verifies connectivity via a simple ping request:
+
+```bash
+python setup_cloud_connection.py https://cloud.example.com my-api-key
+```
+
+If the connection succeeds the script prints `Connection successful` and the
+background workers will use these values on the next run.
+
 The `mobile-client/` folder now contains a minimal React Native app that lists devices from the REST API. Use `npm install` then `npm start` inside that directory to launch it with Expo.
 
 ## Interface Themes
@@ -343,6 +356,9 @@ The application reads several options from the environment. Important variables 
 - `ENABLE_SYNC_PUSH_WORKER` – start the worker that pushes local changes.
 - `ENABLE_SYNC_PULL_WORKER` – start the worker that pulls updates from the cloud.
 - `ENABLE_BACKGROUND_WORKERS` – disable to skip queue and scheduler startup.
+- `CLOUD_BASE_URL` – base URL of the cloud server (overrides tunable).
+- `SYNC_PUSH_URL` and `SYNC_PULL_URL` – custom endpoints for synchronization.
+- `SYNC_API_KEY` – bearer token sent with sync requests.
 ## Nginx reverse proxy with SSL
 
 Install Nginx on the host and create a server block that proxies requests to

--- a/seed_tunables.py
+++ b/seed_tunables.py
@@ -74,6 +74,22 @@ def main():
                 data_type="text",
                 description="Bearer token for Netbird API access",
             ),
+            SystemTunable(
+                name="Cloud Base URL",
+                value="http://cloud",
+                function="Sync",
+                file_type="application",
+                data_type="text",
+                description="Base URL of the cloud server",
+            ),
+            SystemTunable(
+                name="Cloud API Key",
+                value="",
+                function="Sync",
+                file_type="application",
+                data_type="text",
+                description="API key used for cloud synchronization",
+            ),
             # ----- Newly added tunables -----
             SystemTunable(
                 name="Queue Interval",

--- a/server/routes/api/sync.py
+++ b/server/routes/api/sync.py
@@ -210,3 +210,9 @@ async def pull_changes(
             results.append({"model": model_name, **data})
 
     return results
+
+
+@router.get("/ping")
+async def sync_ping():
+    """Simple health check used by local sites."""
+    return {"status": "ok"}

--- a/setup_cloud_connection.py
+++ b/setup_cloud_connection.py
@@ -1,0 +1,59 @@
+import asyncio
+import sys
+import httpx
+
+from core.utils.db_session import SessionLocal
+from core.models.models import SystemTunable
+
+
+def set_tunable(db, name: str, value: str) -> None:
+    row = db.query(SystemTunable).filter(SystemTunable.name == name).first()
+    if row:
+        row.value = value
+    else:
+        db.add(
+            SystemTunable(
+                name=name,
+                value=value,
+                function="Sync",
+                file_type="application",
+                data_type="text",
+            )
+        )
+    db.commit()
+
+
+async def confirm_connection(base_url: str, api_key: str) -> None:
+    url = base_url.rstrip("/") + "/api/v1/sync/ping"
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(url, headers=headers)
+    resp.raise_for_status()
+
+
+def main() -> None:
+    if len(sys.argv) >= 3:
+        base_url = sys.argv[1]
+        api_key = sys.argv[2]
+    else:
+        base_url = input("Cloud base URL: ").strip()
+        api_key = input("API key: ").strip()
+
+    db = SessionLocal()
+    try:
+        set_tunable(db, "Cloud Base URL", base_url)
+        set_tunable(db, "Cloud API Key", api_key)
+    finally:
+        db.close()
+
+    print("Testing cloud connection...")
+    try:
+        asyncio.run(confirm_connection(base_url, api_key))
+    except Exception as exc:
+        print(f"Connection failed: {exc}")
+        sys.exit(1)
+    print("Connection successful")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/workers/test_sync_pull_worker.py
+++ b/tests/workers/test_sync_pull_worker.py
@@ -118,8 +118,9 @@ def test_pull_once_updates_and_inserts(monkeypatch):
     ]
 
     monkeypatch.setattr(sync_pull_worker, "SessionLocal", lambda: db)
+    monkeypatch.setattr(sync_pull_worker, "_get_sync_config", lambda: ("http://push", "http://pull", ""))
 
-    async def fake_fetch(url, payload, log):
+    async def fake_fetch(url, payload, log, api_key):
         return sample
 
     monkeypatch.setattr(sync_pull_worker, "_fetch_with_retry", fake_fetch)

--- a/tests/workers/test_sync_push_worker.py
+++ b/tests/workers/test_sync_push_worker.py
@@ -103,9 +103,10 @@ def test_push_once_sends_unsynced_records(monkeypatch):
     old_value = db.data[models.SystemTunable][0].value
 
     monkeypatch.setattr(sync_push_worker, "SessionLocal", lambda: db)
+    monkeypatch.setattr(sync_push_worker, "_get_sync_config", lambda: ("http://push", "http://pull", ""))
     sent = {}
 
-    async def fake_request(method, url, payload, log):
+    async def fake_request(method, url, payload, log, api_key):
         sent["payload"] = payload
 
     monkeypatch.setattr(sync_push_worker, "_request_with_retry", fake_request)
@@ -142,5 +143,5 @@ async def test_request_with_retry_retries(monkeypatch):
 
     monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=None: FakeClient())
     log = mock.Mock()
-    await cloud_sync._request_with_retry("POST", "http://example", {}, log)
+    await cloud_sync._request_with_retry("POST", "http://example", {}, log, "key")
     assert len(calls) == 2


### PR DESCRIPTION
## Summary
- allow a local site to configure its cloud connection
- provide a helper script to store the cloud URL and API key and verify connectivity
- read sync settings from tunables if environment variables aren't set
- add `/api/v1/sync/ping` endpoint
- document new setup process and variables

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518fec9f208324885f72592f7f49fa