### PR TITLE
Handle KeyboardInterrupt in installer

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -166,7 +166,10 @@ def install():
         run("systemctl reload nginx")
 
     run("./init_db.sh")
-    run("./start.sh")
+    try:
+        run("./start.sh")
+    except KeyboardInterrupt:
+        print("Start script interrupted; exiting installer")
 
     print("Installation complete.")
 


### PR DESCRIPTION
## Summary
- handle `KeyboardInterrupt` gracefully when running `start.sh` via the installer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68519adec2ac832491313b82d62b8987