### PR TITLE
Add cloud connection heartbeat

### DIFF
--- a/alembic/versions/0006_connected_sites.py
+++ b/alembic/versions/0006_connected_sites.py
@@ -1,0 +1,28 @@
+"""create connected_sites table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0006'
+down_revision = '0005'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'connected_sites',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('site_id', sa.String(), nullable=False, unique=True),
+        sa.Column('last_seen', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('last_version', sa.String(), nullable=True),
+        sa.Column('sync_status', sa.String(), nullable=True),
+        sa.Column('last_update_status', sa.String(), nullable=True),
+        sa.Column('ip_address', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('connected_sites')

--- a/core/models/models.py
+++ b/core/models/models.py
@@ -496,3 +496,24 @@ class ImportLog(Base):
 
     user = relationship("User")
     site = relationship("Site")
+
+
+
+class ConnectedSite(Base):
+    """Cloud server record of registered local sites."""
+
+    __tablename__ = "connected_sites"
+
+    id = Column(Integer, primary_key=True)
+    site_id = Column(String, unique=True, nullable=False)
+    last_seen = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
+    last_version = Column(String, nullable=True)
+    sync_status = Column(String, nullable=True)
+    last_update_status = Column(String, nullable=True)
+    ip_address = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+    )

--- a/seed_tunables.py
+++ b/seed_tunables.py
@@ -90,6 +90,22 @@ def main():
                 data_type="text",
                 description="API key used for cloud synchronization",
             ),
+            SystemTunable(
+                name="Cloud Site ID",
+                value="1",
+                function="Sync",
+                file_type="application",
+                data_type="text",
+                description="Unique identifier for this local site",
+            ),
+            SystemTunable(
+                name="Enable Cloud Sync",
+                value="false",
+                function="Sync",
+                file_type="application",
+                data_type="bool",
+                description="Toggle periodic cloud heartbeat and sync",
+            ),
             # ----- Newly added tunables -----
             SystemTunable(
                 name="Queue Interval",

--- a/server/main.py
+++ b/server/main.py
@@ -49,6 +49,7 @@ from server.routes import (
     install_router,
 )
 from server.routes.api.sync import router as api_sync_router
+from server.routes.api.register_site import router as register_site_router
 from server.routes.ui.sync_diagnostics import router as sync_diagnostics_router
 from server.routes.ui.tunables import router as tunables_router
 from server.routes.ui.editor import router as editor_router
@@ -63,6 +64,7 @@ from server.workers.syslog_listener import setup_syslog_listener
 from server.workers.cloud_sync import start_cloud_sync, stop_cloud_sync
 from server.workers.sync_push_worker import start_sync_push_worker, stop_sync_push_worker
 from server.workers.sync_pull_worker import start_sync_pull_worker, stop_sync_pull_worker
+from server.workers.heartbeat import start_heartbeat, stop_heartbeat
 from core.utils.templates import templates
 from core.utils.db_session import engine, SessionLocal
 from core.models.models import SystemTunable
@@ -99,6 +101,7 @@ async def lifespan(app: FastAPI):
             setup_syslog_listener()
         if settings.enable_cloud_sync:
             start_cloud_sync()
+            start_heartbeat()
         if settings.enable_sync_push_worker:
             start_sync_push_worker()
         if settings.enable_sync_pull_worker:
@@ -110,6 +113,7 @@ async def lifespan(app: FastAPI):
         await stop_cloud_sync()
         await stop_sync_push_worker()
         await stop_sync_pull_worker()
+        await stop_heartbeat()
 
 app = FastAPI(lifespan=lifespan)
 # Respect headers like X-Forwarded-Proto so generated URLs use the
@@ -169,6 +173,7 @@ app.include_router(api_vlans_router)
 app.include_router(api_ssh_credentials_router)
 if settings.role == "cloud":
     app.include_router(api_sync_router)
+    app.include_router(register_site_router)
     app.include_router(sync_diagnostics_router)
 app.include_router(admin_profiles_router)
 app.include_router(configs_router)

--- a/server/routes/__init__.py
+++ b/server/routes/__init__.py
@@ -39,6 +39,7 @@ from .api.users import router as api_users_router
 from .api.vlans import router as api_vlans_router
 from .api.ssh_credentials import router as api_ssh_credentials_router
 from .api.sync import router as api_sync_router
+from .api.register_site import router as register_site_router
 from .install import router as install_router
 
 __all__ = [
@@ -83,5 +84,6 @@ __all__ = [
     "api_vlans_router",
     "api_ssh_credentials_router",
     "api_sync_router",
+    "register_site_router",
     "install_router",
 ]

--- a/server/routes/api/register_site.py
+++ b/server/routes/api/register_site.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Body, Depends, Request, HTTPException
+from sqlalchemy.orm import Session
+from datetime import datetime, timezone
+import logging
+
+from core.utils.db_session import get_db
+from core.models.models import ConnectedSite
+
+router = APIRouter(prefix="/api/v1", tags=["cloud"])
+
+
+@router.post("/register-site")
+async def register_site(
+    request: Request,
+    payload: dict = Body(...),
+    db: Session = Depends(get_db),
+):
+    site_id = payload.get("site_id")
+    if not site_id:
+        raise HTTPException(status_code=400, detail="Missing site_id")
+    ip = request.headers.get("x-forwarded-for") or (request.client.host if request.client else "")
+    entry = db.query(ConnectedSite).filter(ConnectedSite.site_id == site_id).first()
+    if not entry:
+        entry = ConnectedSite(site_id=site_id, created_at=datetime.now(timezone.utc))
+        db.add(entry)
+    entry.last_seen = datetime.now(timezone.utc)
+    entry.last_version = payload.get("git_version")
+    entry.sync_status = payload.get("sync_status")
+    entry.last_update_status = payload.get("last_update_status")
+    entry.ip_address = ip
+    entry.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    logging.getLogger(__name__).info("Registered site %s from %s", site_id, ip)
+    return {"status": "ok"}

--- a/server/routes/ui/admin_update.py
+++ b/server/routes/ui/admin_update.py
@@ -1,9 +1,11 @@
-from fastapi import APIRouter, Request, Depends, HTTPException
+from fastapi import APIRouter, Request, Depends, HTTPException, Form
 from fastapi.responses import HTMLResponse, JSONResponse
 from sqlalchemy.orm import Session
 from sqlalchemy import or_
 import subprocess
 import asyncio
+import logging
+from datetime import datetime, timezone, timedelta
 
 from core.utils.auth import require_role
 from core.utils.db_session import get_db, SessionLocal
@@ -11,6 +13,7 @@ from core.utils.templates import templates
 from core.models.models import SystemTunable, Device, User
 from core.utils.audit import log_audit
 from server.workers.sync_push_worker import _load_last_sync
+from server.workers.heartbeat import send_heartbeat_once
 
 router = APIRouter()
 
@@ -106,8 +109,7 @@ async def update_ws(websocket):
         await websocket.close()
 
 
-@router.get("/admin/update")
-async def update_page(request: Request, db: Session = Depends(get_db), current_user=Depends(require_role("admin"))):
+def _render_update(request: Request, db: Session, current_user, message: str = ""):
     allow_row = db.query(SystemTunable).filter(SystemTunable.name == "ALLOW_SELF_UPDATE").first()
     if allow_row and str(allow_row.value).lower() in {"false", "0", "no"}:
         raise HTTPException(status_code=404)
@@ -117,6 +119,21 @@ async def update_page(request: Request, db: Session = Depends(get_db), current_u
     remote = _git(["git", "rev-parse", "--short", "origin/main"])
     update_available = commit != remote
     unsynced = _unsynced_records_exist(db)
+    cloud_url = db.query(SystemTunable).filter(SystemTunable.name == "Cloud Base URL").first()
+    site_id_row = db.query(SystemTunable).filter(SystemTunable.name == "Cloud Site ID").first()
+    enabled_row = db.query(SystemTunable).filter(SystemTunable.name == "Enable Cloud Sync").first()
+    last_contact = db.query(SystemTunable).filter(SystemTunable.name == "Last Cloud Contact").first()
+    last_contact_val = last_contact.value if last_contact else None
+    connection_status = "Disconnected"
+    if last_contact_val:
+        try:
+            ts = datetime.fromisoformat(last_contact_val)
+            if datetime.now(timezone.utc) - ts < timedelta(minutes=10):
+                connection_status = "Connected"
+            else:
+                connection_status = "Unreachable"
+        except Exception:
+            pass
     context = {
         "request": request,
         "branch": branch,
@@ -125,8 +142,19 @@ async def update_page(request: Request, db: Session = Depends(get_db), current_u
         "update_available": update_available,
         "unsynced": unsynced,
         "current_user": current_user,
+        "cloud_enabled": enabled_row.value.lower() == "true" if enabled_row else False,
+        "cloud_url": cloud_url.value if cloud_url else "",
+        "site_id": site_id_row.value if site_id_row else "",
+        "last_contact": last_contact_val,
+        "connection_status": connection_status,
+        "cloud_message": message,
     }
     return templates.TemplateResponse("update_system.html", context)
+
+
+@router.get("/admin/update")
+async def update_page(request: Request, db: Session = Depends(get_db), current_user=Depends(require_role("admin"))):
+    return _render_update(request, db, current_user)
 
 
 @router.get("/admin/check-update")
@@ -136,6 +164,44 @@ async def check_update(db: Session = Depends(get_db), current_user=Depends(requi
     remote = _git(["git", "rev-parse", "--short", "origin/main"])
     unsynced = _unsynced_records_exist(db)
     return {"update_available": local != remote, "unsynced": unsynced, "commit": local, "remote": remote}
+
+
+@router.post("/admin/test-cloud")
+async def test_cloud_connection(
+    request: Request,
+    cloud_url: str = Form(""),
+    site_id: str = Form(""),
+    enable: str = Form("off"),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("admin")),
+):
+    enabled = enable == "on" or enable.lower() in {"true", "1", "yes"}
+    msg = ""
+    if cloud_url and site_id:
+        try:
+            await send_heartbeat_once(logging.getLogger(__name__), cloud_url, site_id)
+            row = db.query(SystemTunable).filter(SystemTunable.name == "Cloud Base URL").first()
+            if row:
+                row.value = cloud_url
+            else:
+                db.add(SystemTunable(name="Cloud Base URL", value=cloud_url, function="Sync", file_type="application", data_type="text"))
+            row = db.query(SystemTunable).filter(SystemTunable.name == "Cloud Site ID").first()
+            if row:
+                row.value = site_id
+            else:
+                db.add(SystemTunable(name="Cloud Site ID", value=site_id, function="Sync", file_type="application", data_type="text"))
+            row = db.query(SystemTunable).filter(SystemTunable.name == "Enable Cloud Sync").first()
+            if row:
+                row.value = "true" if enabled else "false"
+            else:
+                db.add(SystemTunable(name="Enable Cloud Sync", value="true" if enabled else "false", function="Sync", file_type="application", data_type="bool"))
+            db.commit()
+            msg = "Connection successful"
+        except Exception as exc:
+            msg = f"Connection failed: {exc}"
+    else:
+        msg = "Cloud URL and Site ID required"
+    return _render_update(request, db, current_user, msg)
 
 
 @router.post("/admin/update")

--- a/server/workers/heartbeat.py
+++ b/server/workers/heartbeat.py
@@ -1,0 +1,121 @@
+import asyncio
+import logging
+import os
+import subprocess
+from datetime import datetime, timezone
+
+import httpx
+
+from core.utils.db_session import SessionLocal
+from core.models.models import SystemTunable
+
+HEARTBEAT_INTERVAL = int(os.environ.get("HEARTBEAT_INTERVAL", "300"))
+
+
+def _get_config() -> tuple[str, str, bool]:
+    db = SessionLocal()
+    try:
+        url = os.environ.get("CLOUD_BASE_URL")
+        if not url:
+            row = db.query(SystemTunable).filter(SystemTunable.name == "Cloud Base URL").first()
+            url = row.value if row else ""
+        site_id = os.environ.get("SITE_ID")
+        if not site_id:
+            row = db.query(SystemTunable).filter(SystemTunable.name == "Cloud Site ID").first()
+            site_id = row.value if row else ""
+        enabled_env = os.environ.get("ENABLE_CLOUD_SYNC")
+        if enabled_env is None:
+            row = db.query(SystemTunable).filter(SystemTunable.name == "Enable Cloud Sync").first()
+            enabled = row and str(row.value).lower() in {"true", "1", "yes"}
+        else:
+            enabled = enabled_env == "1"
+        return url, site_id, enabled
+    finally:
+        db.close()
+
+
+def _update_last_contact(db) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    entry = db.query(SystemTunable).filter(SystemTunable.name == "Last Cloud Contact").first()
+    if entry:
+        entry.value = now
+    else:
+        db.add(SystemTunable(name="Last Cloud Contact", value=now, function="Sync", file_type="application", data_type="text"))
+    db.commit()
+
+
+async def send_heartbeat_once(log: logging.Logger, url: str | None = None, site_id: str | None = None) -> None:
+    cfg_url, cfg_site, enabled = _get_config()
+    if url is None:
+        url = cfg_url
+    if site_id is None:
+        site_id = cfg_site
+    if not enabled or not url or not site_id:
+        return
+    payload = {
+        "site_id": site_id,
+        "git_version": _git(["git", "rev-parse", "--short", "HEAD"]),
+        "sync_status": "enabled" if enabled else "disabled",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "app_version": _app_version(),
+        "environment": os.environ.get("ROLE", "local"),
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(url.rstrip("/") + "/api/v1/register-site", json=payload)
+        resp.raise_for_status()
+        db = SessionLocal()
+        try:
+            _update_last_contact(db)
+        finally:
+            db.close()
+        log.info("Heartbeat sent successfully")
+    except Exception as exc:
+        log.error("Heartbeat failed: %s", exc)
+
+
+async def _heartbeat_loop() -> None:
+    log = logging.getLogger(__name__)
+    while True:
+        await send_heartbeat_once(log)
+        await asyncio.sleep(HEARTBEAT_INTERVAL)
+
+
+_heartbeat_task: asyncio.Task | None = None
+
+
+def start_heartbeat() -> None:
+    role = os.environ.get("ROLE", "local")
+    if role == "cloud":
+        return
+    global _heartbeat_task
+    _heartbeat_task = asyncio.create_task(_heartbeat_loop())
+
+
+async def stop_heartbeat() -> None:
+    global _heartbeat_task
+    if _heartbeat_task:
+        _heartbeat_task.cancel()
+        try:
+            await _heartbeat_task
+        except asyncio.CancelledError:
+            pass
+        _heartbeat_task = None
+
+
+# Helper functions
+
+def _git(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip())
+    return result.stdout.strip()
+
+
+def _app_version() -> str:
+    db = SessionLocal()
+    try:
+        row = db.query(SystemTunable).filter(SystemTunable.name == "App Version").first()
+        return row.value if row else "unknown"
+    finally:
+        db.close()

--- a/tests/test_register_site.py
+++ b/tests/test_register_site.py
@@ -1,0 +1,112 @@
+import os
+import sys
+import importlib
+from unittest import mock
+from fastapi.testclient import TestClient
+from datetime import datetime, timezone
+
+
+class DummyQuery:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def filter_by(self, **kw):
+        for k, v in kw.items():
+            self.items = [i for i in self.items if getattr(i, k) == v]
+        return self
+
+    def filter(self, expr):
+        from sqlalchemy.sql import operators
+        col = expr.left.key
+        val = expr.right.value
+        if expr.operator == operators.eq:
+            self.items = [i for i in self.items if getattr(i, col) == val]
+        return self
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+    def all(self):
+        return list(self.items)
+
+
+class DummyDB:
+    def __init__(self):
+        with mock.patch("sqlalchemy.create_engine"), mock.patch("sqlalchemy.schema.MetaData.create_all"):
+            models = importlib.import_module("core.models.models")
+        self.models = models
+        self.data = {models.ConnectedSite: []}
+
+    def query(self, model):
+        return DummyQuery(self.data.get(model, []))
+
+    def add(self, obj):
+        self.data.setdefault(type(obj), []).append(obj)
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+    def rollback(self):
+        pass
+
+
+def override_get_db():
+    db = DummyDB()
+    try:
+        yield db
+    finally:
+        pass
+
+
+def get_test_client():
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    os.environ["ROLE"] = "cloud"
+    if "settings" in sys.modules:
+        del sys.modules["settings"]
+    for m in list(sys.modules):
+        if m.startswith("server"):
+            del sys.modules[m]
+    with mock.patch("sqlalchemy.create_engine"), \
+         mock.patch("sqlalchemy.schema.MetaData.create_all"), \
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"), \
+         mock.patch("server.workers.sync_pull_worker.start_sync_pull_worker"), \
+         mock.patch("server.workers.cloud_sync.start_cloud_sync"), \
+         mock.patch("server.workers.heartbeat.start_heartbeat"):
+        app = importlib.import_module("server.main").app
+        app.dependency_overrides[importlib.import_module("core.utils.db_session").get_db] = override_get_db
+        return TestClient(app)
+
+
+client = get_test_client()
+
+
+def test_register_site_upserts():
+    models = importlib.import_module("core.models.models")
+    db = DummyDB()
+    def _override():
+        try:
+            yield db
+        finally:
+            pass
+    key = importlib.import_module("core.utils.db_session").get_db
+    client.app.dependency_overrides[key] = _override
+    payload = {
+        "site_id": "A",
+        "git_version": "abc",
+        "sync_status": "enabled",
+        "last_update_status": "ok",
+    }
+    resp = client.post("/api/v1/register-site", json=payload)
+    assert resp.status_code == 200
+    assert len(db.data[models.ConnectedSite]) == 1
+    resp = client.post("/api/v1/register-site", json=payload)
+    assert resp.status_code == 200
+    assert len(db.data[models.ConnectedSite]) == 1
+    client.app.dependency_overrides[key] = override_get_db

--- a/web-client/templates/update_system.html
+++ b/web-client/templates/update_system.html
@@ -13,4 +13,22 @@
 <p class="text-red-600 mb-2">Unsynced local data detected. Please sync with the cloud before updating.</p>
 {% endif %}
 <button hx-post="/admin/update" hx-target="#modal" hx-swap="innerHTML" class="btn" {% if unsynced %}disabled{% endif %}>Update to latest version</button>
+
+<h2 class="text-lg mt-6 mb-2">Cloud Connection</h2>
+<form method="post" action="/admin/test-cloud" class="space-y-2">
+  <label class="block"><input type="checkbox" name="enable" {% if cloud_enabled %}checked{% endif %}> Enable Cloud Sync</label>
+  <div>
+    <label class="block mb-1">Cloud URL</label>
+    <input type="text" name="cloud_url" value="{{ cloud_url }}" class="w-full p-1 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
+  </div>
+  <div>
+    <label class="block mb-1">Site ID</label>
+    <input type="text" name="site_id" value="{{ site_id }}" class="w-full p-1 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
+  </div>
+  <button type="submit" class="btn">Test Connection</button>
+  {% if cloud_message %}
+  <p class="mt-2">{{ cloud_message }}</p>
+  {% endif %}
+  <p class="mt-2">Status: {{ connection_status }}{% if last_contact %} (last at {{ last_contact }}){% endif %}</p>
+</form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add ConnectedSite model and migration
- implement cloud heartbeat worker and registration endpoint
- allow configuring cloud sync from update page
- persist cloud connection details in tunables
- test register-site endpoint

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a1749cd883249da48d03663b2c65