### PR TITLE
Display stored API key on update page

### DIFF
--- a/server/routes/ui/admin_update.py
+++ b/server/routes/ui/admin_update.py
@@ -121,6 +121,7 @@ def _render_update(request: Request, db: Session, current_user, message: str = "
     unsynced = _unsynced_records_exist(db)
     cloud_url = db.query(SystemTunable).filter(SystemTunable.name == "Cloud Base URL").first()
     site_id_row = db.query(SystemTunable).filter(SystemTunable.name == "Cloud Site ID").first()
+    api_key_row = db.query(SystemTunable).filter(SystemTunable.name == "Cloud API Key").first()
     enabled_row = db.query(SystemTunable).filter(SystemTunable.name == "Enable Cloud Sync").first()
     last_contact = db.query(SystemTunable).filter(SystemTunable.name == "Last Cloud Contact").first()
     last_contact_val = last_contact.value if last_contact else None
@@ -145,6 +146,7 @@ def _render_update(request: Request, db: Session, current_user, message: str = "
         "cloud_enabled": enabled_row.value.lower() == "true" if enabled_row else False,
         "cloud_url": cloud_url.value if cloud_url else "",
         "site_id": site_id_row.value if site_id_row else "",
+        "api_key": api_key_row.value if api_key_row else "",
         "last_contact": last_contact_val,
         "connection_status": connection_status,
         "cloud_message": message,

--- a/tests/test_update_page.py
+++ b/tests/test_update_page.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import importlib
+import types
+from unittest import mock
+from fastapi.testclient import TestClient
+
+
+def get_client():
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    os.environ["ROLE"] = "local"
+    if "settings" in sys.modules:
+        del sys.modules["settings"]
+    for m in list(sys.modules):
+        if m.startswith("server"):
+            del sys.modules[m]
+    with mock.patch("sqlalchemy.create_engine"), \
+         mock.patch("sqlalchemy.schema.MetaData.create_all"), \
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"), \
+         mock.patch("server.workers.sync_pull_worker.start_sync_pull_worker"), \
+         mock.patch("server.workers.cloud_sync.start_cloud_sync"), \
+         mock.patch("server.workers.heartbeat.start_heartbeat"):
+        app = importlib.import_module("server.main").app
+        return TestClient(app)
+
+
+def test_update_page_shows_api_key():
+    client = get_client()
+    from core.utils import auth as auth_utils
+    from core.utils import templates as templates_utils
+    from core.models import models
+
+    class DummyQuery:
+        def __init__(self, items):
+            self.items = list(items)
+        def filter(self, expr):
+            from sqlalchemy.sql import operators
+            col = expr.left.key
+            val = expr.right.value
+            if expr.operator == operators.eq:
+                self.items = [i for i in self.items if getattr(i, col) == val]
+            return self
+        def first(self):
+            return self.items[0] if self.items else None
+
+    class DummyDB:
+        def __init__(self):
+            self.models = models
+            self.data = {
+                models.SystemTunable: [
+                    models.SystemTunable(name="Cloud Base URL", value="http://cloud", function="Sync", file_type="application", data_type="text"),
+                    models.SystemTunable(name="Cloud Site ID", value="A", function="Sync", file_type="application", data_type="text"),
+                    models.SystemTunable(name="Cloud API Key", value="secret", function="Sync", file_type="application", data_type="text"),
+                ]
+            }
+        def query(self, model):
+            return DummyQuery(self.data.get(model, []))
+        def commit(self):
+            pass
+    def override_get_db():
+        db = DummyDB()
+        try:
+            yield db
+        finally:
+            pass
+
+    key = importlib.import_module("core.utils.db_session").get_db
+    client.app.dependency_overrides[key] = override_get_db
+
+    admin_user = types.SimpleNamespace(
+        id=1,
+        email="admin@example.com",
+        role="admin",
+        theme="dark_colourful",
+        font="sans",
+        menu_style="tabbed",
+    )
+    templates_utils.templates.env.globals["get_device_types"] = lambda: []
+    client.app.dependency_overrides[auth_utils.get_current_user] = lambda: admin_user
+
+    with mock.patch("server.routes.ui.admin_update._git", return_value="x"), \
+         mock.patch("server.routes.ui.admin_update._unsynced_records_exist", return_value=False):
+        resp = client.get("/admin/update")
+
+    assert resp.status_code == 200
+    assert "secret" in resp.text

--- a/web-client/templates/update_system.html
+++ b/web-client/templates/update_system.html
@@ -27,7 +27,12 @@
   </div>
   <div>
     <label class="block mb-1">API Key</label>
-    <input type="text" name="api_key" value="" placeholder="Enter key" class="w-full p-1 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
+    <input type="text" name="api_key" value="{{ api_key }}" placeholder="Enter key" class="w-full p-1 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
+    {% if api_key %}
+    <p class="text-sm mt-1">Current key: <code>{{ api_key }}</code></p>
+    {% else %}
+    <p class="text-sm mt-1">No API key configured</p>
+    {% endif %}
   </div>
   <button type="submit" class="btn">Test Connection</button>
   {% if cloud_message %}


### PR DESCRIPTION
## Summary
- show stored cloud API key on Update System page
- fetch the API key in update view
- add regression test for the update page

## Testing
- `pytest -q`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_6851b4b101fc8324a70817009f79b70b