### PR TITLE
Fix sync push worker test

### DIFF
--- a/tests/workers/test_sync_push_worker.py
+++ b/tests/workers/test_sync_push_worker.py
@@ -119,8 +119,7 @@ def test_push_once_sends_unsynced_records(monkeypatch):
 
 
 @pytest.mark.unit
-@pytest.mark.asyncio
-async def test_request_with_retry_retries(monkeypatch):
+def test_request_with_retry_retries(monkeypatch):
     calls = []
 
     class FakeClient:
@@ -143,5 +142,5 @@ async def test_request_with_retry_retries(monkeypatch):
 
     monkeypatch.setattr(httpx, "AsyncClient", lambda timeout=None: FakeClient())
     log = mock.Mock()
-    await cloud_sync._request_with_retry("POST", "http://example", {}, log, "key")
+    asyncio.run(cloud_sync._request_with_retry("POST", "http://example", {}, log, "site1", "key"))
     assert len(calls) == 2


### PR DESCRIPTION
## Summary
- make async retry test synchronous to avoid plugin dependency
- pass site and key params correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d3406e7c8324a954d2ca6f686f28