### PR TITLE
Implement device table autoscaling

### DIFF
--- a/web-client/static/css/layout.css
+++ b/web-client/static/css/layout.css
@@ -167,7 +167,12 @@ table.devices-table tbody tr {
 }
 
 /* Pinned actions column */
+.checkbox-col {
+  width: 3rem;
+}
+
 .actions-col {
+  width: 6rem;
   position: sticky;
   right: 0;
   background: var(--card-bg);

--- a/web-client/static/js/table.js
+++ b/web-client/static/js/table.js
@@ -51,6 +51,7 @@ function setupTablePrefs() {
 
 function initResize(table, tableId) {
   table.querySelectorAll('th').forEach((th, idx) => {
+    if (th.classList.contains('no-resize') || th.classList.contains('checkbox-col') || th.classList.contains('actions-col')) return
     th.dataset.colIndex = idx
     th.style.position = 'relative'
     const handle = document.createElement('div')
@@ -146,6 +147,12 @@ function loadPrefs(table, tableId) {
           if (cell) cell.style.display = 'none'
         })
       })
+      if (Object.keys(p.column_widths).length === 0) {
+        setTimeout(() => {
+          autoscale(table)
+          saveWidths(table, tableId)
+        })
+      }
     })
 }
 
@@ -179,6 +186,28 @@ function getHidden(table) {
   const arr = []
   table.querySelectorAll('th').forEach((th,i)=>{ if (th.style.display==='none') arr.push(String(i)) })
   return arr
+}
+
+function autoscale(table) {
+  const rows = table.querySelectorAll('tbody tr')
+  table.querySelectorAll('th').forEach((th, i) => {
+    if (th.classList.contains('checkbox-col') || th.classList.contains('actions-col') || th.classList.contains('no-resize')) return
+    if (th.style.display === 'none') return
+    let max = th.scrollWidth
+    rows.forEach(row => {
+      const cell = row.children[i]
+      if (cell && cell.style.display !== 'none') {
+        const width = cell.scrollWidth
+        if (width > max) max = width
+      }
+    })
+    const final = max + 16
+    th.style.width = final + 'px'
+    rows.forEach(row => {
+      const cell = row.children[i]
+      if (cell) cell.style.width = final + 'px'
+    })
+  })
 }
 
 document.addEventListener('DOMContentLoaded', setupTablePrefs)

--- a/web-client/templates/device_list.html
+++ b/web-client/templates/device_list.html
@@ -31,7 +31,7 @@
 <table class="min-w-full table-fixed text-left border-collapse devices-table">
   <thead>
     <tr>
-      <th class="table-cell"><input type="checkbox" id="select-all" @change="toggleAll($event.target.checked)"></th>
+      <th class="table-cell checkbox-col no-resize"><input type="checkbox" id="select-all" @change="toggleAll($event.target.checked)"></th>
       {% if column_prefs.hostname %}<th class="table-cell table-header">{{ column_labels['hostname'] }}</th>{% endif %}
       {% if column_prefs.ip %}<th class="table-cell table-header">{{ column_labels['ip'] }}</th>{% endif %}
       {% if column_prefs.mac %}<th class="table-cell table-header">{{ column_labels['mac'] }}</th>{% endif %}
@@ -51,13 +51,13 @@
       {% if column_prefs.status %}<th class="table-cell table-header">{{ column_labels['status'] }}</th>{% endif %}
       {% if column_prefs.tags %}<th class="table-cell table-header">{{ column_labels['tags'] }}</th>{% endif %}
       <th class="table-cell table-header">Ver</th>
-      <th class="table-header text-right actions-col">Actions</th>
+      <th class="table-header text-right actions-col no-resize">Actions</th>
     </tr>
   </thead>
   <tbody>
   {% for device in devices %}
     <tr {% if device.conflict_data %}style="background-color:#7f1d1d"{% endif %}>
-      <td class="table-cell"><input type="checkbox" name="selected" value="{{ device.id }}" x-model="selectedIds"></td>
+      <td class="table-cell checkbox-col no-resize"><input type="checkbox" name="selected" value="{{ device.id }}" x-model="selectedIds"></td>
       {% if column_prefs.hostname %}<td class="table-cell">{{ device.hostname }}</td>{% endif %}
       {% if column_prefs.ip %}<td class="table-cell {% if device.ip and duplicate_ips.get(device.ip) %}duplicate{% endif %}" title="{{ duplicate_ips.get(device.ip)|join(', ') if duplicate_ips.get(device.ip) }}">{{ device.ip }}</td>{% endif %}
       {% if column_prefs.mac %}<td class="table-cell {% if device.mac and duplicate_macs.get(device.mac) %}duplicate{% endif %}" title="{{ duplicate_macs.get(device.mac)|join(', ') if duplicate_macs.get(device.mac) }}">{{ device.mac or '' }}</td>{% endif %}
@@ -93,7 +93,7 @@
         {{ device.version }}
         {% if device.conflict_data %}{{ include_icon('alert-triangle','text-red-500','1.5') }}{% endif %}
       </td>
-      <td class="actions-col text-right whitespace-nowrap">
+      <td class="actions-col text-right whitespace-nowrap no-resize">
         <div class="flex justify-end gap-1">
           {% if device.ssh_credential or personal_creds.get(device.id) %}
           <a href="/ssh/port-config?device_id={{ device.id }}" title="View in Network Devices" aria-label="Live Config" class="icon-btn">{{ include_icon('eye') }}</a>
@@ -112,7 +112,7 @@
   </tbody>
   <tfoot x-show="selectedIds.length > 0" x-cloak>
     <tr class="bg-[var(--card-bg)]">
-      <td class="table-cell"></td>
+      <td class="table-cell checkbox-col no-resize"></td>
       {% if column_prefs.hostname %}<td class="table-cell"><input name="hostname" class="w-full bg-[var(--input-bg)] text-[var(--input-text)] rounded" /></td>{% endif %}
       {% if column_prefs.ip %}<td class="table-cell"><input name="ip" class="w-full bg-[var(--input-bg)] text-[var(--input-text)] rounded" /></td>{% endif %}
       {% if column_prefs.mac %}<td class="table-cell"><input name="mac" class="w-full bg-[var(--input-bg)] text-[var(--input-text)] rounded" /></td>{% endif %}
@@ -132,7 +132,7 @@
       {% if column_prefs.status %}<td class="table-cell"></td>{% endif %}
       {% if column_prefs.tags %}<td class="table-cell"><input name="tag_names" class="w-full bg-[var(--input-bg)] text-[var(--input-text)] rounded" /></td>{% endif %}
       <td class="table-cell"></td>
-      <td class="actions-col text-right"><button type="button" @click="bulkUpdate" aria-label="Apply" class="icon-btn">{{ include_icon('check','text-green-500','1.5') }}</button></td>
+      <td class="actions-col text-right no-resize"><button type="button" @click="bulkUpdate" aria-label="Apply" class="icon-btn">{{ include_icon('check','text-green-500','1.5') }}</button></td>
     </tr>
   </tfoot>
 </table>


### PR DESCRIPTION
## Summary
- fix width for checkbox and actions columns
- autoscale column widths based on visible rows
- save default autoscaled widths as table prefs
- skip resizing fixed columns
- rebuild CSS

## Testing
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851dca32eb883249058143f4801685d