### PR TITLE
Standardize icon size in tables

### DIFF
--- a/core/utils/templates.py
+++ b/core/utils/templates.py
@@ -97,7 +97,7 @@ def include_icon(ctx, name: str, color: str | None = None, size: str | int = "3"
         classes.append(color)
     else:
         classes.append("text-[var(--btn-text)]")
-    classes.append("transition")
+    classes.extend(["align-middle", "transition"])
     svg = svg.replace(
         "<svg",
         f'<svg class="{" ".join(classes)}"',

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -22,6 +22,8 @@ export default defineConfig({
   },
   // Ensure UnoCSS includes the shortcuts even when used dynamically
   safelist: [
-    'table-cell', 'table-header', 'w-[0.375rem]', 'h-[0.375rem]',
+    'table-cell', 'table-header',
+    'w-[0.375rem]', 'h-[0.375rem]',
+    'w-5', 'h-5', 'align-middle',
   ],
 })

--- a/web-client/static/css/unocss.css
+++ b/web-client/static/css/unocss.css
@@ -29,7 +29,6 @@
 .ml-4{margin-left:1rem;}
 .ml-6{margin-left:1.5rem;}
 .ml-auto{margin-left:auto;}
-.mr-1{margin-right:0.25rem;}
 .mr-2{margin-right:0.5rem;}
 .ms{margin-inline-start:1rem;}
 .mt-1{margin-top:0.25rem;}
@@ -53,6 +52,7 @@
 .h-20{height:5rem;}
 .h-40{height:10rem;}
 .h-48{height:12rem;}
+.h-5{height:1.25rem;}
 .h-6{height:1.5rem;}
 .h-64{height:16rem;}
 .h-auto{height:auto;}
@@ -77,6 +77,7 @@
 .w-3\/4{width:75%;}
 .w-32{width:8rem;}
 .w-48{width:12rem;}
+.w-5{width:1.25rem;}
 .w-6{width:1.5rem;}
 .w-96{width:24rem;}
 .w-auto{width:auto;}
@@ -171,6 +172,7 @@
 .text-center{text-align:center;}
 .text-left{text-align:left;}
 .text-right{text-align:right;}
+.align-middle{vertical-align:middle;}
 .text-\[0\.65rem\]{font-size:0.65rem;}
 .text-\[0\.6rem\]{font-size:0.6rem;}
 .text-2xl{font-size:1.5rem;line-height:2rem;}

--- a/web-client/templates/device_list.html
+++ b/web-client/templates/device_list.html
@@ -96,12 +96,12 @@
       <td class="actions-col text-right whitespace-nowrap no-resize">
         <div class="flex justify-end gap-1">
           {% if device.ssh_credential or personal_creds.get(device.id) %}
-          <a href="/ssh/port-config?device_id={{ device.id }}" title="View in Network Devices" aria-label="Live Config" class="icon-btn">{{ include_icon('eye') }}</a>
+          <a href="/ssh/port-config?device_id={{ device.id }}" title="View in Network Devices" aria-label="Live Config" class="icon-btn">{{ include_icon('eye', '', '5') }}</a>
           {% endif %}
           {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
-          <a href="/devices/{{ device.id }}/edit" aria-label="Edit" class="icon-btn">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
+          <a href="/devices/{{ device.id }}/edit" aria-label="Edit" class="icon-btn">{{ include_icon('pencil','text-blue-500','5') }}</a>
           <form method="post" action="/devices/{{ device.id }}/delete" class="inline">
-            <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete device?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+            <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete device?')">{{ include_icon('trash-2','text-red-500','5') }}</button>
           </form>
           {% endif %}
         </div>
@@ -132,7 +132,7 @@
       {% if column_prefs.status %}<td class="table-cell"></td>{% endif %}
       {% if column_prefs.tags %}<td class="table-cell"><input name="tag_names" class="w-full bg-[var(--input-bg)] text-[var(--input-text)] rounded" /></td>{% endif %}
       <td class="table-cell"></td>
-      <td class="actions-col text-right no-resize"><button type="button" @click="bulkUpdate" aria-label="Apply" class="icon-btn">{{ include_icon('check','text-green-500','1.5') }}</button></td>
+      <td class="actions-col text-right no-resize"><button type="button" @click="bulkUpdate" aria-label="Apply" class="icon-btn">{{ include_icon('check','text-green-500','5') }}</button></td>
     </tr>
   </tfoot>
 </table>

--- a/web-client/templates/device_type_list.html
+++ b/web-client/templates/device_type_list.html
@@ -32,9 +32,9 @@
       <td class="table-cell">{{ dt.name }}</td>
       <td class="actions-col text-center whitespace-nowrap">
         <div class="flex justify-center gap-1">
-          <a href="/device-types/{{ dt.id }}/edit" aria-label="Edit" class="icon-btn">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
+          <a href="/device-types/{{ dt.id }}/edit" aria-label="Edit" class="icon-btn">{{ include_icon('pencil','text-blue-500','5') }}</a>
           <form method="post" action="/device-types/{{ dt.id }}/delete" class="inline">
-            <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete type?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+            <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete type?')">{{ include_icon('trash-2','text-red-500','5') }}</button>
           </form>
         </div>
       </td>

--- a/web-client/templates/ip_ban_list.html
+++ b/web-client/templates/ip_ban_list.html
@@ -36,7 +36,7 @@
       <td class="actions-col text-center whitespace-nowrap">
         <div class="flex justify-center gap-1">
           <form method="post" action="/admin/ip-bans/{{ ban.id }}/unban" class="inline">
-          <button type='submit' aria-label='Unban' class='icon-btn' onclick="return confirm('Unban this IP?')">{{ include_icon('x-circle') }}</button>
+          <button type='submit' aria-label='Unban' class='icon-btn' onclick="return confirm('Unban this IP?')">{{ include_icon('x-circle', '', '5') }}</button>
           </form>
         </div>
       </td>

--- a/web-client/templates/location_list.html
+++ b/web-client/templates/location_list.html
@@ -21,10 +21,12 @@
       <td class="px-4 py-2">{{ loc.name }}</td>
       <td class="px-4 py-2">{{ loc.location_type }}</td>
       <td class="actions-col px-4 py-2">
-        <a href="/admin/locations/{{ loc.id }}/edit" aria-label="Edit" class="icon-btn mr-1">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
-        <form method="post" action="/admin/locations/{{ loc.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete location?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
-        </form>
+        <div class="flex gap-1">
+          <a href="/admin/locations/{{ loc.id }}/edit" aria-label="Edit" class="icon-btn">{{ include_icon('pencil','text-blue-500','5') }}</a>
+          <form method="post" action="/admin/locations/{{ loc.id }}/delete" class="inline">
+            <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete location?')">{{ include_icon('trash-2','text-red-500','5') }}</button>
+          </form>
+        </div>
       </td>
     </tr>
   {% endfor %}

--- a/web-client/templates/port_status.html
+++ b/web-client/templates/port_status.html
@@ -105,8 +105,10 @@
       </td>
       <td class="px-4 py-2">{{ port.alias or '' }}</td>
       <td class="px-4 py-2 actions-col">
-        <a href="/devices/{{ device.id }}/ports/{{ port.name }}/config" aria-label="Config" class="icon-btn">{{ include_icon('zap','text-yellow-400','1.5') }}</a>
-        <a href="/devices/{{ device.id }}/ports/{{ port.name }}/apply-template" aria-label="Template" class="icon-btn ml-1">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
+        <div class="flex gap-1">
+          <a href="/devices/{{ device.id }}/ports/{{ port.name }}/config" aria-label="Config" class="icon-btn">{{ include_icon('zap','text-yellow-400','5') }}</a>
+          <a href="/devices/{{ device.id }}/ports/{{ port.name }}/apply-template" aria-label="Template" class="icon-btn">{{ include_icon('pencil','text-blue-500','5') }}</a>
+        </div>
       </td>
     </tr>
   {% endfor %}

--- a/web-client/templates/site_keys.html
+++ b/web-client/templates/site_keys.html
@@ -39,9 +39,9 @@
       <td class="actions-col text-center">
         <form method="post" action="/admin/site-keys/{{ key.id }}/toggle">
           {% if key.active %}
-          <button type="submit" aria-label="Disable" class="icon-btn" onclick="return confirm('Disable key?')">{{ include_icon('x-circle','text-red-500','1.5') }}</button>
+          <button type="submit" aria-label="Disable" class="icon-btn" onclick="return confirm('Disable key?')">{{ include_icon('x-circle','text-red-500','5') }}</button>
           {% else %}
-          <button type="submit" aria-label="Enable" class="icon-btn">{{ include_icon('check-circle','text-green-500','1.5') }}</button>
+          <button type="submit" aria-label="Enable" class="icon-btn">{{ include_icon('check-circle','text-green-500','5') }}</button>
           {% endif %}
         </form>
       </td>


### PR DESCRIPTION
## Summary
- size all action icons consistently
- keep icon colors intact
- generate UnoCSS with needed classes

## Testing
- `npm run build:web`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6851e23299048324a81a838e3f56162a