### PR TITLE
Improve update modal handling

### DIFF
--- a/web-client/static/js/update.js
+++ b/web-client/static/js/update.js
@@ -1,11 +1,55 @@
 function startUpdateSocket() {
   const log = document.getElementById('update-log');
+  const status = document.getElementById('update-status');
+  let failed = false;
+  let finished = false;
   const socket = new WebSocket(`ws://${location.host}/ws/update`);
+
+  function closeModal() {
+    if (!finished) {
+      finished = true;
+      status.textContent = failed ? 'Update failed' : 'Update successful';
+      if (!failed) {
+        fetch('/admin/check-update')
+          .then(r => r.json())
+          .then(data => {
+            const commitEl = document.getElementById('commit-id');
+            const statusEl = document.getElementById('update-status-line');
+            if (commitEl) commitEl.textContent = data.commit;
+            if (statusEl) {
+              statusEl.textContent = data.update_available ?
+                `Update available (remote ${data.remote})` :
+                'System is up to date.';
+              if (data.update_available) {
+                statusEl.classList.add('text-green-600');
+              } else {
+                statusEl.classList.remove('text-green-600');
+              }
+            }
+          })
+          .catch(() => {});
+      }
+      setTimeout(() => {
+        const modal = document.getElementById('modal');
+        if (modal) modal.innerHTML = '';
+      }, 2000);
+    }
+  }
+
   socket.addEventListener('message', (evt) => {
     log.textContent += evt.data + '\n';
     log.scrollTop = log.scrollHeight;
+    status.textContent = evt.data;
+    if (/failed/i.test(evt.data)) {
+      failed = true;
+    }
+    if (evt.data === 'DONE') {
+      closeModal();
+    }
   });
-  socket.addEventListener('close', () => {
-    log.textContent += '\nUpdate complete.';
-  });
+
+  socket.addEventListener('close', closeModal);
+  socket.addEventListener('error', closeModal);
+
+  setTimeout(closeModal, 60000);
 }

--- a/web-client/templates/update_modal.html
+++ b/web-client/templates/update_modal.html
@@ -13,6 +13,7 @@
     </div>
     {% else %}
     <h1 class="text-xl mb-2">Updating...</h1>
+    <p id="update-status" class="mb-2">Fetching update...</p>
     <pre id="update-log" class="h-48 overflow-y-auto bg-black text-green-400 p-2 rounded"></pre>
     {% endif %}
   </div>

--- a/web-client/templates/update_system.html
+++ b/web-client/templates/update_system.html
@@ -3,11 +3,11 @@
 {% block content %}
 <h1 class="text-xl mb-4">Update System</h1>
 <p class="mb-2">Branch: {{ branch }}</p>
-<p class="mb-2">Current Commit: {{ commit }}</p>
+<p class="mb-2">Current Commit: <span id="commit-id">{{ commit }}</span></p>
 {% if update_available %}
-<p class="mb-2 text-green-600">Update available (remote {{ remote }})</p>
+<p id="update-status-line" class="mb-2 text-green-600">Update available (remote {{ remote }})</p>
 {% else %}
-<p class="mb-2">System is up to date.</p>
+<p id="update-status-line" class="mb-2">System is up to date.</p>
 {% endif %}
 {% if unsynced %}
 <p class="text-red-600 mb-2">Unsynced local data detected. Please sync with the cloud before updating.</p>


### PR DESCRIPTION
## Summary
- add dynamic commit/update status elements
- show status text during update
- auto-refresh update status when update completes
- auto-close update modal after completion

## Testing
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851f6450b9883248a6dc17dd8e7d389