### PR TITLE
Add Show Pad and Reports menus

### DIFF
--- a/web-client/templates/consumables_order.html
+++ b/web-client/templates/consumables_order.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Consumables Order</h1>
+<p class="text-base text-[var(--card-text)]">This page will be built out later.</p>
+{% endblock %}

--- a/web-client/templates/consumables_report.html
+++ b/web-client/templates/consumables_report.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Consumables Report</h1>
+<p class="text-base text-[var(--card-text)]">This page will be built out later.</p>
+{% endblock %}

--- a/web-client/templates/current_kits.html
+++ b/web-client/templates/current_kits.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Current Kits</h1>
+<p class="text-base text-[var(--card-text)]">This page will be built out later.</p>
+{% endblock %}

--- a/web-client/templates/end_show_consumables.html
+++ b/web-client/templates/end_show_consumables.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">End of Show Consumables</h1>
+<p class="text-base text-[var(--card-text)]">This page will be built out later.</p>
+{% endblock %}

--- a/web-client/templates/nav_dropdown.html
+++ b/web-client/templates/nav_dropdown.html
@@ -6,6 +6,8 @@
       <div class="flex flex-col space-y-1 submenu text-sm">
         <a href="/dashboard" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Dashboard</a>
         <a href="/devices" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Devices</a>
+        <a href="/inventory/show-pad" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Show Pad</a>
+        <a href="/inventory/reports" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Reports</a>
         <a href="/network/ip-search" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">IP Search</a>
         <a href="/vlans" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">VLAN MGMT</a>
         <a href="/network/port-configs" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Port Configs</a>

--- a/web-client/templates/nav_folder.html
+++ b/web-client/templates/nav_folder.html
@@ -35,6 +35,8 @@
       </div>
       <div x-show="isOpen('inventory')" x-transition class="mt-1 pl-4 flex flex-col space-y-1">
         <a href="/devices" :class="active('/devices')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Devices</a>
+        <a href="/inventory/show-pad" :class="active('/inventory/show-pad')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Show Pad</a>
+        <a href="/inventory/reports" :class="active('/inventory/reports')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Reports</a>
       </div>
     </div>
     <div>

--- a/web-client/templates/nav_tabbed.html
+++ b/web-client/templates/nav_tabbed.html
@@ -52,6 +52,8 @@
       <div x-show="ready && activeTopMenu == 'inventory'" x-transition.opacity.duration.150ms :class="(submenuAlign === 'right' ? 'text-right' : '') + ' w-full border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3'" x-cloak>
         <div :class="mobile ? 'flex flex-col space-y-2 submenu text-sm' : (submenuAlign === 'right' ? 'flex space-x-2 text-sm justify-end submenu' : 'flex space-x-2 text-sm submenu')">
           <a href="/devices" @click="setSub('/devices')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/devices'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Devices</a>
+          <a href="/inventory/show-pad" @click="setSub('/inventory/show-pad')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/inventory/show-pad'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Show Pad</a>
+          <a href="/inventory/reports" @click="setSub('/inventory/reports')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/inventory/reports'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Reports</a>
         </div>
       </div>
       <div x-show="ready && activeTopMenu == 'network'" x-transition.opacity.duration.150ms :class="(submenuAlign === 'right' ? 'text-right' : '') + ' w-full border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3'" x-cloak>

--- a/web-client/templates/reports_grid.html
+++ b/web-client/templates/reports_grid.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="mx-auto w-3/4">
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-0">
+    {% for item in items %}
+    <a href="{{ item.href }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('{{ item.img }}'); background-size:cover; background-position:center;">
+      <span class="bg-black bg-opacity-50 px-2 py-1 rounded">{{ item.label }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/web-client/templates/show_pad_grid.html
+++ b/web-client/templates/show_pad_grid.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="mx-auto w-3/4">
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-0">
+    {% for item in items %}
+    <a href="{{ item.href }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('{{ item.img }}'); background-size:cover; background-position:center;">
+      <span class="bg-black bg-opacity-50 px-2 py-1 rounded">{{ item.label }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Show Pad and Reports tabs under Inventory menu
- implement grid views for Show Pad and Reports
- create placeholder pages for new sections
- build static CSS for new templates
- update navigation templates

## Testing
- `npm install`
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851fc4e3d508324a36862425c4e355a