### PR TITLE
Add Network menu and inventory settings

### DIFF
--- a/server/routes/ui/inventory.py
+++ b/server/routes/ui/inventory.py
@@ -181,3 +181,17 @@ async def consumables_report(request: Request, current_user=Depends(require_role
 async def current_kits(request: Request, current_user=Depends(require_role("viewer"))):
     context = {"request": request, "current_user": current_user}
     return templates.TemplateResponse('current_kits.html', context)
+
+@router.get('/inventory/settings')
+async def inventory_settings(request: Request, current_user=Depends(require_role("viewer")), db: Session = Depends(get_db)):
+    images = {}
+    items = [
+        {"label": "Edit Tags", "href": "/tasks/edit-tags", "img": images.get("tags", "")},
+        {"label": "Device Types", "href": "/device-types", "img": images.get("device_types", "")},
+        {"label": "Site Inventory", "href": "/inventory/sites", "img": images.get("sites", "")},
+        {"label": "Trailer Inventory", "href": "/inventory/trailers", "img": images.get("trailers", "")},
+    ]
+    if current_user.role in ['editor','admin','superadmin']:
+        items.append({"label": "Add Device", "href": "/inventory/add-device", "img": images.get("add_device", "")})
+    context = {"request": request, "items": items, "current_user": current_user}
+    return templates.TemplateResponse('inventory_settings.html', context)

--- a/server/routes/ui/network.py
+++ b/server/routes/ui/network.py
@@ -30,3 +30,72 @@ async def ip_search(
         "current_user": current_user,
     }
     return templates.TemplateResponse("ip_search.html", context)
+
+@router.get('/network/dashboard')
+async def network_dashboard(request: Request, site_id: int | None = None, db: Session = Depends(get_db), current_user=Depends(get_current_user)):
+    # reuse dashboard logic from welcome.dashboard
+    from .welcome import dashboard as dash_func
+    return await dash_func(request=request, site_id=site_id, db=db, current_user=current_user)
+
+@router.get('/network/conf')
+async def network_conf_menu(request: Request, current_user=Depends(get_current_user)):
+    if not current_user:
+        raise HTTPException(status_code=401, detail='Not authenticated')
+    items = [
+        {'label': 'Port Config', 'href': '/ssh/port-config', 'img': ''},
+        {'label': 'Switch Config', 'href': '/network/switch-config', 'img': ''},
+        {'label': 'Bulk Port Update', 'href': '/ssh/bulk-port-update', 'img': ''},
+        {'label': 'VLAN Bulk Update', 'href': '/bulk/vlan-push', 'img': ''},
+    ]
+    context = {'request': request, 'items': items, 'current_user': current_user}
+    return templates.TemplateResponse('network_conf_grid.html', context)
+
+@router.get('/network/show')
+async def network_show_menu(request: Request, current_user=Depends(get_current_user)):
+    if not current_user:
+        raise HTTPException(status_code=401, detail='Not authenticated')
+    items = [
+        {'label': 'Port Config', 'href': '/ssh/port-config', 'img': ''},
+        {'label': 'Switch Config', 'href': '/network/switch-config', 'img': ''},
+        {'label': 'Port Search', 'href': '/ssh/port-search', 'img': ''},
+    ]
+    context = {'request': request, 'items': items, 'current_user': current_user}
+    return templates.TemplateResponse('network_show_grid.html', context)
+
+@router.get('/network/tasks')
+async def network_tasks_menu(request: Request, current_user=Depends(get_current_user)):
+    if not current_user:
+        raise HTTPException(status_code=401, detail='Not authenticated')
+    items = [
+        {'label': 'Task Scheduler', 'href': '/network/tasks/scheduler', 'img': ''},
+        {'label': 'Task Queue', 'href': '/tasks', 'img': ''},
+    ]
+    context = {'request': request, 'items': items, 'current_user': current_user}
+    return templates.TemplateResponse('network_tasks_grid.html', context)
+
+@router.get('/network/settings')
+async def network_settings_menu(request: Request, current_user=Depends(get_current_user)):
+    if not current_user:
+        raise HTTPException(status_code=401, detail='Not authenticated')
+    items = [
+        {'label': 'VLAN MGMT', 'href': '/vlans', 'img': ''},
+        {'label': 'SSH Credentials (Global)', 'href': '/admin/ssh', 'img': ''},
+        {'label': 'SNMP', 'href': '/admin/snmp', 'img': ''},
+        {'label': 'Logging', 'href': '/admin/debug', 'img': ''},
+    ]
+    context = {'request': request, 'items': items, 'current_user': current_user}
+    return templates.TemplateResponse('network_settings_grid.html', context)
+
+@router.get('/network/switch-config')
+async def switch_config_placeholder(request: Request, current_user=Depends(get_current_user)):
+    if not current_user:
+        raise HTTPException(status_code=401, detail='Not authenticated')
+    context = {'request': request, 'current_user': current_user}
+    return templates.TemplateResponse('switch_config.html', context)
+
+@router.get('/network/tasks/scheduler')
+async def task_scheduler_placeholder(request: Request, current_user=Depends(get_current_user)):
+    if not current_user:
+        raise HTTPException(status_code=401, detail='Not authenticated')
+    context = {'request': request, 'current_user': current_user}
+    return templates.TemplateResponse('task_scheduler.html', context)

--- a/server/routes/ui/welcome.py
+++ b/server/routes/ui/welcome.py
@@ -122,7 +122,7 @@ async def welcome_role(role: str, request: Request, current_user=Depends(get_cur
     return templates.TemplateResponse("welcome.html", context)
 
 
-@router.get("/dashboard")
+@router.get("/network/dashboard")
 async def dashboard(
     request: Request,
     site_id: int | None = None,
@@ -276,7 +276,7 @@ async def dashboard(
     return templates.TemplateResponse("dashboard.html", context)
 
 
-@router.get("/dashboard/preferences")
+@router.get("/network/dashboard/preferences")
 async def dashboard_prefs(
     request: Request,
     site_id: int | None = None,
@@ -297,7 +297,7 @@ async def dashboard_prefs(
     return templates.TemplateResponse("dashboard_prefs.html", context)
 
 
-@router.post("/dashboard/preferences")
+@router.post("/network/dashboard/preferences")
 async def save_dashboard_prefs(
     request: Request,
     widgets: list[str] = Form([]),
@@ -321,4 +321,4 @@ async def save_dashboard_prefs(
             )
         )
     db.commit()
-    return RedirectResponse(url="/dashboard", status_code=302)
+    return RedirectResponse(url="/network/dashboard", status_code=302)

--- a/web-client/templates/dashboard.html
+++ b/web-client/templates/dashboard.html
@@ -98,5 +98,5 @@
   </div>
   {% endif %}
 </div>
-<a href="/dashboard/preferences" class="underline block mt-4">Customize Dashboard</a>
+<a href="/network/dashboard/preferences" class="underline block mt-4">Customize Dashboard</a>
 {% endblock %}

--- a/web-client/templates/inventory_settings.html
+++ b/web-client/templates/inventory_settings.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="mx-auto w-3/4">
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-0">
+    {% for item in items %}
+    <a href="{{ item.href }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('{{ item.img }}'); background-size:cover; background-position:center;">
+      <span class="bg-black bg-opacity-50 px-2 py-1 rounded">{{ item.label }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/web-client/templates/nav_dropdown.html
+++ b/web-client/templates/nav_dropdown.html
@@ -4,36 +4,22 @@
       <a href="javascript:history.back()" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Back</a>
       {% if current_user %}
       <div class="flex flex-col space-y-1 submenu text-sm">
-        <a href="/dashboard" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Dashboard</a>
+        <a href="/network/dashboard" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Dashboard</a>
         <a href="/devices" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Devices</a>
         <a href="/inventory/show-pad" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Show Pad</a>
         <a href="/inventory/reports" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Reports</a>
-        <a href="/network/ip-search" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">IP Search</a>
-        <a href="/vlans" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">VLAN MGMT</a>
-        <a href="/network/port-configs" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Port Configs</a>
+        <a href="/inventory/settings" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Inventory Settings</a>
         <a href="/tasks" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Task Queue</a>
         <a href="/reports/vlan-usage" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">VLAN Usage</a>
         {% if current_user.role in ['admin','superadmin'] %}
         <a href="/tasks/google-sheets" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Google Sheets</a>
         {% endif %}
-        <span class="mt-2 font-bold">Inventory Admin</span>
-        <a href="/tasks/edit-tags" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Edit Tags</a>
-        <a href="/device-types" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Device Types</a>
-        <a href="/inventory/sites" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Site Inventory</a>
-        <a href="/inventory/trailers" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Trailer Inventory</a>
-        {% if current_user.role in ['editor','admin','superadmin'] %}
-        <a href="/inventory/add-device" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Add Device</a>
-        {% endif %}
-        <span class="mt-2 font-bold">Reports</span>
-        <a href="/inventory/audit" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Audit</a>
-        <a href="/devices/duplicates" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Duplicate Checker</a>
-        <span class="mt-2 font-bold">Network Devices</span>
-        <a href="/ssh/port-config" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Port Config</a>
-        <a href="/ssh/port-check" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Port Check</a>
-        <a href="/ssh/config-check" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Config Check</a>
-        <a href="/ssh/port-search" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Port Search</a>
-        <a href="/ssh/bulk-port-update" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Bulk Port Update</a>
-        <a href="/bulk/vlan-push" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">VLAN Bulk Push</a>
+        <span class="mt-2 font-bold">Network</span>
+        <a href="/network/dashboard" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Dashboard</a>
+        <a href="/network/conf" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Conf t</a>
+        <a href="/network/show" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Show</a>
+        <a href="/network/tasks" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Tasks</a>
+        <a href="/network/settings" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Network Settings</a>
         {% if current_user.role in ['admin','superadmin'] %}
         <span class="mt-2 font-bold">Tunables</span>
         {% for cat in get_tunable_categories() %}

--- a/web-client/templates/nav_folder.html
+++ b/web-client/templates/nav_folder.html
@@ -7,10 +7,11 @@
         <span x-html="isOpen('network') ? minusIcon : plusIcon"></span>
       </div>
       <div x-show="isOpen('network')" x-transition class="mt-1 pl-4 flex flex-col space-y-1">
-        <a href="/dashboard" :class="active('/dashboard')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Dashboard</a>
-        <a href="/network/ip-search" :class="active('/network/ip-search')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">IP Search</a>
-        <a href="/vlans" :class="active('/vlans')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">VLAN MGMT</a>
-        <a href="/network/port-configs" :class="active('/network/port-configs')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Port Configs</a>
+        <a href="/network/dashboard" :class="active('/network/dashboard')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Dashboard</a>
+        <a href="/network/conf" :class="active('/network/conf')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Conf t</a>
+        <a href="/network/show" :class="active('/network/show')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Show</a>
+        <a href="/network/tasks" :class="active('/network/tasks')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Tasks</a>
+        <a href="/network/settings" :class="active('/network/settings')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Network Settings</a>
       </div>
     </div>
     <div>
@@ -37,22 +38,7 @@
         <a href="/devices" :class="active('/devices')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Devices</a>
         <a href="/inventory/show-pad" :class="active('/inventory/show-pad')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Show Pad</a>
         <a href="/inventory/reports" :class="active('/inventory/reports')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Reports</a>
-      </div>
-    </div>
-    <div>
-      <div class="flex items-center cursor-pointer px-2 py-1 rounded hover:bg-[var(--tab-hover)]" @click="toggle('inventory-admin')">
-        <span class="flex-1">Inventory Admin</span>
-        <button @click.stop="pin('inventory-admin')" class="mr-1 text-xs" x-text="isPinned('inventory-admin') ? '★' : '☆'"></button>
-        <span x-html="isOpen('inventory-admin') ? minusIcon : plusIcon"></span>
-      </div>
-      <div x-show="isOpen('inventory-admin')" x-transition class="mt-1 pl-4 flex flex-col space-y-1">
-        <a href="/tasks/edit-tags" :class="active('/tasks/edit-tags')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Edit Tags</a>
-        <a href="/device-types" :class="active('/device-types')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Device Types</a>
-        <a href="/inventory/sites" :class="active('/inventory/sites')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Site Inventory</a>
-        <a href="/inventory/trailers" :class="active('/inventory/trailers')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Trailer Inventory</a>
-        {% if current_user.role in ['editor','admin','superadmin'] %}
-        <a href="/inventory/add-device" :class="active('/inventory/add-device')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Add Device</a>
-        {% endif %}
+        <a href="/inventory/settings" :class="active('/inventory/settings')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Inventory Settings</a>
       </div>
     </div>
     <div>

--- a/web-client/templates/nav_tabbed.html
+++ b/web-client/templates/nav_tabbed.html
@@ -8,13 +8,11 @@
             <button onclick="history.back()" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Back</button>
             {% if current_user %}
             <button @click="setTop('inventory', $event.target.dataset.align)" data-align="left" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Inventory</button>
-            <button @click="setTop('reports', $event.target.dataset.align)" data-align="left" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Reports</button>
-            <button @click="setTop('inventory-admin', $event.target.dataset.align)" data-align="left" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Inventory Admin</button>
+            <button @click="setTop('network', $event.target.dataset.align)" data-align="left" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Network</button>
             {% endif %}
           </div>
           {% if current_user %}
           <div class="flex space-x-4 ml-auto">
-            <button @click="setTop('network', $event.target.dataset.align)" data-align="right" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Network</button>
             <button @click="setTop('tasks', $event.target.dataset.align)" data-align="right" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Tasks</button>
             <button @click="setTop('netdev', $event.target.dataset.align)" data-align="right" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Network Devices</button>
             {% if current_user.role in ['admin','superadmin'] %}
@@ -54,14 +52,16 @@
           <a href="/devices" @click="setSub('/devices')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/devices'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Devices</a>
           <a href="/inventory/show-pad" @click="setSub('/inventory/show-pad')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/inventory/show-pad'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Show Pad</a>
           <a href="/inventory/reports" @click="setSub('/inventory/reports')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/inventory/reports'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Reports</a>
+          <a href="/inventory/settings" @click="setSub('/inventory/settings')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/inventory/settings'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Inventory Settings</a>
         </div>
       </div>
       <div x-show="ready && activeTopMenu == 'network'" x-transition.opacity.duration.150ms :class="(submenuAlign === 'right' ? 'text-right' : '') + ' w-full border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3'" x-cloak>
         <div :class="mobile ? 'flex flex-col space-y-2 submenu text-sm' : (submenuAlign === 'right' ? 'flex space-x-2 text-sm justify-end submenu' : 'flex space-x-2 text-sm submenu')">
-          <a href="/dashboard" @click="setSub('/dashboard')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/dashboard'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Dashboard</a>
-          <a href="/network/ip-search" @click="setSub('/network/ip-search')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/network/ip-search'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">IP Search</a>
-          <a href="/vlans" @click="setSub('/vlans')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/vlans'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">VLAN MGMT</a>
-          <a href="/network/port-configs" @click="setSub('/network/port-configs')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/network/port-configs'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Port Configs</a>
+          <a href="/network/dashboard" @click="setSub('/network/dashboard')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/network/dashboard'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Dashboard</a>
+          <a href="/network/conf" @click="setSub('/network/conf')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/network/conf'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Conf t</a>
+          <a href="/network/show" @click="setSub('/network/show')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/network/show'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Show</a>
+          <a href="/network/tasks" @click="setSub('/network/tasks')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/network/tasks'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Tasks</a>
+          <a href="/network/settings" @click="setSub('/network/settings')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/network/settings'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Network Settings</a>
         </div>
       </div>
       <div x-show="ready && activeTopMenu == 'tasks'" x-transition.opacity.duration.150ms :class="(submenuAlign === 'right' ? 'text-right' : '') + ' w-full border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3'" x-cloak>
@@ -70,23 +70,6 @@
           <a href="/reports/vlan-usage" @click="setSub('/reports/vlan-usage')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/reports/vlan-usage'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">VLAN Usage</a>
           {% if current_user.role in ['admin','superadmin'] %}
           <a href="/tasks/google-sheets" @click="setSub('/tasks/google-sheets')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/tasks/google-sheets'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Google Sheets</a>
-          {% endif %}
-        </div>
-      </div>
-      <div x-show="ready && activeTopMenu == 'reports'" x-transition.opacity.duration.150ms :class="(submenuAlign === 'right' ? 'text-right' : '') + ' w-full border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3'" x-cloak>
-        <div :class="mobile ? 'flex flex-col space-y-2 submenu text-sm' : (submenuAlign === 'right' ? 'flex space-x-2 text-sm justify-end submenu' : 'flex space-x-2 text-sm submenu')">
-          <a href="/inventory/audit" @click="setSub('/inventory/audit')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/inventory/audit'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Audit</a>
-          <a href="/devices/duplicates" @click="setSub('/devices/duplicates')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/devices/duplicates'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Duplicate Checker</a>
-        </div>
-      </div>
-      <div x-show="ready && activeTopMenu == 'inventory-admin'" x-transition.opacity.duration.150ms :class="(submenuAlign === 'right' ? 'text-right' : '') + ' w-full border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3'" x-cloak>
-        <div :class="mobile ? 'flex flex-col space-y-2 submenu text-sm' : (submenuAlign === 'right' ? 'flex space-x-2 text-sm justify-end submenu' : 'flex space-x-2 text-sm submenu')">
-          <a href="/tasks/edit-tags" @click="setSub('/tasks/edit-tags')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/tasks/edit-tags'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Edit Tags</a>
-          <a href="/device-types" @click="setSub('/device-types')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/device-types'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Device Types</a>
-          <a href="/inventory/sites" @click="setSub('/inventory/sites')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/inventory/sites'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Site Inventory</a>
-          <a href="/inventory/trailers" @click="setSub('/inventory/trailers')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/inventory/trailers'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Trailer Inventory</a>
-          {% if current_user.role in ['editor','admin','superadmin'] %}
-          <a href="/inventory/add-device" @click="setSub('/inventory/add-device')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/inventory/add-device'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Add Device</a>
           {% endif %}
         </div>
       </div>

--- a/web-client/templates/network_conf_grid.html
+++ b/web-client/templates/network_conf_grid.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="mx-auto w-3/4">
+  <h1 class="text-xl mb-4">Conf t</h1>
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-0">
+    {% for item in items %}
+    <a href="{{ item.href }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('{{ item.img }}'); background-size:cover; background-position:center;">
+      <span class="bg-black bg-opacity-50 px-2 py-1 rounded">{{ item.label }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/web-client/templates/network_settings_grid.html
+++ b/web-client/templates/network_settings_grid.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="mx-auto w-3/4">
+  <h1 class="text-xl mb-4">Network Settings</h1>
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-0">
+    {% for item in items %}
+    <a href="{{ item.href }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('{{ item.img }}'); background-size:cover; background-position:center;">
+      <span class="bg-black bg-opacity-50 px-2 py-1 rounded">{{ item.label }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/web-client/templates/network_show_grid.html
+++ b/web-client/templates/network_show_grid.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="mx-auto w-3/4">
+  <h1 class="text-xl mb-4">Show</h1>
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-0">
+    {% for item in items %}
+    <a href="{{ item.href }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('{{ item.img }}'); background-size:cover; background-position:center;">
+      <span class="bg-black bg-opacity-50 px-2 py-1 rounded">{{ item.label }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/web-client/templates/network_tasks_grid.html
+++ b/web-client/templates/network_tasks_grid.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="mx-auto w-3/4">
+  <h1 class="text-xl mb-4">Network Tasks</h1>
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-0">
+    {% for item in items %}
+    <a href="{{ item.href }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('{{ item.img }}'); background-size:cover; background-position:center;">
+      <span class="bg-black bg-opacity-50 px-2 py-1 rounded">{{ item.label }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/web-client/templates/switch_config.html
+++ b/web-client/templates/switch_config.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Switch Config</h1>
+<p class="text-base text-[var(--card-text)]">This page will display and edit switch configurations in the future.</p>
+{% endblock %}

--- a/web-client/templates/task_scheduler.html
+++ b/web-client/templates/task_scheduler.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Task Scheduler</h1>
+<p class="text-base text-[var(--card-text)]">Scheduling functionality will be added here.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- move dashboard under `/network/` and add network-related menus
- add new Inventory Settings page and route
- reorganize navigation templates
- provide placeholder views for upcoming network pages

## Testing
- `npm run build:web`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6852032ad4548324979b23f9306f19f8