### PR TITLE
Implement cloud check-in API and update heartbeat

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -54,6 +54,7 @@ from server.routes import (
 )
 from server.routes.api.sync import router as api_sync_router
 from server.routes.api.register_site import router as register_site_router
+from server.routes.api.check_in import router as check_in_router
 from server.routes.ui.sync_diagnostics import router as sync_diagnostics_router
 from server.routes.ui.tunables import router as tunables_router
 from server.routes.ui.editor import router as editor_router
@@ -179,6 +180,7 @@ app.include_router(api_ssh_credentials_router)
 if settings.role == "cloud":
     app.include_router(api_sync_router)
     app.include_router(register_site_router)
+    app.include_router(check_in_router)
     app.include_router(sync_diagnostics_router)
 app.include_router(admin_profiles_router)
 app.include_router(configs_router)

--- a/server/routes/api/__init__.py
+++ b/server/routes/api/__init__.py
@@ -4,6 +4,7 @@ from .users import router as users_router
 from .vlans import router as vlans_router
 from .ssh_credentials import router as ssh_credentials_router
 from .sync import router as sync_router
+from .check_in import router as check_in_router
 
 __all__ = [
     "api_router",
@@ -12,4 +13,5 @@ __all__ = [
     "vlans_router",
     "ssh_credentials_router",
     "sync_router",
+    "check_in_router",
 ]

--- a/server/routes/api/check_in.py
+++ b/server/routes/api/check_in.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, Body, Depends, Request, HTTPException
+from sqlalchemy.orm import Session
+from datetime import datetime, timezone
+import logging
+
+from core.utils.db_session import get_db
+from core.models.models import ConnectedSite
+from core.utils.site_auth import validate_site_key
+
+router = APIRouter(prefix="/api/sync", tags=["cloud"])
+
+
+@router.post("/check-in")
+async def check_in(
+    request: Request,
+    payload: dict = Body(...),
+    db: Session = Depends(get_db),
+    key=Depends(validate_site_key),
+):
+    """Receive a check-in from a local server."""
+    site_id = key.site_id
+    if not site_id:
+        raise HTTPException(status_code=400, detail="Missing site_id")
+    ip = request.headers.get("x-forwarded-for") or (request.client.host if request.client else "")
+    entry = db.query(ConnectedSite).filter(ConnectedSite.site_id == site_id).first()
+    if not entry:
+        entry = ConnectedSite(site_id=site_id, created_at=datetime.now(timezone.utc))
+        db.add(entry)
+    entry.last_seen = datetime.now(timezone.utc)
+    entry.last_version = payload.get("git_version")
+    entry.sync_status = payload.get("sync_status")
+    entry.last_update_status = payload.get("last_update_status")
+    entry.ip_address = ip
+    entry.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    logging.getLogger(__name__).info("Checked in site %s from %s", site_id, ip)
+    return {"tasks": [], "status": "ok"}

--- a/server/workers/heartbeat.py
+++ b/server/workers/heartbeat.py
@@ -69,7 +69,7 @@ async def send_heartbeat_once(log: logging.Logger, url: str | None = None, site_
     try:
         headers = {"Site-ID": site_id, "API-Key": api_key}
         async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.post(url.rstrip("/") + "/api/v1/register-site", json=payload, headers=headers)
+            resp = await client.post(url.rstrip("/") + "/api/sync/check-in", json=payload, headers=headers)
         resp.raise_for_status()
         db = SessionLocal()
         try:

--- a/tests/test_check_in.py
+++ b/tests/test_check_in.py
@@ -1,0 +1,111 @@
+from fastapi.testclient import TestClient
+from datetime import datetime, timezone
+import os
+import sys
+import importlib
+from unittest import mock
+
+class DummyQuery:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def filter_by(self, **kw):
+        for k, v in kw.items():
+            self.items = [i for i in self.items if getattr(i, k) == v]
+        return self
+
+    def filter(self, expr):
+        from sqlalchemy.sql import operators
+        col = expr.left.key
+        val = expr.right.value
+        if expr.operator == operators.eq:
+            self.items = [i for i in self.items if getattr(i, col) == val]
+        return self
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+    def all(self):
+        return list(self.items)
+
+class DummyDB:
+    def __init__(self):
+        with mock.patch("sqlalchemy.create_engine"), mock.patch("sqlalchemy.schema.MetaData.create_all"):
+            models = importlib.import_module("core.models.models")
+        self.models = models
+        self.data = {
+            models.ConnectedSite: [],
+            models.SiteKey: [models.SiteKey(site_id="A", site_name="Test", api_key="key", active=True)],
+        }
+
+    def query(self, model):
+        return DummyQuery(self.data.get(model, []))
+
+    def add(self, obj):
+        self.data.setdefault(type(obj), []).append(obj)
+
+    def commit(self):
+        pass
+
+    def refresh(self, obj):
+        pass
+
+    def rollback(self):
+        pass
+
+def override_get_db():
+    db = DummyDB()
+    try:
+        yield db
+    finally:
+        pass
+
+def get_test_client():
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    os.environ["ROLE"] = "cloud"
+    if "settings" in sys.modules:
+        del sys.modules["settings"]
+    for m in list(sys.modules):
+        if m.startswith("server"):
+            del sys.modules[m]
+    with mock.patch("sqlalchemy.create_engine"), \
+         mock.patch("sqlalchemy.schema.MetaData.create_all"), \
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"), \
+         mock.patch("server.workers.sync_pull_worker.start_sync_pull_worker"), \
+         mock.patch("server.workers.cloud_sync.start_cloud_sync"), \
+         mock.patch("server.workers.heartbeat.start_heartbeat"):
+        app = importlib.import_module("server.main").app
+        app.dependency_overrides[importlib.import_module("core.utils.db_session").get_db] = override_get_db
+        return TestClient(app)
+
+client = get_test_client()
+
+
+def test_check_in_upserts():
+    models = importlib.import_module("core.models.models")
+    db = DummyDB()
+    def _override():
+        try:
+            yield db
+        finally:
+            pass
+    key = importlib.import_module("core.utils.db_session").get_db
+    client.app.dependency_overrides[key] = _override
+    payload = {
+        "site_id": "A",
+        "git_version": "abc",
+        "sync_status": "enabled",
+        "last_update_status": "ok",
+    }
+    headers = {"Site-ID": "A", "API-Key": "key"}
+    resp = client.post("/api/sync/check-in", json=payload, headers=headers)
+    assert resp.status_code == 200
+    assert len(db.data[models.ConnectedSite]) == 1
+    resp = client.post("/api/sync/check-in", json=payload, headers=headers)
+    assert resp.status_code == 200
+    assert len(db.data[models.ConnectedSite]) == 1
+    client.app.dependency_overrides[key] = override_get_db

--- a/web-client/templates/cloud_sync.html
+++ b/web-client/templates/cloud_sync.html
@@ -1,6 +1,11 @@
 {% extends "base.html" %}
 {% block content %}
 <h1 class="text-xl mb-4">Cloud Sync</h1>
+{% if role == 'cloud' %}
+<h2 class="text-lg mb-2">Local Servers (Cloud View)</h2>
+{% else %}
+<h2 class="text-lg mb-2">Cloud Servers (Local View)</h2>
+{% endif %}
 <div x-data="tableControls()" class="space-y-2 full-width">
   <div class="flex justify-between items-center">
     <label>Show


### PR DESCRIPTION
## Summary
- add `/api/sync/check-in` endpoint for local server heartbeats
- call new endpoint from heartbeat worker
- expose check-in router in API module and main app
- show role-specific heading on Cloud Sync page
- add regression test for check-in endpoint
- rebuild UnoCSS

## Testing
- `npm run build:web`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68520bc5ee588324b04dd77ef2024e73