### PR TITLE
Refactor menus and profile

### DIFF
--- a/server/routes/ui/network.py
+++ b/server/routes/ui/network.py
@@ -58,6 +58,9 @@ async def network_show_menu(request: Request, current_user=Depends(get_current_u
         {'label': 'Port Config', 'href': '/ssh/port-config', 'img': ''},
         {'label': 'Switch Config', 'href': '/network/switch-config', 'img': ''},
         {'label': 'Port Search', 'href': '/ssh/port-search', 'img': ''},
+        {'label': 'Logging', 'href': '/admin/debug', 'img': ''},
+        {'label': 'VLAN Usage', 'href': '/reports/vlan-usage', 'img': ''},
+        {'label': 'IP Search', 'href': '/network/ip-search', 'img': ''},
     ]
     context = {'request': request, 'items': items, 'current_user': current_user}
     return templates.TemplateResponse('network_show_grid.html', context)
@@ -81,7 +84,6 @@ async def network_settings_menu(request: Request, current_user=Depends(get_curre
         {'label': 'VLAN MGMT', 'href': '/vlans', 'img': ''},
         {'label': 'SSH Credentials (Global)', 'href': '/admin/ssh', 'img': ''},
         {'label': 'SNMP', 'href': '/admin/snmp', 'img': ''},
-        {'label': 'Logging', 'href': '/admin/debug', 'img': ''},
     ]
     context = {'request': request, 'items': items, 'current_user': current_user}
     return templates.TemplateResponse('network_settings_grid.html', context)

--- a/server/routes/ui/user_pages.py
+++ b/server/routes/ui/user_pages.py
@@ -10,6 +10,7 @@ from core.utils.auth import (
     ROLE_HIERARCHY,
     get_password_hash,
 )
+from core.models.models import UserSSHCredential
 from core.models.models import User, SystemTunable, LoginEvent
 
 router = APIRouter()
@@ -34,12 +35,18 @@ async def my_profile(
         .order_by(LoginEvent.timestamp.desc())
         .first()
     )
+    creds = (
+        db.query(UserSSHCredential)
+        .filter(UserSSHCredential.user_id == current_user.id)
+        .all()
+    )
     context = {
         "request": request,
         "user": current_user,
         "current_user": current_user,
         "api_key": api_key,
         "last_login": last_login,
+        "creds": creds,
         "themes": [
             "dark_colourful",
             "dark",

--- a/web-client/static/css/unocss.css
+++ b/web-client/static/css/unocss.css
@@ -1,8 +1,24 @@
 /* layer: preflights */
 *,::before,::after{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgb(0 0 0 / 0);--un-ring-shadow:0 0 rgb(0 0 0 / 0);--un-shadow-inset: ;--un-shadow:0 0 rgb(0 0 0 / 0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgb(147 197 253 / 0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}::backdrop{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgb(0 0 0 / 0);--un-ring-shadow:0 0 rgb(0 0 0 / 0);--un-shadow-inset: ;--un-shadow:0 0 rgb(0 0 0 / 0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgb(147 197 253 / 0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}
 /* layer: shortcuts */
+.container{width:100%;}
 .table-cell{border-bottom-width:1px;--un-border-opacity:1;border-color:rgb(55 65 81 / var(--un-border-opacity));padding-left:1rem;padding-right:1rem;padding-top:0.5rem;padding-bottom:0.5rem;}
 .table-header{--un-bg-opacity:1;background-color:rgb(31 41 55 / var(--un-bg-opacity)) /* #1f2937 */;--un-text-opacity:1;color:rgb(255 255 255 / var(--un-text-opacity)) /* #fff */;}
+@media (min-width: 640px){
+.container{max-width:640px;}
+}
+@media (min-width: 768px){
+.container{max-width:768px;}
+}
+@media (min-width: 1024px){
+.container{max-width:1024px;}
+}
+@media (min-width: 1280px){
+.container{max-width:1280px;}
+}
+@media (min-width: 1536px){
+.container{max-width:1536px;}
+}
 /* layer: default */
 .absolute{position:absolute;}
 .fixed{position:fixed;}
@@ -151,6 +167,7 @@
 .bg-\[var\(--submenu-bg\)\]{background-color:var(--submenu-bg) /* var(--submenu-bg) */;}
 .bg-\[var\(--submenu-hover-bg\)\]{background-color:var(--submenu-hover-bg) /* var(--submenu-hover-bg) */;}
 .bg-\[var\(--tab-bg\)\]{background-color:var(--tab-bg) /* var(--tab-bg) */;}
+.bg-\[var\(--tab-hover\)\]{background-color:var(--tab-hover) /* var(--tab-hover) */;}
 .bg-black{--un-bg-opacity:1;background-color:rgb(0 0 0 / var(--un-bg-opacity)) /* #000 */;}
 .bg-black\/50{background-color:rgb(0 0 0 / 0.5) /* #000 */;}
 .hover\:bg-\[var\(--btn-hover\)\]:hover{background-color:var(--btn-hover) /* var(--btn-hover) */;}
@@ -211,6 +228,7 @@
 .fw-bold{font-weight:700;}
 .font-mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;}
 .underline{text-decoration-line:underline;}
+.tab{-moz-tab-size:4;-o-tab-size:4;tab-size:4;}
 .opacity-0{opacity:0;}
 .opacity-100{opacity:1;}
 .opacity-50{opacity:0.5;}

--- a/web-client/templates/base.html
+++ b/web-client/templates/base.html
@@ -23,8 +23,6 @@
           </a>
           <div class="login-area flex items-center space-x-2">
             {% if current_user %}
-            <a href="/users/me" class="px-4 py-1.5 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded shadow transition">My Profile</a>
-            <a href="/user/ssh" class="px-4 py-1.5 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded shadow transition">SSH Profiles</a>
             <a href="/auth/logout" class="px-4 py-1.5 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded shadow transition logged-in">Logout</a>
             {% else %}
             <a href="/auth/login" class="px-4 py-1.5 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded shadow transition logged-out">Login</a>

--- a/web-client/templates/nav_dropdown.html
+++ b/web-client/templates/nav_dropdown.html
@@ -9,7 +9,6 @@
         <a href="/inventory/show-pad" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Show Pad</a>
         <a href="/inventory/reports" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Reports</a>
         <a href="/inventory/settings" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Inventory Settings</a>
-        <a href="/tasks" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Task Queue</a>
         <a href="/reports/vlan-usage" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">VLAN Usage</a>
         {% if current_user.role in ['admin','superadmin'] %}
         <a href="/tasks/google-sheets" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Google Sheets</a>
@@ -33,8 +32,7 @@
         {% if current_user.role in ['admin','superadmin'] %}
           {% if current_user.role == 'superadmin' %}
           {% set admin_items = [
-            {'label':'SSH Credentials','href':'/admin/ssh'},
-            {'label':'SNMP Credentials','href':'/admin/snmp'},
+            {'label':'My Profile','href':'/users/me'},
             {'label':'Tag Manager','href':'/admin/tags'},
             {'label':'Locations','href':'/admin/locations'},
             {'label':'Device Import','href':'/bulk/device-import'},
@@ -47,8 +45,7 @@
           ] %}
           {% else %}
           {% set admin_items = [
-            {'label':'SSH Credentials','href':'/admin/ssh'},
-            {'label':'SNMP Credentials','href':'/admin/snmp'},
+            {'label':'My Profile','href':'/users/me'},
             {'label':'Locations','href':'/admin/locations'},
             {'label':'Device Import','href':'/bulk/device-import'}
           ] %}

--- a/web-client/templates/nav_folder.html
+++ b/web-client/templates/nav_folder.html
@@ -15,20 +15,6 @@
       </div>
     </div>
     <div>
-      <div class="flex items-center cursor-pointer px-2 py-1 rounded hover:bg-[var(--tab-hover)]" @click="toggle('tasks')">
-        <span class="flex-1">Tasks</span>
-        <button @click.stop="pin('tasks')" class="mr-1 text-xs" x-text="isPinned('tasks') ? '★' : '☆'"></button>
-        <span x-html="isOpen('tasks') ? minusIcon : plusIcon"></span>
-      </div>
-      <div x-show="isOpen('tasks')" x-transition class="mt-1 pl-4 flex flex-col space-y-1">
-        <a href="/tasks" :class="active('/tasks')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Task Queue</a>
-        <a href="/reports/vlan-usage" :class="active('/reports/vlan-usage')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">VLAN Usage</a>
-        {% if current_user.role in ['admin','superadmin'] %}
-        <a href="/tasks/google-sheets" :class="active('/tasks/google-sheets')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Google Sheets</a>
-        {% endif %}
-      </div>
-    </div>
-    <div>
       <div class="flex items-center cursor-pointer px-2 py-1 rounded hover:bg-[var(--tab-hover)]" @click="toggle('inventory')">
         <span class="flex-1">Inventory</span>
         <button @click.stop="pin('inventory')" class="mr-1 text-xs" x-text="isPinned('inventory') ? '★' : '☆'"></button>
@@ -39,21 +25,6 @@
         <a href="/inventory/show-pad" :class="active('/inventory/show-pad')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Show Pad</a>
         <a href="/inventory/reports" :class="active('/inventory/reports')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Reports</a>
         <a href="/inventory/settings" :class="active('/inventory/settings')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Inventory Settings</a>
-      </div>
-    </div>
-    <div>
-      <div class="flex items-center cursor-pointer px-2 py-1 rounded hover:bg-[var(--tab-hover)]" @click="toggle('netdev')">
-        <span class="flex-1">Network Devices</span>
-        <button @click.stop="pin('netdev')" class="mr-1 text-xs" x-text="isPinned('netdev') ? '★' : '☆'"></button>
-        <span x-html="isOpen('netdev') ? minusIcon : plusIcon"></span>
-      </div>
-      <div x-show="isOpen('netdev')" x-transition class="mt-1 pl-4 flex flex-col space-y-1">
-        <a href="/ssh/port-config" :class="active('/ssh/port-config')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Port Config</a>
-        <a href="/ssh/port-check" :class="active('/ssh/port-check')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Port Check</a>
-        <a href="/ssh/config-check" :class="active('/ssh/config-check')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Config Check</a>
-        <a href="/ssh/port-search" :class="active('/ssh/port-search')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Port Search</a>
-        <a href="/ssh/bulk-port-update" :class="active('/ssh/bulk-port-update')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Bulk Port Update</a>
-        <a href="/bulk/vlan-push" :class="active('/bulk/vlan-push')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">VLAN Bulk Push</a>
       </div>
     </div>
     {% if current_user.role in ['admin','superadmin'] %}
@@ -82,8 +53,7 @@
       <div x-show="isOpen('admin')" x-transition class="mt-1 pl-4 flex flex-col space-y-1">
         {% if current_user.role == 'superadmin' %}
         {% set admin_items = [
-          {'label':'SSH Credentials','href':'/admin/ssh'},
-          {'label':'SNMP Credentials','href':'/admin/snmp'},
+          {'label':'My Profile','href':'/users/me'},
           {'label':'Tag Manager','href':'/admin/tags'},
           {'label':'Locations','href':'/admin/locations'},
           {'label':'Device Import','href':'/bulk/device-import'},
@@ -96,8 +66,7 @@
         ] %}
         {% else %}
         {% set admin_items = [
-          {'label':'SSH Credentials','href':'/admin/ssh'},
-          {'label':'SNMP Credentials','href':'/admin/snmp'},
+          {'label':'My Profile','href':'/users/me'},
           {'label':'Locations','href':'/admin/locations'},
           {'label':'Device Import','href':'/bulk/device-import'}
         ] %}

--- a/web-client/templates/nav_tabbed.html
+++ b/web-client/templates/nav_tabbed.html
@@ -13,14 +13,11 @@
           </div>
           {% if current_user %}
           <div class="flex space-x-4 ml-auto">
-            <button @click="setTop('tasks', $event.target.dataset.align)" data-align="right" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Tasks</button>
-            <button @click="setTop('netdev', $event.target.dataset.align)" data-align="right" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Network Devices</button>
             {% if current_user.role in ['admin','superadmin'] %}
             <button @click="setTop('tunables', $event.target.dataset.align)" data-align="right" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Tunables</button>
             {% if current_user.role == 'superadmin' %}
             {% set admin_items = [
-              {'label':'SSH Credentials','href':'/admin/ssh'},
-              {'label':'SNMP Credentials','href':'/admin/snmp'},
+              {'label':'My Profile','href':'/users/me'},
               {'label':'Tag Manager','href':'/admin/tags'},
               {'label':'Locations','href':'/admin/locations'},
               {'label':'Device Import','href':'/bulk/device-import'},
@@ -33,8 +30,7 @@
             ] %}
             {% else %}
             {% set admin_items = [
-              {'label':'SSH Credentials','href':'/admin/ssh'},
-              {'label':'SNMP Credentials','href':'/admin/snmp'},
+              {'label':'My Profile','href':'/users/me'},
               {'label':'Locations','href':'/admin/locations'},
               {'label':'Device Import','href':'/bulk/device-import'}
             ] %}
@@ -62,25 +58,6 @@
           <a href="/network/show" @click="setSub('/network/show')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/network/show'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Show</a>
           <a href="/network/tasks" @click="setSub('/network/tasks')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/network/tasks'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Tasks</a>
           <a href="/network/settings" @click="setSub('/network/settings')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/network/settings'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Network Settings</a>
-        </div>
-      </div>
-      <div x-show="ready && activeTopMenu == 'tasks'" x-transition.opacity.duration.150ms :class="(submenuAlign === 'right' ? 'text-right' : '') + ' w-full border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3'" x-cloak>
-        <div :class="mobile ? 'flex flex-col space-y-2 submenu text-sm' : (submenuAlign === 'right' ? 'flex space-x-2 text-sm justify-end submenu' : 'flex space-x-2 text-sm submenu')">
-          <a href="/tasks" @click="setSub('/tasks')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/tasks'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Task Queue</a>
-          <a href="/reports/vlan-usage" @click="setSub('/reports/vlan-usage')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/reports/vlan-usage'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">VLAN Usage</a>
-          {% if current_user.role in ['admin','superadmin'] %}
-          <a href="/tasks/google-sheets" @click="setSub('/tasks/google-sheets')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/tasks/google-sheets'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Google Sheets</a>
-          {% endif %}
-        </div>
-      </div>
-      <div x-show="ready && activeTopMenu == 'netdev'" x-transition.opacity.duration.150ms :class="(submenuAlign === 'right' ? 'text-right' : '') + ' w-full border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3'" x-cloak>
-        <div :class="mobile ? 'flex flex-col space-y-2 submenu text-sm' : (submenuAlign === 'right' ? 'flex space-x-2 text-sm justify-end submenu' : 'flex space-x-2 text-sm submenu')">
-          <a href="/ssh/port-config" @click="setSub('/ssh/port-config')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/ssh/port-config'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Port Config</a>
-          <a href="/ssh/port-check" @click="setSub('/ssh/port-check')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/ssh/port-check'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Port Check</a>
-          <a href="/ssh/config-check" @click="setSub('/ssh/config-check')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/ssh/config-check'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Config Check</a>
-          <a href="/ssh/port-search" @click="setSub('/ssh/port-search')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/ssh/port-search'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Port Search</a>
-          <a href="/ssh/bulk-port-update" @click="setSub('/ssh/bulk-port-update')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/ssh/bulk-port-update'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Bulk Port Update</a>
-          <a href="/bulk/vlan-push" @click="setSub('/bulk/vlan-push')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/bulk/vlan-push'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">VLAN Bulk Push</a>
         </div>
       </div>
       {% if current_user.role in ['admin','superadmin'] %}

--- a/web-client/templates/user_detail.html
+++ b/web-client/templates/user_detail.html
@@ -2,7 +2,13 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">User Details</h1>
-<div class="flex flex-wrap gap-4 items-start">
+<div x-data="{tab: 'profile'}">
+  <div class="flex space-x-2 mb-4">
+    <button @click="tab = 'profile'" :class="{'bg-[var(--tab-hover)]': tab === 'profile'}" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">Profile</button>
+    <button @click="tab = 'ssh'" :class="{'bg-[var(--tab-hover)]': tab === 'ssh'}" class="rounded-t-lg border border-[var(--border-color)] border-b-0 px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] transition">SSH Profiles</button>
+  </div>
+  <div x-show="tab === 'profile'">
+    <div class="flex flex-wrap gap-4 items-start">
   <div class="flex-1 min-w-[200px] overflow-auto">
     <table class="min-w-full table-fixed text-left">
       <tbody>
@@ -128,6 +134,36 @@
   </form>
 
   <a href="/users/me/edit" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition mt-4">Edit Profile</a>
+  </div> {# end profile tab #}
+  <div x-show="tab === 'ssh'" x-cloak>
+    <a href="/user/ssh/new" class="underline">Add SSH Credential</a>
+    <div class="w-full overflow-auto">
+      <table class="min-w-full table-fixed text-left mt-4">
+        <thead>
+          <tr>
+            <th class="px-4 py-2 text-left">Name</th>
+            <th class="px-4 py-2 text-left">Username</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for cred in creds %}
+          <tr class="border-t border-gray-700">
+            <td class="px-4 py-2">{{ cred.name }}</td>
+            <td class="px-4 py-2">{{ cred.username }}</td>
+            <td class="px-4 py-2">
+              <a href="/user/ssh/{{ cred.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
+              <form method="post" action="/user/ssh/{{ cred.id }}/delete" class="inline">
+                <button type="submit" aria-label="Delete" class="p-2 rounded transition" onclick="return confirm('Delete profile?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div> {# end ssh tab #}
+</div> {# end tab container #}
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- reorganize network Show menu
- move profile links to Admin menus
- add profile tabs for SSH Profiles
- drop duplicate menu entries

## Testing
- `npm run build:web`
- `pytest -q` *(fails: 19 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68521384b9d883249a2de25e19eec32a