### PR TITLE
Update sync pull worker headers

### DIFF
--- a/server/workers/sync_pull_worker.py
+++ b/server/workers/sync_pull_worker.py
@@ -49,8 +49,10 @@ def _update_last_sync(db: Session) -> None:
     db.commit()
 
 
-async def _fetch_with_retry(url: str, payload: dict, log: logging.Logger, api_key: str) -> Any:
-    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+async def _fetch_with_retry(
+    url: str, payload: dict, log: logging.Logger, site_id: str, api_key: str
+) -> Any:
+    headers = {"Site-ID": site_id, "API-Key": api_key}
     delay = 1
     for attempt in range(SYNC_RETRIES):
         try:
@@ -70,11 +72,11 @@ async def pull_once(log: logging.Logger) -> None:
     db = SessionLocal()
     try:
         since = _load_last_sync(db)
-        _, pull_url, api_key = _get_sync_config()
+        _, pull_url, site_id, api_key = _get_sync_config()
         payload: dict[str, Any] = {"since": since.isoformat(), "models": SYNC_PULL_MODELS}
         if SITE_ID:
             payload["site_id"] = SITE_ID
-        data = await _fetch_with_retry(pull_url, payload, log, api_key)
+        data = await _fetch_with_retry(pull_url, payload, log, site_id, api_key)
         if not isinstance(data, list):
             log.error("Invalid pull response: %s", data)
             return

--- a/tests/workers/test_sync_pull_worker.py
+++ b/tests/workers/test_sync_pull_worker.py
@@ -118,9 +118,13 @@ def test_pull_once_updates_and_inserts(monkeypatch):
     ]
 
     monkeypatch.setattr(sync_pull_worker, "SessionLocal", lambda: db)
-    monkeypatch.setattr(sync_pull_worker, "_get_sync_config", lambda: ("http://push", "http://pull", ""))
+    monkeypatch.setattr(
+        sync_pull_worker,
+        "_get_sync_config",
+        lambda: ("http://push", "http://pull", "site1", ""),
+    )
 
-    async def fake_fetch(url, payload, log, api_key):
+    async def fake_fetch(url, payload, log, site_id, api_key):
         return sample
 
     monkeypatch.setattr(sync_pull_worker, "_fetch_with_retry", fake_fetch)


### PR DESCRIPTION
## Summary
- send Site-ID and API-Key headers in `sync_pull_worker._fetch_with_retry`
- thread site ID from `_get_sync_config` into the pull worker
- adjust unit test for new header behaviour

## Testing
- `pytest tests/workers/test_sync_pull_worker.py -q`
- `pytest -q` *(fails: test_admin_nav.py::test_admin_links_present)*

------
https://chatgpt.com/codex/tasks/task_e_68521a7171848324aa3aba73eee6b9f1