### PR TITLE
Add site ID and sync flag to setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,15 +261,20 @@ python -m server.workers.sync_pull_worker
 ### Connecting a Local Site to the Cloud
 
 After installation you can configure cloud sync parameters using the
-`setup_cloud_connection.py` helper. This stores the cloud URL and API key in the
-`system_tunables` table and verifies connectivity via a simple ping request:
+`setup_cloud_connection.py` helper. This stores the cloud URL, API key, site ID
+and sync flag in the `system_tunables` table and verifies connectivity via a
+simple ping request:
 
 ```bash
-python setup_cloud_connection.py https://cloud.example.com my-api-key
+python setup_cloud_connection.py https://cloud.example.com my-api-key 123 yes
 ```
 
-If the connection succeeds the script prints `Connection successful` and the
-background workers will use these values on the next run.
+If any of the parameters are omitted you will be prompted interactively. The
+final argument enables cloud sync when set to `yes`/`1`. If the connection
+succeeds the script prints `Connection successful` and the background workers
+will use these values on the next run. Remember to set the environment variables
+`ENABLE_CLOUD_SYNC`, `ENABLE_SYNC_PUSH_WORKER` and `ENABLE_SYNC_PULL_WORKER` so
+the related workers actually start.
 
 The `mobile-client/` folder now contains a minimal React Native app that lists devices from the REST API. Use `npm install` then `npm start` inside that directory to launch it with Expo.
 

--- a/setup_cloud_connection.py
+++ b/setup_cloud_connection.py
@@ -32,17 +32,26 @@ async def confirm_connection(base_url: str, api_key: str) -> None:
 
 
 def main() -> None:
-    if len(sys.argv) >= 3:
-        base_url = sys.argv[1]
-        api_key = sys.argv[2]
+    args = sys.argv[1:]
+    if len(args) >= 4:
+        base_url, api_key, site_id, enable_flag = args[:4]
+    elif len(args) >= 2:
+        base_url, api_key = args[:2]
+        site_id = input("Cloud site ID: ").strip()
+        enable_flag = input("Enable cloud sync? [y/N]: ").strip()
     else:
         base_url = input("Cloud base URL: ").strip()
         api_key = input("API key: ").strip()
+        site_id = input("Cloud site ID: ").strip()
+        enable_flag = input("Enable cloud sync? [y/N]: ").strip()
+    enabled = str(enable_flag).lower() in {"y", "yes", "1", "true"}
 
     db = SessionLocal()
     try:
         set_tunable(db, "Cloud Base URL", base_url)
         set_tunable(db, "Cloud API Key", api_key)
+        set_tunable(db, "Cloud Site ID", site_id)
+        set_tunable(db, "Enable Cloud Sync", "true" if enabled else "false")
     finally:
         db.close()
 

--- a/web-client/templates/nav_dropdown.html
+++ b/web-client/templates/nav_dropdown.html
@@ -35,6 +35,7 @@
             {'label':'My Profile','href':'/users/me'},
             {'label':'Tag Manager','href':'/admin/tags'},
             {'label':'Locations','href':'/admin/locations'},
+            {'label':'SSH Credentials','href':'/admin/ssh'},
             {'label':'Device Import','href':'/bulk/device-import'},
             {'label':'Audit Log','href':'/admin/audit'},
             {'label':'IP Bans','href':'/admin/ip-bans'},
@@ -47,6 +48,7 @@
           {% set admin_items = [
             {'label':'My Profile','href':'/users/me'},
             {'label':'Locations','href':'/admin/locations'},
+            {'label':'SSH Credentials','href':'/admin/ssh'},
             {'label':'Device Import','href':'/bulk/device-import'}
           ] %}
           {% endif %}

--- a/web-client/templates/nav_folder.html
+++ b/web-client/templates/nav_folder.html
@@ -56,6 +56,7 @@
           {'label':'My Profile','href':'/users/me'},
           {'label':'Tag Manager','href':'/admin/tags'},
           {'label':'Locations','href':'/admin/locations'},
+          {'label':'SSH Credentials','href':'/admin/ssh'},
           {'label':'Device Import','href':'/bulk/device-import'},
           {'label':'Audit Log','href':'/admin/audit'},
           {'label':'IP Bans','href':'/admin/ip-bans'},
@@ -68,6 +69,7 @@
         {% set admin_items = [
           {'label':'My Profile','href':'/users/me'},
           {'label':'Locations','href':'/admin/locations'},
+          {'label':'SSH Credentials','href':'/admin/ssh'},
           {'label':'Device Import','href':'/bulk/device-import'}
         ] %}
         {% endif %}

--- a/web-client/templates/nav_tabbed.html
+++ b/web-client/templates/nav_tabbed.html
@@ -20,6 +20,7 @@
               {'label':'My Profile','href':'/users/me'},
               {'label':'Tag Manager','href':'/admin/tags'},
               {'label':'Locations','href':'/admin/locations'},
+              {'label':'SSH Credentials','href':'/admin/ssh'},
               {'label':'Device Import','href':'/bulk/device-import'},
               {'label':'Audit Log','href':'/admin/audit'},
               {'label':'IP Bans','href':'/admin/ip-bans'},
@@ -32,6 +33,7 @@
             {% set admin_items = [
               {'label':'My Profile','href':'/users/me'},
               {'label':'Locations','href':'/admin/locations'},
+              {'label':'SSH Credentials','href':'/admin/ssh'},
               {'label':'Device Import','href':'/bulk/device-import'}
             ] %}
             {% endif %}


### PR DESCRIPTION
## Summary
- prompt for site ID and sync flag in `setup_cloud_connection.py`
- document script parameters and required environment variables
- include SSH Credentials in admin menus

## Testing
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521c1be61c83248235fc2b7c999663