### PR TITLE
Add new Super Admin submenu

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -46,6 +46,7 @@ from server.routes import (
     admin_update_router,
     admin_site_keys_router,
     cloud_sync_router,
+    admin_menu_router,
     api_devices_router,
     api_users_router,
     api_vlans_router,
@@ -213,6 +214,7 @@ app.include_router(admin_logo_router)
 app.include_router(admin_update_router)
 app.include_router(admin_site_keys_router)
 app.include_router(cloud_sync_router)
+app.include_router(admin_menu_router)
 
 
 @app.exception_handler(HTTPException)

--- a/server/routes/__init__.py
+++ b/server/routes/__init__.py
@@ -36,6 +36,7 @@ from .ui.admin_logo import router as admin_logo_router
 from .ui.admin_update import router as admin_update_router
 from .ui.admin_site_keys import router as admin_site_keys_router
 from .ui.cloud_sync import router as cloud_sync_router
+from .ui.admin_menu import router as admin_menu_router
 from .api.devices import router as api_devices_router
 from .api.users import router as api_users_router
 from .api.vlans import router as api_vlans_router
@@ -83,6 +84,7 @@ __all__ = [
     "admin_update_router",
     "admin_site_keys_router",
     "cloud_sync_router",
+    "admin_menu_router",
     "api_devices_router",
     "api_users_router",
     "api_vlans_router",

--- a/server/routes/ui/admin_menu.py
+++ b/server/routes/ui/admin_menu.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Request, Depends
+
+from core.utils.auth import require_role
+from core.utils.templates import templates
+
+router = APIRouter()
+
+@router.get("/admin/system")
+async def system_menu(request: Request, current_user=Depends(require_role("superadmin"))):
+    items = [
+        {"label": "Backup", "href": "/compare-configs", "img": ""},
+        {"label": "Locations", "href": "/admin/locations", "img": ""},
+        {"label": "IP Bans", "href": "/admin/ip-bans", "img": ""},
+        {"label": "Upload Logo", "href": "/admin/logo", "img": ""},
+        {"label": "Update System", "href": "/admin/update", "img": ""},
+    ]
+    context = {"request": request, "items": items, "title": "System", "current_user": current_user}
+    return templates.TemplateResponse("admin_menu_grid.html", context)
+
+
+@router.get("/admin/sync")
+async def sync_menu(request: Request, current_user=Depends(require_role("superadmin"))):
+    items = [
+        {"label": "Google Sheets", "href": "/tasks/google-sheets", "img": ""},
+        {"label": "Google Maps", "href": "/tunables?category=Google%20Maps", "img": ""},
+        {"label": "Netbird", "href": "/ssh/netbird-connect", "img": ""},
+        {"label": "Site Keys", "href": "/admin/site-keys", "img": ""},
+    ]
+    context = {"request": request, "items": items, "title": "Sync / APIs", "current_user": current_user}
+    return templates.TemplateResponse("admin_menu_grid.html", context)
+
+
+@router.get("/admin/logs")
+async def logs_menu(request: Request, current_user=Depends(require_role("superadmin"))):
+    items = [
+        {"label": "Debug Logs", "href": "/admin/debug", "img": ""},
+        {"label": "Audit Log", "href": "/admin/audit", "img": ""},
+        {"label": "Login Locations and logs", "href": "/admin/login-events", "img": ""},
+    ]
+    context = {"request": request, "items": items, "title": "Logs", "current_user": current_user}
+    return templates.TemplateResponse("admin_menu_grid.html", context)

--- a/web-client/templates/admin_menu_grid.html
+++ b/web-client/templates/admin_menu_grid.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="mx-auto w-3/4">
+  <h1 class="text-xl mb-4">{{ title }}</h1>
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-0">
+    {% for item in items %}
+    <a href="{{ item.href }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('{{ item.img or '' }}'); background-size:cover; background-position:center;">
+      <span class="bg-black bg-opacity-50 px-2 py-1 rounded">{{ item.label }}</span>
+    </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/web-client/templates/nav_dropdown.html
+++ b/web-client/templates/nav_dropdown.html
@@ -10,9 +10,6 @@
         <a href="/inventory/reports" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Reports</a>
         <a href="/inventory/settings" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Inventory Settings</a>
         <a href="/reports/vlan-usage" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">VLAN Usage</a>
-        {% if current_user.role in ['admin','superadmin'] %}
-        <a href="/tasks/google-sheets" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Google Sheets</a>
-        {% endif %}
         <span class="mt-2 font-bold">Network</span>
         <a href="/network/dashboard" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Dashboard</a>
         <a href="/network/conf" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Conf t</a>
@@ -24,25 +21,14 @@
         {% for cat in get_tunable_categories() %}
         <a href="/tunables?category={{ cat | urlencode }}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">{{ cat }}</a>
         {% endfor %}
-        <a href="/admin/logo" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Upload Logo</a>
-        {% if allow_self_update() %}
-        <a href="/admin/update" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Update System</a>
-        {% endif %}
         {% endif %}
         {% if current_user.role in ['admin','superadmin'] %}
           {% if current_user.role == 'superadmin' %}
           {% set admin_items = [
             {'label':'My Profile','href':'/users/me'},
-            {'label':'Tag Manager','href':'/admin/tags'},
-            {'label':'Locations','href':'/admin/locations'},
-            {'label':'SSH Credentials','href':'/admin/ssh'},
-            {'label':'Device Import','href':'/bulk/device-import'},
-            {'label':'Audit Log','href':'/admin/audit'},
-            {'label':'IP Bans','href':'/admin/ip-bans'},
-            {'label':'User Management','href':'/admin/users'},
-            {'label':'Debug Logs','href':'/admin/debug'},
-            {'label':'Site Keys','href':'/admin/site-keys'},
-            {'label':'Cloud Sync','href':'/admin/cloud-sync'}
+            {'label':'System','href':'/admin/system'},
+            {'label':'Sync / API\'s','href':'/admin/sync'},
+            {'label':'Logs','href':'/admin/logs'}
           ] %}
           {% else %}
           {% set admin_items = [

--- a/web-client/templates/nav_folder.html
+++ b/web-client/templates/nav_folder.html
@@ -38,10 +38,6 @@
         {% for cat in get_tunable_categories() %}
         <a href="/tunables?category={{ cat | urlencode }}" :class="active('/tunables?category={{ cat | urlencode }}')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">{{ cat }}</a>
         {% endfor %}
-        <a href="/admin/logo" :class="active('/admin/logo')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Upload Logo</a>
-        {% if allow_self_update() %}
-        <a href="/admin/update" :class="active('/admin/update')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Update System</a>
-        {% endif %}
       </div>
     </div>
     <div>
@@ -54,16 +50,9 @@
         {% if current_user.role == 'superadmin' %}
         {% set admin_items = [
           {'label':'My Profile','href':'/users/me'},
-          {'label':'Tag Manager','href':'/admin/tags'},
-          {'label':'Locations','href':'/admin/locations'},
-          {'label':'SSH Credentials','href':'/admin/ssh'},
-          {'label':'Device Import','href':'/bulk/device-import'},
-          {'label':'Audit Log','href':'/admin/audit'},
-          {'label':'IP Bans','href':'/admin/ip-bans'},
-          {'label':'User Management','href':'/admin/users'},
-          {'label':'Debug Logs','href':'/admin/debug'},
-          {'label':'Site Keys','href':'/admin/site-keys'},
-          {'label':'Cloud Sync','href':'/admin/cloud-sync'}
+          {'label':'System','href':'/admin/system'},
+          {'label':'Sync / API\'s','href':'/admin/sync'},
+          {'label':'Logs','href':'/admin/logs'}
         ] %}
         {% else %}
         {% set admin_items = [

--- a/web-client/templates/nav_tabbed.html
+++ b/web-client/templates/nav_tabbed.html
@@ -18,16 +18,9 @@
             {% if current_user.role == 'superadmin' %}
             {% set admin_items = [
               {'label':'My Profile','href':'/users/me'},
-              {'label':'Tag Manager','href':'/admin/tags'},
-              {'label':'Locations','href':'/admin/locations'},
-              {'label':'SSH Credentials','href':'/admin/ssh'},
-              {'label':'Device Import','href':'/bulk/device-import'},
-              {'label':'Audit Log','href':'/admin/audit'},
-              {'label':'IP Bans','href':'/admin/ip-bans'},
-              {'label':'User Management','href':'/admin/users'},
-              {'label':'Debug Logs','href':'/admin/debug'},
-              {'label':'Site Keys','href':'/admin/site-keys'},
-              {'label':'Cloud Sync','href':'/admin/cloud-sync'}
+              {'label':'System','href':'/admin/system'},
+              {'label':'Sync / API\'s','href':'/admin/sync'},
+              {'label':'Logs','href':'/admin/logs'}
             ] %}
             {% else %}
             {% set admin_items = [
@@ -68,10 +61,7 @@
           {% for cat in get_tunable_categories() %}
           <a href="/tunables?category={{ cat | urlencode }}" @click="setSub('/tunables?category={{ cat | urlencode }}')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/tunables?category={{ cat | urlencode }}'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">{{ cat }}</a>
           {% endfor %}
-          <a href="/admin/logo" @click="setSub('/admin/logo')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/admin/logo'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Upload Logo</a>
-          {% if allow_self_update() %}
-          <a href="/admin/update" @click="setSub('/admin/update')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/admin/update'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Update System</a>
-          {% endif %}
+          
         </div>
       </div>
       {% endif %}


### PR DESCRIPTION
## Summary
- add new grid template and router for Super Admin menus
- include new router in main app
- remove logo/upload options from Tunables menu
- restructure Super Admin menu entries
- keep existing admin menu for non-superadmin

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_admin_nav.py::test_admin_links_present -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852378eb3c48324aeea3d36d95d7661