### PR TITLE
Implement image upload management

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -47,6 +47,7 @@ from server.routes import (
     admin_site_keys_router,
     cloud_sync_router,
     admin_menu_router,
+    admin_images_router,
     api_devices_router,
     api_users_router,
     api_vlans_router,
@@ -215,6 +216,7 @@ app.include_router(admin_update_router)
 app.include_router(admin_site_keys_router)
 app.include_router(cloud_sync_router)
 app.include_router(admin_menu_router)
+app.include_router(admin_images_router)
 
 
 @app.exception_handler(HTTPException)

--- a/server/routes/__init__.py
+++ b/server/routes/__init__.py
@@ -37,6 +37,7 @@ from .ui.admin_update import router as admin_update_router
 from .ui.admin_site_keys import router as admin_site_keys_router
 from .ui.cloud_sync import router as cloud_sync_router
 from .ui.admin_menu import router as admin_menu_router
+from .ui.admin_images import router as admin_images_router
 from .api.devices import router as api_devices_router
 from .api.users import router as api_users_router
 from .api.vlans import router as api_vlans_router
@@ -85,6 +86,7 @@ __all__ = [
     "admin_site_keys_router",
     "cloud_sync_router",
     "admin_menu_router",
+    "admin_images_router",
     "api_devices_router",
     "api_users_router",
     "api_vlans_router",

--- a/server/routes/ui/admin_images.py
+++ b/server/routes/ui/admin_images.py
@@ -1,0 +1,191 @@
+from fastapi import APIRouter, Request, Depends, UploadFile, File, HTTPException
+from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy.orm import Session
+import os
+
+from core.utils.auth import require_role
+from core.utils.db_session import get_db
+from core.utils.templates import templates
+from core.utils.paths import STATIC_DIR
+from core.models.models import DeviceType, SystemTunable
+
+router = APIRouter()
+
+MENU_LABELS = [
+    "Backup",
+    "Locations",
+    "IP Bans",
+    "Upload Logo",
+    "Update System",
+    "Google Sheets",
+    "Google Maps",
+    "Netbird",
+    "Site Keys",
+    "Debug Logs",
+    "Audit Log",
+    "Login Locations and logs",
+]
+
+def slugify(label: str) -> str:
+    return label.lower().replace(" ", "_")
+
+
+def get_menu_images(db: Session) -> dict[str, dict[str, str | None]]:
+    items: dict[str, dict[str, str | None]] = {}
+    for label in MENU_LABELS:
+        slug = slugify(label)
+        icon_row = (
+            db.query(SystemTunable)
+            .filter(SystemTunable.name == f"MENU_ICON_{slug}")
+            .first()
+        )
+        img_row = (
+            db.query(SystemTunable)
+            .filter(SystemTunable.name == f"MENU_IMAGE_{slug}")
+            .first()
+        )
+        items[label] = {
+            "slug": slug,
+            "icon": icon_row.value if icon_row else None,
+            "image": img_row.value if img_row else None,
+        }
+    return items
+
+
+def save_menu_images(db: Session, label: str, icon: str | None, image: str | None) -> None:
+    slug = slugify(label)
+    icon_name = f"MENU_ICON_{slug}"
+    img_name = f"MENU_IMAGE_{slug}"
+    row = db.query(SystemTunable).filter(SystemTunable.name == icon_name).first()
+    if icon is not None:
+        if row:
+            row.value = icon
+        else:
+            db.add(
+                SystemTunable(
+                    name=icon_name,
+                    value=icon,
+                    function="Menu",
+                    file_type="application",
+                    data_type="text",
+                )
+            )
+    row = db.query(SystemTunable).filter(SystemTunable.name == img_name).first()
+    if image is not None:
+        if row:
+            row.value = image
+        else:
+            db.add(
+                SystemTunable(
+                    name=img_name,
+                    value=image,
+                    function="Menu",
+                    file_type="application",
+                    data_type="text",
+                )
+            )
+    db.commit()
+
+
+@router.get("/admin/upload-image")
+async def upload_image_page(
+    request: Request,
+    category: str = "device",
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    if category == "menu":
+        items = get_menu_images(db)
+    else:
+        types = db.query(DeviceType).all()
+        items = {
+            t.name: {
+                "id": t.id,
+                "icon": t.upload_icon,
+                "image": t.upload_image,
+            }
+            for t in types
+        }
+    context = {
+        "request": request,
+        "category": category,
+        "items": items,
+        "current_user": current_user,
+    }
+    return templates.TemplateResponse("upload_image_list.html", context)
+
+
+@router.get("/admin/upload-image/{category}/{key}/modal")
+async def edit_modal(
+    category: str,
+    key: str,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    if category == "menu":
+        items = get_menu_images(db)
+        if key not in [v["slug"] for v in items.values()]:
+            raise HTTPException(status_code=404)
+        label = next(k for k, v in items.items() if v["slug"] == key)
+        icon = items[label]["icon"]
+        image = items[label]["image"]
+    else:
+        dtype = db.query(DeviceType).filter(DeviceType.id == int(key)).first()
+        if not dtype:
+            raise HTTPException(status_code=404)
+        label = dtype.name
+        icon = dtype.upload_icon
+        image = dtype.upload_image
+    context = {
+        "request": request,
+        "category": category,
+        "key": key,
+        "label": label,
+        "icon": icon,
+        "image": image,
+        "current_user": current_user,
+    }
+    return templates.TemplateResponse("upload_image_modal.html", context)
+
+
+@router.post("/admin/upload-image/{category}/{key}")
+async def update_images(
+    category: str,
+    key: str,
+    request: Request,
+    icon: UploadFile | None = File(None),
+    image: UploadFile | None = File(None),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    upload_dir = os.path.join(STATIC_DIR, "uploads", "menu-items" if category == "menu" else "device-types")
+    os.makedirs(upload_dir, exist_ok=True)
+    icon_name = None
+    image_name = None
+    if icon and icon.filename:
+        if not icon.content_type.startswith("image/"):
+            raise HTTPException(status_code=400, detail="Invalid icon type")
+        icon_name = f"{key}_icon_{os.path.basename(icon.filename)}"
+        with open(os.path.join(upload_dir, icon_name), "wb") as f:
+            f.write(await icon.read())
+    if image and image.filename:
+        if not image.content_type.startswith("image/"):
+            raise HTTPException(status_code=400, detail="Invalid image type")
+        image_name = f"{key}_img_{os.path.basename(image.filename)}"
+        with open(os.path.join(upload_dir, image_name), "wb") as f:
+            f.write(await image.read())
+    if category == "menu":
+        save_menu_images(db, next(k for k, v in get_menu_images(db).items() if v["slug"] == key), icon_name if icon_name else None, image_name if image_name else None)
+    else:
+        dtype = db.query(DeviceType).filter(DeviceType.id == int(key)).first()
+        if not dtype:
+            raise HTTPException(status_code=404)
+        if icon_name:
+            dtype.upload_icon = icon_name
+        if image_name:
+            dtype.upload_image = image_name
+        db.commit()
+    if request.headers.get("HX-Request"):
+        return HTMLResponse("", status_code=204)
+    return RedirectResponse(url=f"/admin/upload-image?category={category}", status_code=302)

--- a/server/routes/ui/admin_menu.py
+++ b/server/routes/ui/admin_menu.py
@@ -1,41 +1,77 @@
 from fastapi import APIRouter, Request, Depends
+from sqlalchemy.orm import Session
 
 from core.utils.auth import require_role
+from core.utils.db_session import get_db
 from core.utils.templates import templates
+from core.models.models import SystemTunable
+from core.utils.paths import STATIC_DIR
+import os
 
 router = APIRouter()
 
+def _slug(label: str) -> str:
+    return label.lower().replace(" ", "_")
+
+def _menu_image(db: Session, label: str) -> str:
+    slug = _slug(label)
+    row = db.query(SystemTunable).filter(SystemTunable.name == f"MENU_IMAGE_{slug}").first()
+    if row and row.value:
+        path = os.path.join(STATIC_DIR, "uploads", "menu-items", row.value)
+        if os.path.exists(path):
+            return f"/static/uploads/menu-items/{row.value}"
+    return ""
+
 @router.get("/admin/system")
-async def system_menu(request: Request, current_user=Depends(require_role("superadmin"))):
+async def system_menu(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
     items = [
-        {"label": "Backup", "href": "/compare-configs", "img": ""},
-        {"label": "Locations", "href": "/admin/locations", "img": ""},
-        {"label": "IP Bans", "href": "/admin/ip-bans", "img": ""},
-        {"label": "Upload Logo", "href": "/admin/logo", "img": ""},
-        {"label": "Update System", "href": "/admin/update", "img": ""},
+        {"label": "Backup", "href": "/compare-configs"},
+        {"label": "Locations", "href": "/admin/locations"},
+        {"label": "IP Bans", "href": "/admin/ip-bans"},
+        {"label": "Upload Logo", "href": "/admin/logo"},
+        {"label": "Upload Image", "href": "/admin/upload-image"},
+        {"label": "Update System", "href": "/admin/update"},
     ]
+    for item in items:
+        item["img"] = _menu_image(db, item["label"])
     context = {"request": request, "items": items, "title": "System", "current_user": current_user}
     return templates.TemplateResponse("admin_menu_grid.html", context)
 
 
 @router.get("/admin/sync")
-async def sync_menu(request: Request, current_user=Depends(require_role("superadmin"))):
+async def sync_menu(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
     items = [
-        {"label": "Google Sheets", "href": "/tasks/google-sheets", "img": ""},
-        {"label": "Google Maps", "href": "/tunables?category=Google%20Maps", "img": ""},
-        {"label": "Netbird", "href": "/ssh/netbird-connect", "img": ""},
-        {"label": "Site Keys", "href": "/admin/site-keys", "img": ""},
+        {"label": "Google Sheets", "href": "/tasks/google-sheets"},
+        {"label": "Google Maps", "href": "/tunables?category=Google%20Maps"},
+        {"label": "Netbird", "href": "/ssh/netbird-connect"},
+        {"label": "Site Keys", "href": "/admin/site-keys"},
     ]
+    for item in items:
+        item["img"] = _menu_image(db, item["label"])
     context = {"request": request, "items": items, "title": "Sync / APIs", "current_user": current_user}
     return templates.TemplateResponse("admin_menu_grid.html", context)
 
 
 @router.get("/admin/logs")
-async def logs_menu(request: Request, current_user=Depends(require_role("superadmin"))):
+async def logs_menu(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
     items = [
-        {"label": "Debug Logs", "href": "/admin/debug", "img": ""},
-        {"label": "Audit Log", "href": "/admin/audit", "img": ""},
-        {"label": "Login Locations and logs", "href": "/admin/login-events", "img": ""},
+        {"label": "Debug Logs", "href": "/admin/debug"},
+        {"label": "Audit Log", "href": "/admin/audit"},
+        {"label": "Login Locations and logs", "href": "/admin/login-events"},
     ]
+    for item in items:
+        item["img"] = _menu_image(db, item["label"])
     context = {"request": request, "items": items, "title": "Logs", "current_user": current_user}
     return templates.TemplateResponse("admin_menu_grid.html", context)

--- a/web-client/static/css/unocss.css
+++ b/web-client/static/css/unocss.css
@@ -25,7 +25,11 @@
 .relative{position:relative;}
 .static{position:static;}
 .inset-0{inset:0;}
+.bottom-2{bottom:0.5rem;}
 .bottom-full{bottom:100%;}
+.left-2{left:0.5rem;}
+.right-2{right:0.5rem;}
+.top-2{top:0.5rem;}
 .grid{display:grid;}
 .grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr));}
 .grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr));}
@@ -67,12 +71,14 @@
 .h-\[calc\(100vh-4rem\)\]{height:calc(100vh - 4rem);}
 .h-10{height:2.5rem;}
 .h-14{height:3.5rem;}
+.h-16{height:4rem;}
 .h-20{height:5rem;}
 .h-40{height:10rem;}
 .h-48{height:12rem;}
 .h-5{height:1.25rem;}
 .h-6{height:1.5rem;}
 .h-64{height:16rem;}
+.h-8{height:2rem;}
 .h-auto{height:auto;}
 .h-full{height:100%;}
 .h-screen{height:100vh;}
@@ -98,6 +104,7 @@
 .w-5{width:1.25rem;}
 .w-6{width:1.5rem;}
 .w-64{width:16rem;}
+.w-8{width:2rem;}
 .w-96{width:24rem;}
 .w-auto{width:auto;}
 .w-full{width:100%;}
@@ -175,6 +182,7 @@
 .hover\:bg-\[var\(--submenu-hover-bg\)\]:hover{background-color:var(--submenu-hover-bg) /* var(--submenu-hover-bg) */;}
 .hover\:bg-\[var\(--tab-hover\)\]:hover{background-color:var(--tab-hover) /* var(--tab-hover) */;}
 .bg-opacity-50{--un-bg-opacity:0.5;}
+.object-contain{object-fit:contain;}
 .p-1{padding:0.25rem;}
 .p-2{padding:0.5rem;}
 .p-3{padding:0.75rem;}
@@ -245,6 +253,7 @@
 @media (min-width: 768px){
 .md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr));}
 .md\:grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr));}
+.md\:grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr));}
 }
 @media (min-width: 1024px){
 .lg\:hidden{display:none;}

--- a/web-client/templates/upload_image_list.html
+++ b/web-client/templates/upload_image_list.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Upload Image</h1>
+<div class="mb-4">
+  <label for="cat" class="mr-2">Category</label>
+  <select id="cat" onchange="location.href='?category='+this.value" class="rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)] px-2 py-1">
+    <option value="device" {% if category == 'device' %}selected{% endif %}>Device Types</option>
+    <option value="menu" {% if category == 'menu' %}selected{% endif %}>Menu Items</option>
+  </select>
+</div>
+<div id="grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-2">
+  {% for label, item in items.items() %}
+  <div class="relative border rounded p-2 h-40">
+    {% if item.icon %}
+    <img src="/static/uploads/{{ 'menu-items' if category=='menu' else 'device-types' }}/{{ item.icon }}" class="absolute top-2 left-2 w-8 h-8 object-contain" alt="">
+    {% endif %}
+    {% if item.image %}
+    <img src="/static/uploads/{{ 'menu-items' if category=='menu' else 'device-types' }}/{{ item.image }}" class="absolute top-2 right-2 h-16 object-contain" alt="">
+    {% endif %}
+    <div class="absolute bottom-2 left-2">
+      <button hx-get="/admin/upload-image/{{ category }}/{{ item.slug if category=='menu' else item.id }}/modal" hx-target="#modal" hx-swap="innerHTML" class="px-2 py-1 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded">Update</button>
+    </div>
+    <div class="absolute bottom-2 right-2 text-sm">{{ label }}</div>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/web-client/templates/upload_image_modal.html
+++ b/web-client/templates/upload_image_modal.html
@@ -1,0 +1,25 @@
+<div id="modal" class="fixed inset-0 bg-black/50 flex items-center justify-center">
+  <div class="bg-[var(--card-bg)] p-4 rounded shadow min-w-[20rem]">
+    <h1 class="text-xl mb-4">Update {{ label }}</h1>
+    <form hx-post="/admin/upload-image/{{ category }}/{{ key }}" hx-target="#modal" hx-swap="outerHTML" enctype="multipart/form-data" method="post">
+      <div class="mb-2">
+        <label class="block">Icon</label>
+        <input type="file" name="icon" accept="image/*" class="text-[var(--input-text)]">
+        {% if icon %}
+        <img src="/static/uploads/{{ 'menu-items' if category=='menu' else 'device-types' }}/{{ icon }}" class="h-10 mt-1" alt="">
+        {% endif %}
+      </div>
+      <div class="mb-2">
+        <label class="block">Image</label>
+        <input type="file" name="image" accept="image/*" class="text-[var(--input-text)]">
+        {% if image %}
+        <img src="/static/uploads/{{ 'menu-items' if category=='menu' else 'device-types' }}/{{ image }}" class="h-20 mt-1" alt="">
+        {% endif %}
+      </div>
+      <div class="text-right mt-2">
+        <button type="submit" class="px-3 py-1 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded">Save</button>
+        <button type="button" class="px-3 py-1 ml-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded" onclick="document.getElementById('modal').innerHTML=''">Cancel</button>
+      </div>
+    </form>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add Upload Image UI to manage icons and images for menu items and device types
- hook new page into system menu
- store menu item image paths via SystemTunables
- build UnoCSS assets

## Testing
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68523d1feae08324927021c5443754d4