### PR TITLE
Fix missing menu color columns

### DIFF
--- a/alembic/versions/0010_add_menu_colors.py
+++ b/alembic/versions/0010_add_menu_colors.py
@@ -1,0 +1,21 @@
+"""add menu color settings to users"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0010'
+down_revision = '0009'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('menu_tab_color', sa.String(), nullable=True))
+    op.add_column('users', sa.Column('menu_bg_color', sa.String(), nullable=True))
+    op.add_column('users', sa.Column('menu_stick_theme', sa.Boolean(), nullable=False, server_default='true'))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'menu_stick_theme')
+    op.drop_column('users', 'menu_bg_color')
+    op.drop_column('users', 'menu_tab_color')

--- a/init_db.sh
+++ b/init_db.sh
@@ -38,6 +38,9 @@ psql "$PG_URL" -tc "SELECT 1 FROM pg_database WHERE datname = '$DB_NAME';" | gre
 # Install dependencies
 pip install -r requirements.txt
 
+# Apply latest database migrations
+alembic upgrade head
+
 # Seed tables
 python seed_tunables.py
 python seed_superuser.py


### PR DESCRIPTION
## Summary
- add Alembic migration for user menu color settings
- run migrations in init_db.sh before seeding

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685240dcbc048324986a5aa7edb6eccb