### PR TITLE
Ensure HTMX modals close after saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,9 @@ python -m pip install -r requirements.txt
 ### `venv/bin/python: No such file or directory`
 This message appears when the `venv` directory has not been created. Run the commands above to create the virtual environment before installing the dependencies.
 
+### Modal window stays open after saving
+Forms posted via HTMX replace the `#modal` element with the server response. If the response uses HTTP 204 the dialog remains visible because no HTML is swapped in. Return a small snippet like `close_modal.html` to clear the container instead. See [docs/modals.md](docs/modals.md) for details.
+
 ## Automated Installer
 
 For unattended deployments on a fresh server run the interactive installer.

--- a/docs/modals.md
+++ b/docs/modals.md
@@ -1,0 +1,22 @@
+# Handling HTMX Modals
+
+All pop-up dialogs are rendered into the empty `<div id="modal"></div>` found in `base.html`.
+When a form inside a modal posts via HTMX, the response replaces this container.
+
+Returning an HTTP 204 status will leave the dialog in place because HTMX does not modify the DOM.
+Instead, return HTML that clears the container or provide a snippet that does so.
+
+Example:
+
+```python
+if request.headers.get("HX-Request"):
+    return templates.TemplateResponse("close_modal.html", {"request": request})
+```
+
+The `close_modal.html` template simply empties the modal element:
+
+```html
+<div id="modal"></div>
+```
+
+This pattern ensures the modal disappears after a successful action.

--- a/server/routes/ui/devices.py
+++ b/server/routes/ui/devices.py
@@ -223,7 +223,7 @@ async def save_device_column_prefs(
         )
     db.commit()
     if request.headers.get("HX-Request"):
-        return HTMLResponse("", status_code=204)
+        return templates.TemplateResponse("close_modal.html", {"request": request})
     return RedirectResponse(url="/devices/table", status_code=302)
 
 

--- a/web-client/templates/close_modal.html
+++ b/web-client/templates/close_modal.html
@@ -1,0 +1,1 @@
+<div id="modal"></div>


### PR DESCRIPTION
## Summary
- return `close_modal.html` when saving device column preferences via HTMX
- document how to close modals in `docs/modals.md`
- mention modal behaviour in README troubleshooting section
- rebuild UnoCSS after adding template

## Testing
- `npm install`
- `npm run build:web`
- `pytest -q` *(fails: 18 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68529342ed7c8324b152bc4a213a5e5e