### PR TITLE
Fix admin submenu alignment persistence

### DIFF
--- a/web-client/templates/nav_tabbed.html
+++ b/web-client/templates/nav_tabbed.html
@@ -71,7 +71,7 @@
         mobile: false,
         activeTopMenu: '',
         activeSubMenu: '',
-        submenuAlign: 'left',
+        submenuAlign: localStorage.getItem('submenuAlign') || 'left',
         ready: false,
         theme,
         stickTheme,
@@ -80,6 +80,7 @@
         initFromStorage() {
           this.activeTopMenu = localStorage.getItem('activeTopMenu') || ''
           this.activeSubMenu = localStorage.getItem('activeSubMenu') || ''
+          this.submenuAlign = localStorage.getItem('submenuAlign') || this.submenuAlign
           this.applyColors(this.activeTopMenu)
           setTimeout(() => this.ready = true, 50)
         },
@@ -87,6 +88,7 @@
           this.activeTopMenu = menu
           this.submenuAlign = align
           localStorage.setItem('activeTopMenu', menu)
+          localStorage.setItem('submenuAlign', align)
           localStorage.removeItem('activeSubMenu')
           this.activeSubMenu = ''
           this.applyColors(menu)


### PR DESCRIPTION
## Summary
- remember submenu alignment choice
- rebuild UnoCSS

## Testing
- `npm run build:web`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68529a1d9134832493823f35bf9ac742