### PR TITLE
Fix startup database migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,8 @@ Start the server with reasonable defaults using the provided `start.sh` script:
 ./start.sh
 ```
 
-This script loads variables from `.env` if present, automatically runs the seed scripts (unless `AUTO_SEED=0` or `false`) and then executes:
+This script loads variables from `.env` if present, applies pending Alembic migrations,
+automatically runs the seed scripts (unless `AUTO_SEED=0` or `false`), and then executes:
 
 ```bash
 gunicorn server.main:app \

--- a/server/routes/ui/admin_users.py
+++ b/server/routes/ui/admin_users.py
@@ -61,7 +61,6 @@ async def create_user(
     icon_style: str = Form("lucide"),
     menu_tab_color: str | None = Form(None),
     menu_bg_color: str | None = Form(None),
-    icon_style: str = Form("lucide"),
     inventory_color: str | None = Form(None),
     network_color: str | None = Form(None),
     admin_color: str | None = Form(None),

--- a/start.sh
+++ b/start.sh
@@ -22,6 +22,9 @@ npm run build:web
 python wait_for_db.py
 sleep 2
 
+# Apply any pending database migrations before seeding
+alembic upgrade head
+
 if [ "${AUTO_SEED:-1}" != "0" ] && [ "${AUTO_SEED}" != "false" ]; then
     python seed_tunables.py
     python seed_superuser.py


### PR DESCRIPTION
## Summary
- run `alembic upgrade head` automatically in `start.sh`
- fix duplicate `icon_style` argument in admin users route
- document that `start.sh` applies migrations before seeding

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a1f920148324b8c664041ff0dd8c