### PR TITLE
Fix Alembic env for new versions

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -44,7 +44,9 @@ def process_revision_directives(context, revision, directives):
         return
     script = directives[0]
     conn = context.connection
-    for op in list(script.upgrade_ops.list_ops()):
+    # Alembic 1.8+ removed the list_ops() helper, upgrade_ops is iterable
+    # so we can access the operations via the ``ops`` attribute.
+    for op in list(script.upgrade_ops.ops):
         if isinstance(op, AddColumnOp):
             column = op.column
             if not column.nullable and column.server_default is None:


### PR DESCRIPTION
## Summary
- update Alembic env.py to remove usage of deprecated `list_ops()`

## Testing
- `alembic revision --autogenerate -m "test"` *(fails: Target database is not up to date)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a4822a008324b5011a3a34265df9