### PR TITLE
Fix update_user missing icon_style parameter

### DIFF
--- a/server/routes/ui/admin_users.py
+++ b/server/routes/ui/admin_users.py
@@ -153,6 +153,7 @@ async def update_user(
     theme: str = Form("dark_colourful"),
     font: str = Form("sans"),
     menu_style: str = Form("tabbed"),
+    icon_style: str = Form("lucide"),
     menu_tab_color: str | None = Form(None),
     menu_bg_color: str | None = Form(None),
     inventory_color: str | None = Form(None),


### PR DESCRIPTION
## Summary
- add `icon_style` to user update form

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a6cf4cec8324b05b3cca3e12afc4