### PR TITLE
Improve installer compatibility for older pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,8 @@ AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'
 Upgrade `pyOpenSSL` before running Certbot:
 
 ```bash
-sudo pip3 install --break-system-packages --upgrade pyOpenSSL
+sudo pip3 install --upgrade pyOpenSSL
+# add --break-system-packages if your pip version supports it
 ```
 
 ### Modal window stays open after saving


### PR DESCRIPTION
## Summary
- support pip versions without `--break-system-packages`
- mention optional `--break-system-packages` flag in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852aecc232c83248a2438a902334254