### PR TITLE
Fix init script Alembic error

### DIFF
--- a/init_db.sh
+++ b/init_db.sh
@@ -46,8 +46,8 @@ from core.utils.db_session import Base, engine
 Base.metadata.create_all(bind=engine)
 PY
 
-# Apply latest database migrations
-alembic upgrade head
+# Mark database as up-to-date with migrations
+alembic stamp head
 
 # Seed tables
 python seed_tunables.py


### PR DESCRIPTION
## Summary
- avoid running migrations when the DB schema already contains the versioned tables

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b138b37c8324b08a0cc09358514a