### PR TITLE
Fix Dark Colourful submenu background

### DIFF
--- a/web-client/static/themes/dark_colourful.css
+++ b/web-client/static/themes/dark_colourful.css
@@ -22,7 +22,7 @@ body {
   --inventory-btn-text: var(--btn-text);
   --network-tab-bg: #8e44ec;
   --network-tab-text: #ffffff;
-  --network-submenu-bg: #7a33d8;
+  --network-submenu-bg: var(--submenu-bg);
   --network-submenu-text: #ffffff;
   --network-btn-bg: #8e44ec;
   --network-btn-text: #ffffff;


### PR DESCRIPTION
## Summary
- match the network submenu colour with the main menu background in the Dark Colourful theme
- rebuild UnoCSS

## Testing
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bb65478c8324ace36abe4c3bffce