### PR TITLE
Add UI to be Sorted page

### DIFF
--- a/server/routes/ui/admin_menu.py
+++ b/server/routes/ui/admin_menu.py
@@ -36,11 +36,21 @@ async def system_menu(
         {"label": "Upload Image", "href": "/admin/upload-image"},
         {"label": "Update System", "href": "/admin/update"},
         {"label": "Tunables", "href": "/tunables"},
+        {"label": "UI to be Sorted", "href": "/admin/ui-to-be-sorted"},
     ]
     for item in items:
         item["img"] = _menu_image(db, item["label"])
     context = {"request": request, "items": items, "title": "System", "current_user": current_user}
     return templates.TemplateResponse("admin_menu_grid.html", context)
+
+
+@router.get("/admin/ui-to-be-sorted")
+async def ui_to_be_sorted(
+    request: Request,
+    current_user=Depends(require_role("superadmin")),
+):
+    context = {"request": request, "current_user": current_user}
+    return templates.TemplateResponse("ui_to_be_sorted.html", context)
 
 
 @router.get("/admin/sync")

--- a/web-client/templates/ui_to_be_sorted.html
+++ b/web-client/templates/ui_to_be_sorted.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">UI to be Sorted</h1>
+<p class="mb-2">The following endpoints exist but are not linked in the current navigation:</p>
+<ul class="list-disc ml-6 space-y-1">
+  <li><a href="/admin/users" class="underline">/admin/users</a></li>
+  <li><a href="/admin/cloud-sync" class="underline">/admin/cloud-sync</a></li>
+  <li><a href="/network/port-configs" class="underline">/network/port-configs</a></li>
+  <li><a href="/inventory/new-product" class="underline">/inventory/new-product</a></li>
+  <li><a href="/inventory/new-camera" class="underline">/inventory/new-camera</a></li>
+  <li><a href="/inventory/new-ruckus-ap" class="underline">/inventory/new-ruckus-ap</a></li>
+  <li><a href="/inventory/switches" class="underline">/inventory/switches</a></li>
+  <li><a href="/inventory/ptp" class="underline">/inventory/ptp</a></li>
+  <li><a href="/inventory/ptmp" class="underline">/inventory/ptmp</a></li>
+  <li><a href="/inventory/aps" class="underline">/inventory/aps</a></li>
+  <li><a href="/inventory/iptv" class="underline">/inventory/iptv</a></li>
+  <li><a href="/inventory/vog" class="underline">/inventory/vog</a></li>
+  <li><a href="/inventory/ip-cameras" class="underline">/inventory/ip-cameras</a></li>
+  <li><a href="/inventory/iot-devices" class="underline">/inventory/iot-devices</a></li>
+  <li><a href="/install" class="underline">/install</a></li>
+  <li><a href="/editor" class="underline">/editor</a></li>
+</ul>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `UI to be Sorted` page under the System menu
- list endpoints that lack nav links

## Testing
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bcbf75e883249f949553f00dc998