### PR TITLE
Add custom column management

### DIFF
--- a/alembic/versions/0012_custom_columns.py
+++ b/alembic/versions/0012_custom_columns.py
@@ -1,0 +1,26 @@
+"""add custom columns table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0012'
+down_revision = '0011'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'custom_columns',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('table_name', sa.String(), nullable=False),
+        sa.Column('column_name', sa.String(), nullable=False),
+        sa.Column('data_type', sa.String(), nullable=False),
+        sa.Column('default_value', sa.String(), nullable=True),
+        sa.Column('user_visible', sa.Boolean(), nullable=False, server_default='true'),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('custom_columns')

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -23,6 +23,7 @@ from .models import (
     DashboardWidget,
     SiteDashboardWidget,
     SiteKey,
+    CustomColumn,
     ColumnPreference,
     TablePreference,
 )
@@ -52,6 +53,7 @@ __all__ = [
     "DashboardWidget",
     "SiteDashboardWidget",
     "SiteKey",
+    "CustomColumn",
     "ColumnPreference",
     "TablePreference",
 ]

--- a/core/models/models.py
+++ b/core/models/models.py
@@ -539,3 +539,17 @@ class SiteKey(Base):
     created_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
     last_used_at = Column(DateTime(timezone=True), nullable=True)
     active = Column(Boolean, default=True)
+
+
+class CustomColumn(Base):
+    """Metadata for columns added at runtime."""
+
+    __tablename__ = "custom_columns"
+
+    id = Column(Integer, primary_key=True)
+    table_name = Column(String, nullable=False)
+    column_name = Column(String, nullable=False)
+    data_type = Column(String, nullable=False)
+    default_value = Column(String, nullable=True)
+    user_visible = Column(Boolean, default=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))

--- a/server/main.py
+++ b/server/main.py
@@ -48,6 +48,7 @@ from server.routes import (
     cloud_sync_router,
     admin_menu_router,
     admin_images_router,
+    admin_columns_router,
     org_settings_router,
     api_devices_router,
     api_users_router,
@@ -218,6 +219,7 @@ app.include_router(admin_site_keys_router)
 app.include_router(cloud_sync_router)
 app.include_router(admin_menu_router)
 app.include_router(admin_images_router)
+app.include_router(admin_columns_router)
 app.include_router(org_settings_router)
 
 

--- a/server/routes/__init__.py
+++ b/server/routes/__init__.py
@@ -38,6 +38,7 @@ from .ui.admin_site_keys import router as admin_site_keys_router
 from .ui.cloud_sync import router as cloud_sync_router
 from .ui.admin_menu import router as admin_menu_router
 from .ui.admin_images import router as admin_images_router
+from .ui.admin_columns import router as admin_columns_router
 from .ui.org_settings import router as org_settings_router
 from .api.devices import router as api_devices_router
 from .api.users import router as api_users_router
@@ -88,6 +89,7 @@ __all__ = [
     "cloud_sync_router",
     "admin_menu_router",
     "admin_images_router",
+    "admin_columns_router",
     "org_settings_router",
     "api_devices_router",
     "api_users_router",

--- a/server/routes/ui/admin_columns.py
+++ b/server/routes/ui/admin_columns.py
@@ -1,0 +1,78 @@
+from fastapi import APIRouter, Request, Depends, Form, HTTPException
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+
+from core.utils.auth import require_role
+from core.utils.db_session import get_db, engine
+import sqlalchemy as sa
+from core.models.models import CustomColumn
+from core.utils.templates import templates
+
+router = APIRouter()
+
+
+@router.get("/admin/columns")
+async def list_columns(request: Request, db: Session = Depends(get_db), current_user=Depends(require_role("superadmin"))):
+    columns = db.query(CustomColumn).order_by(CustomColumn.id).all()
+    context = {"request": request, "columns": columns, "current_user": current_user}
+    return templates.TemplateResponse("column_list.html", context)
+
+
+@router.get("/admin/columns/new")
+async def add_column_form(request: Request, current_user=Depends(require_role("superadmin"))):
+    inspector = sa.inspect(engine)
+    tables = inspector.get_table_names()
+    context = {"request": request, "tables": tables, "current_user": current_user}
+    return templates.TemplateResponse("column_form.html", context)
+
+
+@router.post("/admin/columns/new")
+async def create_column(
+    request: Request,
+    table_name: str = Form(...),
+    column_name: str = Form(...),
+    data_type: str = Form(...),
+    default_value: str | None = Form(None),
+    user_visible: bool = Form(False),
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    if not column_name.isidentifier():
+        raise HTTPException(status_code=400, detail="Invalid column name")
+    full_name = f"custom_{column_name}"
+    stmt = f"ALTER TABLE {table_name} ADD COLUMN {full_name} {data_type}"
+    if default_value:
+        stmt += " DEFAULT :default"
+    try:
+        db.execute(text(stmt), {"default": default_value})
+        db.add(
+            CustomColumn(
+                table_name=table_name,
+                column_name=full_name,
+                data_type=data_type,
+                default_value=default_value,
+                user_visible=user_visible,
+            )
+        )
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Failed to add column")
+    return RedirectResponse("/admin/columns", status_code=302)
+
+
+@router.post("/admin/columns/{col_id}/delete")
+async def delete_column(col_id: int, db: Session = Depends(get_db), current_user=Depends(require_role("superadmin"))):
+    col = db.query(CustomColumn).filter_by(id=col_id).first()
+    if not col:
+        raise HTTPException(status_code=404, detail="Not found")
+    try:
+        db.execute(text(f"ALTER TABLE {col.table_name} DROP COLUMN {col.column_name}"))
+        db.delete(col)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Failed to drop column")
+    return RedirectResponse("/admin/columns", status_code=302)
+

--- a/web-client/templates/column_form.html
+++ b/web-client/templates/column_form.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Add Column</h1>
+<form method="post" action="/admin/columns/new" class="space-y-2">
+  <div>
+    <label>Table</label>
+    <select name="table_name" class="input">
+      {% for t in tables %}<option value="{{ t }}">{{ t }}</option>{% endfor %}
+    </select>
+  </div>
+  <div>
+    <label>Column Name</label>
+    <input type="text" name="column_name" class="input" />
+  </div>
+  <div>
+    <label>Data Type</label>
+    <input type="text" name="data_type" value="TEXT" class="input" />
+  </div>
+  <div>
+    <label>Default Value</label>
+    <input type="text" name="default_value" class="input" />
+  </div>
+  <div>
+    <label><input type="checkbox" name="user_visible" value="1" checked> User Visible</label>
+  </div>
+  <button type="submit" class="btn">Create</button>
+</form>
+{% endblock %}

--- a/web-client/templates/column_list.html
+++ b/web-client/templates/column_list.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 class="text-xl mb-4">Custom Columns</h1>
+<a href="/admin/columns/new" class="btn">Add Column</a>
+<table class="min-w-full mt-4">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Table</th>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Visible</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for col in columns %}
+    <tr>
+      <td>{{ col.id }}</td>
+      <td>{{ col.table_name }}</td>
+      <td>{{ col.column_name }}</td>
+      <td>{{ col.data_type }}</td>
+      <td>{{ col.default_value or '' }}</td>
+      <td>{{ 'Yes' if col.user_visible else 'No' }}</td>
+      <td>
+        <form method="post" action="/admin/columns/{{ col.id }}/delete" onsubmit="return confirm('Delete column?');">
+          <button type="submit" class="text-red-600">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `CustomColumn` model and table
- create migration for the new table
- allow superadmins to add or remove columns at runtime
- expose new admin UI for managing custom columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c4f81b4883249458926e5dc762de