### PR TITLE
Enhance update modal with feedback and auto reload

### DIFF
--- a/web-client/static/css/unocss.css
+++ b/web-client/static/css/unocss.css
@@ -185,6 +185,7 @@
 .bg-black\/50{background-color:rgb(0 0 0 / 0.5) /* #000 */;}
 .bg-green-500{--un-bg-opacity:1;background-color:rgb(34 197 94 / var(--un-bg-opacity)) /* #22c55e */;}
 .bg-red-500{--un-bg-opacity:1;background-color:rgb(239 68 68 / var(--un-bg-opacity)) /* #ef4444 */;}
+.bg-red-600{--un-bg-opacity:1;background-color:rgb(220 38 38 / var(--un-bg-opacity)) /* #dc2626 */;}
 .hover\:bg-\[var\(--btn-hover\)\]:hover{background-color:var(--btn-hover) /* var(--btn-hover) */;}
 .hover\:bg-\[var\(--submenu-hover-bg\)\]:hover{background-color:var(--submenu-hover-bg) /* var(--submenu-hover-bg) */;}
 .hover\:bg-\[var\(--tab-hover\)\]:hover{background-color:var(--tab-hover) /* var(--tab-hover) */;}

--- a/web-client/templates/update_modal.html
+++ b/web-client/templates/update_modal.html
@@ -13,8 +13,13 @@
     </div>
     {% else %}
     <h1 class="text-xl mb-2">Updating...</h1>
+    <div id="update-error" class="mb-2 hidden bg-red-600 text-white p-2 rounded"></div>
     <p id="update-status" class="mb-2">Fetching update...</p>
     <pre id="update-log" class="h-48 overflow-y-auto bg-black text-green-400 p-2 rounded"></pre>
+    <div class="text-right mt-2">
+      <button type="button" id="update-close-btn" class="px-3 py-1 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded" disabled onclick="document.getElementById('modal').innerHTML=''">Close</button>
+      <button type="button" id="update-retry-btn" class="px-3 py-1 ml-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded hidden">Retry</button>
+    </div>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add progress log with close and retry buttons
- reload UI after update finishes and display reboot message
- broadcast update progress including cloud sync information
- rebuild UnoCSS for frontend changes

## Testing
- `npm install`
- `npm run build:web`
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6852c74625dc8324b1b4dc3f76710c6b