### PR TITLE
Fix admin image upload refresh

### DIFF
--- a/server/routes/ui/admin_images.py
+++ b/server/routes/ui/admin_images.py
@@ -193,6 +193,5 @@ async def update_images(
             dtype.upload_image = image_name
         db.commit()
     if request.headers.get("HX-Request"):
-        context = {"request": request, "message": "Images updated"}
-        return templates.TemplateResponse("message_modal.html", context)
+        return HTMLResponse(status_code=204, headers={"HX-Redirect": f"/admin/upload-image?category={category}&message=Images+updated"})
     return RedirectResponse(url=f"/admin/upload-image?category={category}&message=Images+updated", status_code=302)

--- a/tests/test_admin_image_upload.py
+++ b/tests/test_admin_image_upload.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import importlib
+from unittest import mock
+import types
+from io import BytesIO
+from fastapi.testclient import TestClient
+
+
+def get_client(db):
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    for m in list(sys.modules):
+        if m.startswith("server"):
+            del sys.modules[m]
+    with mock.patch("sqlalchemy.create_engine"), \
+         mock.patch("sqlalchemy.schema.MetaData.create_all"), \
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"), \
+         mock.patch("server.workers.sync_pull_worker.start_sync_pull_worker"):
+        app = importlib.import_module("server.main").app
+        key = importlib.import_module("core.utils.db_session").get_db
+        app.dependency_overrides[key] = lambda: db
+        from core.utils import auth as auth_utils
+        app.dependency_overrides[auth_utils.get_current_user] = lambda: types.SimpleNamespace(id=1, role="superadmin")
+        return TestClient(app)
+
+
+class DummyQuery:
+    def __init__(self, obj):
+        self.obj = obj
+    def filter(self, *args, **kwargs):
+        return self
+    def first(self):
+        return self.obj
+
+
+class DummyDB:
+    def __init__(self, dtype):
+        self.dtype = dtype
+        self.committed = False
+    def query(self, model):
+        return DummyQuery(self.dtype if model.__name__ == "DeviceType" else None)
+    def commit(self):
+        self.committed = True
+
+
+def test_update_images_hx_redirect(tmp_path, monkeypatch):
+    from core.models import models
+    dtype = models.DeviceType(id=1, name="Test")
+    db = DummyDB(dtype)
+    client = get_client(db)
+    import server.routes.ui.admin_images as admin_images
+    monkeypatch.setattr(admin_images, "STATIC_DIR", str(tmp_path))
+
+    resp = client.post(
+        "/admin/upload-image/device/1",
+        files={"icon": ("icon.png", BytesIO(b"data"), "image/png")},
+        headers={"HX-Request": "true"},
+    )
+    assert resp.status_code == 204
+    assert resp.headers.get("HX-Redirect")
+    assert db.committed


### PR DESCRIPTION
## Summary
- refresh admin image grid after uploading pictures
- test HX-Redirect for image uploads

## Testing
- `npm install`
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852cadacb6c8324a51feb9f4d54cd0e