### PR TITLE
Fix sync push worker

### DIFF
--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -48,7 +48,7 @@ def _update_last_sync(db) -> None:
 
 
 async def push_once(log: logging.Logger) -> None:
-    push_url, _, api_key = _get_sync_config()
+    push_url, _, site_id, api_key = _get_sync_config()
     db = SessionLocal()
     try:
         since = _load_last_sync(db)
@@ -64,7 +64,7 @@ async def push_once(log: logging.Logger) -> None:
                 {**_serialize(r), "model": Device.__tablename__} for r in records
             ]
         }
-        await _request_with_retry("POST", push_url, payload, log, api_key)
+        await _request_with_retry("POST", push_url, payload, log, site_id, api_key)
         _update_last_sync(db)
     finally:
         db.close()

--- a/tests/workers/test_sync_push_worker.py
+++ b/tests/workers/test_sync_push_worker.py
@@ -103,10 +103,10 @@ def test_push_once_sends_unsynced_records(monkeypatch):
     old_value = db.data[models.SystemTunable][0].value
 
     monkeypatch.setattr(sync_push_worker, "SessionLocal", lambda: db)
-    monkeypatch.setattr(sync_push_worker, "_get_sync_config", lambda: ("http://push", "http://pull", ""))
+    monkeypatch.setattr(sync_push_worker, "_get_sync_config", lambda: ("http://push", "http://pull", "site1", ""))
     sent = {}
 
-    async def fake_request(method, url, payload, log, api_key):
+    async def fake_request(method, url, payload, log, site_id, api_key):
         sent["payload"] = payload
 
     monkeypatch.setattr(sync_push_worker, "_request_with_retry", fake_request)


### PR DESCRIPTION
## Summary
- fix tuple unpacking in `sync_push_worker.push_once`
- update tests to match new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852dd70344c8324a0f97d269ee8eac3