### PR TITLE
Auto-enable sync workers when saving cloud settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,10 +271,10 @@ python setup_cloud_connection.py https://CESTechnologies.Patch-Bay.com my-api-ke
 
 If any of the parameters are omitted you will be prompted interactively. The
 final argument enables cloud sync when set to `yes`/`1`. If the connection
-succeeds the script prints `Connection successful` and the background workers
-will use these values on the next run. Remember to set the environment variables
-`ENABLE_CLOUD_SYNC`, `ENABLE_SYNC_PUSH_WORKER` and `ENABLE_SYNC_PULL_WORKER` so
-the related workers actually start.
+succeeds the script prints `Connection successful`, updates `.env` with the
+required worker flags and the background workers will use these values on the
+next run. Manual editing of `ENABLE_CLOUD_SYNC`, `ENABLE_SYNC_PUSH_WORKER` and
+`ENABLE_SYNC_PULL_WORKER` is no longer required.
 
 The `mobile-client/` folder now contains a minimal React Native app that lists devices from the REST API. Use `npm install` then `npm start` inside that directory to launch it with Expo.
 

--- a/core/utils/env_file.py
+++ b/core/utils/env_file.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from typing import Any
+import re
+
+
+def set_env_vars(path: str = ".env", **updates: str) -> None:
+    """Create or update environment variables in a .env style file."""
+    env_path = Path(path)
+    lines: list[str] = []
+    if env_path.exists():
+        lines = env_path.read_text().splitlines()
+    env_map: dict[str, str] = {}
+    for line in lines:
+        if line.strip().startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        env_map[key.strip()] = value.strip()
+    env_map.update({k: str(v) for k, v in updates.items()})
+    new_lines = []
+    processed = set()
+    for line in lines:
+        if line.strip().startswith("#") or "=" not in line:
+            new_lines.append(line)
+            continue
+        key = line.split("=", 1)[0].strip()
+        if key in updates:
+            new_lines.append(f"{key}={env_map[key]}")
+            processed.add(key)
+        else:
+            new_lines.append(f"{key}={env_map[key]}")
+            processed.add(key)
+    for key, value in env_map.items():
+        if key not in processed:
+            new_lines.append(f"{key}={value}")
+    env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")

--- a/server/routes/ui/sync_diagnostics.py
+++ b/server/routes/ui/sync_diagnostics.py
@@ -11,6 +11,7 @@ from core.models.models import SystemTunable, SiteKey, AuditLog
 from core.utils.templates import templates
 from .tunables import grouped_tunables
 from server.workers.heartbeat import send_heartbeat_once
+from core.utils.env_file import set_env_vars
 
 router = APIRouter()
 
@@ -110,6 +111,11 @@ async def test_cloud_sync(
             else:
                 db.add(SystemTunable(name="Enable Cloud Sync", value="true" if enabled else "false", function="Sync", file_type="application", data_type="bool"))
             db.commit()
+            set_env_vars(
+                ENABLE_CLOUD_SYNC="1" if enabled else "0",
+                ENABLE_SYNC_PUSH_WORKER="1" if enabled else "0",
+                ENABLE_SYNC_PULL_WORKER="1" if enabled else "0",
+            )
             msg = "Connection successful"
         except Exception as exc:
             msg = f"Connection failed: {exc}"

--- a/setup_cloud_connection.py
+++ b/setup_cloud_connection.py
@@ -2,6 +2,8 @@ import asyncio
 import sys
 import httpx
 
+from core.utils.env_file import set_env_vars
+
 from core.utils.db_session import SessionLocal
 from core.models.models import SystemTunable
 
@@ -62,6 +64,12 @@ def main() -> None:
         print(f"Connection failed: {exc}")
         sys.exit(1)
     print("Connection successful")
+    set_env_vars(
+        ENABLE_CLOUD_SYNC="1" if enabled else "0",
+        ENABLE_SYNC_PUSH_WORKER="1" if enabled else "0",
+        ENABLE_SYNC_PULL_WORKER="1" if enabled else "0",
+    )
+    print("Updated .env with sync worker settings")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add utility for updating `.env` files
- update sync diagnostics UI and setup helper to write worker flags
- document automatic worker setup in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e453108c83249a5b1caf81b90ffc