### PR TITLE
Enable sync workers when cloud settings saved

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ After installation you can configure the cloud connection from this page. Look f
 - **Cloud API Key** – token passed with sync requests
 
 Updating these values in the UI takes effect the next time the sync workers run.
+Saving the form also updates `.env` to enable the sync workers automatically.
 
 ## Server Workers
 

--- a/server/routes/ui/cloud_sync.py
+++ b/server/routes/ui/cloud_sync.py
@@ -9,6 +9,7 @@ from core.utils.auth import require_role
 from core.utils.db_session import get_db
 from core.models.models import ConnectedSite, SiteKey, SystemTunable
 from core.utils.templates import templates
+from core.utils.env_file import set_env_vars
 
 router = APIRouter()
 
@@ -97,4 +98,10 @@ async def update_cloud_config(
     _set_tunable(db, "Cloud Base URL", cloud_url)
     _set_tunable(db, "Cloud Site ID", site_id)
     _set_tunable(db, "Cloud API Key", api_key)
+    _set_tunable(db, "Enable Cloud Sync", "true")
+    set_env_vars(
+        ENABLE_CLOUD_SYNC="1",
+        ENABLE_SYNC_PUSH_WORKER="1",
+        ENABLE_SYNC_PULL_WORKER="1",
+    )
     return RedirectResponse("/admin/cloud-sync", status_code=302)

--- a/tests/test_cloud_sync_update.py
+++ b/tests/test_cloud_sync_update.py
@@ -1,0 +1,53 @@
+import importlib
+import os
+import sys
+import types
+from unittest import mock
+from fastapi.testclient import TestClient
+
+
+def get_client():
+    os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/test")
+    os.environ["ROLE"] = "local"
+    if "settings" in sys.modules:
+        del sys.modules["settings"]
+    for m in list(sys.modules):
+        if m.startswith("server"):
+            del sys.modules[m]
+    with mock.patch("sqlalchemy.create_engine"), \
+         mock.patch("sqlalchemy.schema.MetaData.create_all"), \
+         mock.patch("server.workers.queue_worker.start_queue_worker"), \
+         mock.patch("server.workers.config_scheduler.start_config_scheduler"), \
+         mock.patch("server.workers.trap_listener.setup_trap_listener"), \
+         mock.patch("server.workers.syslog_listener.setup_syslog_listener"), \
+         mock.patch("server.workers.sync_push_worker.start_sync_push_worker"), \
+         mock.patch("server.workers.sync_pull_worker.start_sync_pull_worker"), \
+        mock.patch("server.workers.cloud_sync.start_cloud_sync"):
+        app = importlib.import_module("server.main").app
+        from core.utils import templates as templates_utils
+        from datetime import datetime
+        templates_utils.templates.env.globals["datetime"] = datetime
+        return TestClient(app)
+
+
+def test_update_cloud_config_sets_env_vars():
+    client = get_client()
+    from core.utils import auth as auth_utils
+
+    admin_user = types.SimpleNamespace(id=1, role="admin")
+    client.app.dependency_overrides[auth_utils.get_current_user] = lambda: admin_user
+
+    with mock.patch("server.routes.ui.cloud_sync._set_tunable"), \
+         mock.patch("server.routes.ui.cloud_sync.set_env_vars") as set_env:
+        resp = client.post(
+            "/admin/cloud-sync/update",
+            data={"cloud_url": "http://cloud", "site_id": "1", "api_key": "key"},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code == 302
+    set_env.assert_called_once_with(
+        ENABLE_CLOUD_SYNC="1",
+        ENABLE_SYNC_PUSH_WORKER="1",
+        ENABLE_SYNC_PULL_WORKER="1",
+    )


### PR DESCRIPTION
## Summary
- write worker flags to `.env` when updating cloud connection
- clarify README about automatic sync worker setup
- add regression test for the cloud sync update route

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852e98c2cb48324bee96bc695f9515a