### PR TITLE
Clarify NAT and local sync initiation in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ required worker flags and the background workers will use these values on the
 next run. Manual editing of `ENABLE_CLOUD_SYNC`, `ENABLE_SYNC_PUSH_WORKER` and
 `ENABLE_SYNC_PULL_WORKER` is no longer required.
 
+Local sites often run behind NAT or firewalls that block inbound traffic. The sync workers therefore initiate outbound connections to the cloud using the API key assigned to the site. As long as that key exists in the cloud server's allowed list the push and pull operations will succeed without any ports opened on the local network.
+
 The `mobile-client/` folder now contains a minimal React Native app that lists devices from the REST API. Use `npm install` then `npm start` inside that directory to launch it with Expo.
 
 ## Interface Themes

--- a/docs/cloud-architecture.md
+++ b/docs/cloud-architecture.md
@@ -37,7 +37,7 @@ This document outlines the proposed design for Phase 6 of the project. The goal 
 </div>
 
 1. Local replicas queue updates in their worker queue.
-2. When connectivity allows, a periodic job posts batched updates to the cloud `/sync` API via the load balancer.
+2. The connection to the cloud is always initiated by the local site because inbound traffic may be blocked by NAT or firewalls. A periodic job posts batched updates to the cloud `/sync` API via the load balancer using the site's API key.
 3. The sync gateway processes updates and responds with any newer records for the site.
 4. If conflicts occur (matching IDs with different versions), the cloud marks the record as needing manual resolution.
 5. If the connection fails, the queue keeps retrying until the cloud is reachable.


### PR DESCRIPTION
## Summary
- document that local replicas initiate sync with the cloud
- explain NAT/firewall considerations in README

## Testing
- `npm install`
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852f0679e4c8324a9d22949a224f41a