### PR TITLE
Add API key visibility and deletion

### DIFF
--- a/server/routes/ui/admin_site_keys.py
+++ b/server/routes/ui/admin_site_keys.py
@@ -67,3 +67,16 @@ async def toggle_site_key(
         key.active = not key.active
         db.commit()
     return RedirectResponse(url="/admin/site-keys", status_code=302)
+
+
+@router.post("/admin/site-keys/{key_id}/delete")
+async def delete_site_key(
+    key_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    key = db.query(SiteKey).filter(SiteKey.id == key_id).first()
+    if key:
+        db.delete(key)
+        db.commit()
+    return RedirectResponse(url="/admin/site-keys", status_code=302)

--- a/web-client/static/css/unocss.css
+++ b/web-client/static/css/unocss.css
@@ -156,6 +156,7 @@
 .overflow-y-auto{overflow-y:auto;}
 .whitespace-nowrap{white-space:nowrap;}
 .whitespace-pre-wrap{white-space:pre-wrap;}
+.break-all{word-break:break-all;}
 .b,
 .border{border-width:1px;}
 .border-b{border-bottom-width:1px;}

--- a/web-client/templates/admin_sync.html
+++ b/web-client/templates/admin_sync.html
@@ -54,6 +54,7 @@
             <tr>
               <th class="table-cell table-header">Site Name</th>
               <th class="table-cell table-header">Site ID</th>
+              <th class="table-cell table-header">API Key</th>
               <th class="table-cell table-header">Status</th>
               <th class="table-cell table-header">Last Used</th>
               <th class="table-header text-center actions-col">Actions</th>
@@ -65,16 +66,22 @@
             <tr class="border-t border-gray-700">
               <td class="table-cell">{{ key.site_name }}</td>
               <td class="table-cell">{{ key.site_id }}</td>
+              <td class="table-cell font-mono break-all">{{ key.api_key }}</td>
               <td class="table-cell">{{ 'Active' if key.active else 'Revoked' }}</td>
               <td class="table-cell">{{ key.last_used_at or 'never' }}</td>
               <td class="actions-col text-center">
-                <form method="post" action="/admin/site-keys/{{ key.id }}/toggle">
-                  {% if key.active %}
-                  <button type="submit" aria-label="Disable" class="icon-btn" onclick="return confirm('Disable key?')">{{ include_icon('x-circle','text-red-500','5') }}</button>
-                  {% else %}
-                  <button type="submit" aria-label="Enable" class="icon-btn">{{ include_icon('check-circle','text-green-500','5') }}</button>
-                  {% endif %}
-                </form>
+                <div class="flex justify-center gap-1">
+                  <form method="post" action="/admin/site-keys/{{ key.id }}/toggle" class="inline">
+                    {% if key.active %}
+                    <button type="submit" aria-label="Disable" class="icon-btn" onclick="return confirm('Disable key?')">{{ include_icon('x-circle','text-red-500','5') }}</button>
+                    {% else %}
+                    <button type="submit" aria-label="Enable" class="icon-btn">{{ include_icon('check-circle','text-green-500','5') }}</button>
+                    {% endif %}
+                  </form>
+                  <form method="post" action="/admin/site-keys/{{ key.id }}/delete" class="inline">
+                    <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete key?')">{{ include_icon('trash-2','text-red-500','5') }}</button>
+                  </form>
+                </div>
               </td>
             </tr>
           {% endfor %}

--- a/web-client/templates/site_keys.html
+++ b/web-client/templates/site_keys.html
@@ -21,6 +21,7 @@
     <tr>
       <th class="table-cell table-header">Site Name</th>
       <th class="table-cell table-header">Site ID</th>
+      <th class="table-cell table-header">API Key</th>
       <th class="table-cell table-header">Active</th>
       <th class="table-cell table-header">Last Used</th>
       <th class="table-cell table-header">Status</th>
@@ -32,18 +33,24 @@
     <tr class="border-t border-gray-700">
       <td class="table-cell">{{ key.site_name }}</td>
       <td class="table-cell">{{ key.site_id }}</td>
+      <td class="table-cell font-mono break-all">{{ key.api_key }}</td>
       <td class="table-cell">{{ 'yes' if key.active else 'no' }}</td>
       <td class="table-cell">{{ key.last_used_at or 'never' }}</td>
       {% set stale = key.last_used_at is none or (now - key.last_used_at > timedelta(hours=24)) %}
       <td class="table-cell">{{ 'stale' if stale else 'ok' }}</td>
       <td class="actions-col text-center">
-        <form method="post" action="/admin/site-keys/{{ key.id }}/toggle">
-          {% if key.active %}
-          <button type="submit" aria-label="Disable" class="icon-btn" onclick="return confirm('Disable key?')">{{ include_icon('x-circle','text-red-500','5') }}</button>
-          {% else %}
-          <button type="submit" aria-label="Enable" class="icon-btn">{{ include_icon('check-circle','text-green-500','5') }}</button>
-          {% endif %}
-        </form>
+        <div class="flex justify-center gap-1">
+          <form method="post" action="/admin/site-keys/{{ key.id }}/toggle" class="inline">
+            {% if key.active %}
+            <button type="submit" aria-label="Disable" class="icon-btn" onclick="return confirm('Disable key?')">{{ include_icon('x-circle','text-red-500','5') }}</button>
+            {% else %}
+            <button type="submit" aria-label="Enable" class="icon-btn">{{ include_icon('check-circle','text-green-500','5') }}</button>
+            {% endif %}
+          </form>
+          <form method="post" action="/admin/site-keys/{{ key.id }}/delete" class="inline">
+            <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete key?')">{{ include_icon('trash-2','text-red-500','5') }}</button>
+          </form>
+        </div>
       </td>
     </tr>
   {% endfor %}


### PR DESCRIPTION
## Summary
- display API keys in management tables
- allow deleting API key records
- regenerate UnoCSS build

## Testing
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852f5d46d108324b2170c0045d3a7bb