### PR TITLE
Fix install user creation

### DIFF
--- a/server/routes/install.py
+++ b/server/routes/install.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Request, Form
 from fastapi.responses import RedirectResponse
 from core.utils.templates import templates
-import os, subprocess
+import os, subprocess, sys
 from server.utils.cloud import ensure_env_writable
 
 router = APIRouter()
@@ -96,9 +96,9 @@ async def install_finish(request: Request, seed: str = Form("no")):
         "SECRET_KEY": data["secret_key"],
     })
     subprocess.run(["alembic", "upgrade", "head"], check=True, env=env)
-    subprocess.run(["python", "seed_tunables.py"], check=True, env=env)
+    subprocess.run([sys.executable, "seed_tunables.py"], check=True, env=env)
     if seed == "yes":
-        subprocess.run(["python", "seed_data.py"], check=True, env=env)
+        subprocess.run([sys.executable, "seed_data.py"], check=True, env=env)
 
     import json, base64
     payload = {
@@ -118,6 +118,6 @@ async def install_finish(request: Request, seed: str = Form("no")):
         "role='superadmin',is_active=True);"
         "db.add(user);db.commit();db.close()"
     )
-    subprocess.run(["python", "-c", create_admin], check=True, env=env)
+    subprocess.run([sys.executable, "-c", create_admin], check=True, env=env)
     request.session.clear()
     return templates.TemplateResponse("install/complete.html", {"request": request})

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -33,7 +33,7 @@ def test_install_finish_handles_quotes(monkeypatch):
 
     assert fake_run_calls, "subprocess.run not called"
     cmd = fake_run_calls[-1]
-    assert cmd[:2] == ["python", "-c"]
+    assert cmd[:2] == [install_module.sys.executable, "-c"]
     payload = {"email": data["admin_email"], "password": data["admin_password"]}
     encoded = base64.b64encode(json.dumps(payload).encode()).decode()
     assert encoded in cmd[2]


### PR DESCRIPTION
## Summary
- ensure the install wizard uses the running Python interpreter for seeding and admin creation
- update tests for the new command path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852f93301d8832490c3898772320762