### PR TITLE
Fix cloud sync navigation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ adjusted from the same **Edit Profile** form.
 ## System Tunables
 
 The application stores various settings in the `system_tunables` table. These are seeded with default values by `seed_tunables.py` and can be adjusted from the **System Tunables** page in the web UI (admin role required).
+Superadmins can manage the connection to a cloud server from **Cloud Sync / API's** at `/admin/cloud-sync`.
 
 After installation you can configure the cloud connection from this page. Look for the following tunables under the **Sync** function:
 

--- a/server/routes/ui/admin_menu.py
+++ b/server/routes/ui/admin_menu.py
@@ -60,6 +60,7 @@ async def sync_menu(
     current_user=Depends(require_role("superadmin")),
 ):
     items = [
+        {"label": "Cloud Sync", "href": "/admin/cloud-sync"},
         {"label": "Google Sheets", "href": "/tasks/google-sheets"},
         {"label": "Google Maps", "href": "/tunables?category=Google%20Maps"},
         {"label": "Netbird", "href": "/ssh/netbird-connect"},

--- a/web-client/templates/help.html
+++ b/web-client/templates/help.html
@@ -27,7 +27,7 @@
   <ul class="list-disc list-inside space-y-1">
     <li><strong>My Profile</strong> &ndash; Update your user preferences.</li>
     <li><strong>System / Organisation Settings</strong> &ndash; Configure system wide values and organisational details.</li>
-    <li><strong>Sync / API's</strong> &ndash; Manage cloud synchronisation and API keys.</li>
+    <li><strong>Cloud Sync / API's</strong> &ndash; Manage cloud synchronisation and API keys.</li>
     <li><strong>Logs</strong> or <strong>Locations</strong> / <strong>SSH Credentials</strong> &ndash; Tools specific to your role.</li>
   </ul>
 </div>

--- a/web-client/templates/nav_dropdown.html
+++ b/web-client/templates/nav_dropdown.html
@@ -21,7 +21,7 @@
             {'label':'My Profile','href':'/users/me'},
             {'label':'System','href':'/admin/system'},
             {'label':'Organisation Settings','href':'/admin/org-settings'},
-            {'label':'Sync / API\'s','href':'/admin/sync'},
+            {'label':'Cloud Sync / API\'s','href':'/admin/cloud-sync'},
             {'label':'Logs','href':'/admin/logs'}
           ] %}
           {% else %}

--- a/web-client/templates/nav_folder.html
+++ b/web-client/templates/nav_folder.html
@@ -40,7 +40,7 @@
           {'label':'My Profile','href':'/users/me'},
           {'label':'System','href':'/admin/system'},
           {'label':'Organisation Settings','href':'/admin/org-settings'},
-          {'label':'Sync / API\'s','href':'/admin/sync'},
+          {'label':'Cloud Sync / API\'s','href':'/admin/cloud-sync'},
           {'label':'Logs','href':'/admin/logs'}
         ] %}
         {% else %}

--- a/web-client/templates/nav_tabbed.html
+++ b/web-client/templates/nav_tabbed.html
@@ -18,7 +18,7 @@
               {'label':'My Profile','href':'/users/me'},
               {'label':'System','href':'/admin/system'},
               {'label':'Organisation Settings','href':'/admin/org-settings'},
-              {'label':'Sync / API\'s','href':'/admin/sync'},
+              {'label':'Cloud Sync / API\'s','href':'/admin/cloud-sync'},
               {'label':'Logs','href':'/admin/logs'}
             ] %}
             {% else %}


### PR DESCRIPTION
## Summary
- update admin menu to include a link to `/admin/cloud-sync`
- update navigation templates to point at `/admin/cloud-sync`
- tweak help page text
- document the cloud sync page in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853091ae99c83248e7498259ae16d07