### PR TITLE
Fix editor context and datetime serialization

### DIFF
--- a/core/utils/versioning.py
+++ b/core/utils/versioning.py
@@ -16,10 +16,15 @@ def apply_update(
     if incoming_version is not None and incoming_version != current_version:
         conflicts = []
         for field, remote_value in update_data.items():
+            local_value = getattr(obj, field, None)
+            if isinstance(local_value, datetime):
+                local_value = local_value.isoformat()
+            if isinstance(remote_value, datetime):
+                remote_value = remote_value.isoformat()
             conflicts.append(
                 {
                     "field": field,
-                    "local_value": getattr(obj, field, None),
+                    "local_value": local_value,
                     "remote_value": remote_value,
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                     "source": source,

--- a/server/routes/ui/editor.py
+++ b/server/routes/ui/editor.py
@@ -8,5 +8,5 @@ router = APIRouter()
 
 @router.get("/editor")
 async def editor(request: Request, file: str = "/etc/hosts", current_user=Depends(require_role("admin"))):
-    context = {"request": request, "file_path": file}
+    context = {"request": request, "file_path": file, "current_user": current_user}
     return templates.TemplateResponse("editor.html", context)

--- a/web-client/static/css/unocss.css
+++ b/web-client/static/css/unocss.css
@@ -263,7 +263,6 @@
 .sm\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr));}
 }
 @media (min-width: 768px){
-.md\:col-span-2{grid-column:span 2/span 2;}
 .md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr));}
 .md\:grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr));}
 .md\:grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr));}

--- a/web-client/templates/nav_tabbed.html
+++ b/web-client/templates/nav_tabbed.html
@@ -54,7 +54,7 @@
           <a href="/network/settings" @click="setSub('/network/settings')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/network/settings'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Network Settings</a>
         </div>
       </div>
-      {% if current_user.role in ['admin','superadmin'] %}
+      {% if current_user and current_user.role in ['admin','superadmin'] %}
       <div x-show="ready && activeTopMenu == 'admin'" x-transition.opacity.duration.150ms :class="(submenuAlign === 'right' ? 'text-right' : '') + ' w-full border border-[var(--border-color)] border-t-0 rounded-b-lg bg-[var(--submenu-bg)] text-[var(--submenu-text)] px-4 py-3'" x-cloak>
         <div :class="mobile ? 'flex flex-col space-y-2 submenu text-sm' : (submenuAlign === 'right' ? 'flex space-x-2 text-sm justify-end submenu' : 'flex space-x-2 text-sm submenu')">
           {% for item in admin_items %}


### PR DESCRIPTION
## Summary
- include `current_user` when rendering the editor template
- guard admin nav items when `current_user` is missing
- convert datetime values when building conflict data
- rebuild UnoCSS

## Testing
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853127bc0c48324a621f1425fb3d8b4