### PR TITLE
Fix device deletion foreign key

### DIFF
--- a/alembic/versions/0013_audit_log_set_null.py
+++ b/alembic/versions/0013_audit_log_set_null.py
@@ -1,0 +1,32 @@
+"""Set audit log device_id to NULL on device deletion"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0013'
+down_revision = '0012'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint('audit_logs_device_id_fkey', 'audit_logs', type_='foreignkey')
+    op.create_foreign_key(
+        'audit_logs_device_id_fkey',
+        'audit_logs',
+        'devices',
+        ['device_id'],
+        ['id'],
+        ondelete='SET NULL'
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('audit_logs_device_id_fkey', 'audit_logs', type_='foreignkey')
+    op.create_foreign_key(
+        'audit_logs_device_id_fkey',
+        'audit_logs',
+        'devices',
+        ['device_id'],
+        ['id']
+    )

--- a/core/models/models.py
+++ b/core/models/models.py
@@ -280,12 +280,16 @@ class AuditLog(Base):
     id = Column(Integer, primary_key=True)
     user_id = Column(Integer, ForeignKey("users.id"))
     action_type = Column(String, nullable=False)
-    device_id = Column(Integer, ForeignKey("devices.id"), nullable=True)
+    device_id = Column(
+        Integer,
+        ForeignKey("devices.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     timestamp = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
     details = Column(Text, nullable=True)
 
     user = relationship("User")
-    device = relationship("Device")
+    device = relationship("Device", passive_deletes=True)
 
 
 class PortConfigTemplate(Base):


### PR DESCRIPTION
## Summary
- allow cascade delete from devices to audit_logs via ON DELETE SET NULL
- add migration for audit_logs foreign key

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685337b6c8dc83248f2b59f230f28a93