### PR TITLE
Use shared queue for update progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,13 @@ Set the `AUTO_SEED` environment variable to `0` or `false` to skip the automatic
 Adjust `WORKERS`, `TIMEOUT` and `PORT` as needed. The server listens on
 `0.0.0.0` so it can be proxied by a web server such as Nginx.
 
+The update page streams progress over a WebSocket. When running multiple
+workers the messages must be shared between processes so any worker can
+forward them to connected clients. The bundled implementation uses a
+`multiprocessing.Manager` queue controlled by `PROGRESS_HOST`,
+`PROGRESS_PORT` and `PROGRESS_AUTHKEY`. You can swap this out for another
+backend such as Redis pub/sub.
+
 Static assets are served from the `web-client/static` directory.
 This location is fixed. When deploying inside containers or under a reverse
 proxy, ensure that `/path/to/Master-IP-App/web-client/static` is accessible at `/static` so

--- a/server/utils/progress.py
+++ b/server/utils/progress.py
@@ -1,0 +1,77 @@
+import os
+import asyncio
+from multiprocessing.managers import BaseManager
+
+_progress_list = []
+
+def get_progress_list():
+    return _progress_list
+
+
+class ProgressManager(BaseManager):
+    pass
+
+
+ProgressManager.register("get_progress_list", callable=get_progress_list)
+ProgressManager.register("Queue")
+
+HOST = os.environ.get("PROGRESS_HOST", "127.0.0.1")
+PORT = int(os.environ.get("PROGRESS_PORT", "8701"))
+AUTHKEY = os.environ.get("PROGRESS_AUTHKEY", "progress").encode()
+
+_manager: ProgressManager | None = None
+_progress_queues = None
+
+
+def _get_manager() -> ProgressManager:
+    global _manager
+    if _manager is not None:
+        return _manager
+    try:
+        m = ProgressManager(address=(HOST, PORT), authkey=AUTHKEY)
+        m.connect()
+        _manager = m
+    except Exception:
+        m = ProgressManager(address=(HOST, PORT), authkey=AUTHKEY)
+        m.start()
+        _manager = m
+    return _manager
+
+
+def _get_queues():
+    global _progress_queues
+    if _progress_queues is None:
+        manager = _get_manager()
+        _progress_queues = manager.get_progress_list()
+    return _progress_queues
+
+
+def new_queue():
+    manager = _get_manager()
+    q = manager.Queue()
+    _get_queues().append(q)
+    return q
+
+
+def remove_queue(q) -> None:
+    try:
+        _get_queues().remove(q)
+    except ValueError:
+        pass
+
+
+def broadcast(msg: str) -> None:
+    for q in list(_get_queues()):
+        try:
+            q.put(msg)
+        except Exception:
+            pass
+
+
+def has_listeners() -> bool:
+    return bool(_get_queues())
+
+
+async def next_message(q) -> str:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, q.get)


### PR DESCRIPTION
## Summary
- support cross-process broadcast of update events
- listen for progress updates on a manager queue
- document using a shared backend when multiple workers are active

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853cbdb54e483249d6d982cc9d1e99a