### PR TITLE
Fix missing psutil during startup

### DIFF
--- a/server/utils/system_metrics.py
+++ b/server/utils/system_metrics.py
@@ -1,11 +1,18 @@
 import os
-import psutil
 import time
 from typing import Any, Dict
+
+try:
+    import psutil
+except Exception:  # pragma: no cover - optional dependency
+    psutil = None
 
 
 def gather_metrics() -> Dict[str, Any]:
     """Collect system and application metrics."""
+    if psutil is None:
+        return {"error": "psutil not installed"}
+
     cpu_total = psutil.cpu_percent()
     cpu_per_core = psutil.cpu_percent(percpu=True)
     vm = psutil.virtual_memory()


### PR DESCRIPTION
## Summary
- import psutil conditionally
- return an error dictionary when psutil isn't installed

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853d6deecc8832498e1ad8c61b13793