### PR TITLE
Improve cloud sync UI

### DIFF
--- a/server/routes/ui/sync_diagnostics.py
+++ b/server/routes/ui/sync_diagnostics.py
@@ -18,6 +18,19 @@ router = APIRouter()
 
 def _render_sync(request: Request, db: Session, current_user, message: str = ""):
     tunables = {t.name: t.value for t in db.query(SystemTunable).all()}
+    def _fmt(name: str) -> str:
+        val = tunables.get(name)
+        if not val:
+            return "never"
+        try:
+            return datetime.fromisoformat(val).isoformat(sep=" ")
+        except Exception:
+            return "never"
+
+    last_push = _fmt("Last Sync Push")
+    last_pull = _fmt("Last Sync Pull")
+    last_push_worker = _fmt("Last Sync Push Worker")
+    last_pull_worker = _fmt("Last Sync Pull Worker")
     now = datetime.now(timezone.utc)
     last_contact = tunables.get("Last Cloud Contact")
     connection_status = "Disconnected"
@@ -76,6 +89,10 @@ def _render_sync(request: Request, db: Session, current_user, message: str = "")
         "sync_groups": sync_groups,
         "cloud_message": message,
         "current_user": current_user,
+        "last_push": last_push,
+        "last_pull": last_pull,
+        "last_push_worker": last_push_worker,
+        "last_pull_worker": last_pull_worker,
     }
     return templates.TemplateResponse("admin_sync.html", context)
 

--- a/web-client/templates/admin_sync.html
+++ b/web-client/templates/admin_sync.html
@@ -47,13 +47,32 @@
         <li><strong>Type:</strong> {{ connection_type }}</li>
       </ul>
     </div>
+    {% if role == 'cloud' %}
+    <div class="p-3 bg-[var(--card-bg)] rounded">
+      <h2 class="text-lg mb-2">Local Server Connections</h2>
+      {% if sites %}
+      <div class="space-y-1 text-sm">
+        {% for s in sites %}
+        <div class="flex flex-wrap gap-4">
+          <span><strong>Site ID:</strong> {{ s.site_id }}</span>
+          <span><strong>Server:</strong> {{ s.ip_address or 'N/A' }}</span>
+          <span><strong>Type:</strong> local</span>
+          <span><strong>Last Sync:</strong> {{ s.last_seen or 'never' }}</span>
+        </div>
+        {% endfor %}
+      </div>
+      {% else %}
+      <p class="text-sm text-gray-500">No recent connections</p>
+      {% endif %}
+    </div>
+    {% endif %}
     <div class="p-3 bg-[var(--card-bg)] rounded">
       <h2 class="text-lg mb-2">Sync Diagnostics</h2>
       <ul class="list-disc ml-6 text-sm">
-        <li>Last Push: {{ tunables.get('Last Sync Push', 'never') }}</li>
-        <li>Last Pull: {{ tunables.get('Last Sync Pull', 'never') }}</li>
-        <li>Last Push Worker: {{ tunables.get('Last Sync Push Worker', 'never') }}</li>
-        <li>Last Pull Worker: {{ tunables.get('Last Sync Pull Worker', 'never') }}</li>
+        <li>Last Push: {{ last_push }}</li>
+        <li>Last Pull: {{ last_pull }}</li>
+        <li>Last Push Worker: {{ last_push_worker }}</li>
+        <li>Last Pull Worker: {{ last_pull_worker }}</li>
       </ul>
     </div>
   </div>

--- a/web-client/templates/sync_diagnostics.html
+++ b/web-client/templates/sync_diagnostics.html
@@ -3,9 +3,9 @@
 {% block content %}
 <h1 class="text-xl mb-4">Sync Diagnostics</h1>
 <ul class="list-disc ml-6">
-  <li>Last Push: {{ tunables.get('Last Sync Push', 'never') }}</li>
-  <li>Last Pull: {{ tunables.get('Last Sync Pull', 'never') }}</li>
-  <li>Last Push Worker: {{ tunables.get('Last Sync Push Worker', 'never') }}</li>
-  <li>Last Pull Worker: {{ tunables.get('Last Sync Pull Worker', 'never') }}</li>
+  <li>Last Push: {{ last_push }}</li>
+  <li>Last Pull: {{ last_pull }}</li>
+  <li>Last Push Worker: {{ last_push_worker }}</li>
+  <li>Last Pull Worker: {{ last_pull_worker }}</li>
 </ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show local server connections when running in cloud mode
- display last sync activity timestamps without placeholder values

## Testing
- `npm run build:web` *(fails: unocss not found)*
- `pytest -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6853d95c5cb08324bd3d60769b6dc232