### PR TITLE
Exclude tables without version column from sync pull

### DIFF
--- a/server/workers/sync_pull_worker.py
+++ b/server/workers/sync_pull_worker.py
@@ -16,7 +16,9 @@ from .cloud_sync import _get_sync_config
 
 SYNC_PULL_INTERVAL = int(os.environ.get("SYNC_PULL_INTERVAL", "90"))
 _DEFAULT_PULL_MODELS = ",".join(
-    cls.__tablename__ for cls in model_module.Base.__subclasses__()
+    cls.__tablename__
+    for cls in model_module.Base.__subclasses__()
+    if hasattr(cls, "version")
 )
 SYNC_PULL_MODELS = [
     m.strip()


### PR DESCRIPTION
## Summary
- avoid warnings for models without version field
- run pytest

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d99cfae083249cb6145f8d150d1b