### PR TITLE
Fix image upload and replication

### DIFF
--- a/core/utils/image_utils.py
+++ b/core/utils/image_utils.py
@@ -1,0 +1,7 @@
+import base64
+from fastapi import UploadFile
+
+async def file_to_data_uri(file: UploadFile) -> str:
+    data = await file.read()
+    encoded = base64.b64encode(data).decode()
+    return f"data:{file.content_type};base64,{encoded}"

--- a/server/routes/ui/admin_menu.py
+++ b/server/routes/ui/admin_menu.py
@@ -17,6 +17,8 @@ def _menu_image(db: Session, label: str) -> str:
     slug = _slug(label)
     row = db.query(SystemTunable).filter(SystemTunable.name == f"MENU_IMAGE_{slug}").first()
     if row and row.value:
+        if row.value.startswith("data:"):
+            return row.value
         path = os.path.join(STATIC_DIR, "uploads", "menu-items", row.value)
         if os.path.exists(path):
             return f"/static/uploads/menu-items/{row.value}"

--- a/server/routes/ui/device_types.py
+++ b/server/routes/ui/device_types.py
@@ -7,6 +7,7 @@ from core.utils.db_session import get_db
 from core.utils.auth import require_role
 from core.models.models import DeviceType
 import os
+import base64
 from core.utils.paths import STATIC_DIR
 
 
@@ -68,16 +69,18 @@ async def create_device_type(
         if not upload_icon.content_type.startswith("image/"):
             raise HTTPException(status_code=400, detail="Invalid icon type")
         icon_name = f"{dtype.id}_icon_{os.path.basename(upload_icon.filename)}"
+        data = await upload_icon.read()
         with open(os.path.join(upload_dir, icon_name), "wb") as f:
-            f.write(await upload_icon.read())
-        dtype.upload_icon = icon_name
+            f.write(data)
+        dtype.upload_icon = f"data:{upload_icon.content_type};base64,{base64.b64encode(data).decode()}"
     if upload_image and upload_image.filename:
         if not upload_image.content_type.startswith("image/"):
             raise HTTPException(status_code=400, detail="Invalid image type")
         image_name = f"{dtype.id}_img_{os.path.basename(upload_image.filename)}"
+        data = await upload_image.read()
         with open(os.path.join(upload_dir, image_name), "wb") as f:
-            f.write(await upload_image.read())
-        dtype.upload_image = image_name
+            f.write(data)
+        dtype.upload_image = f"data:{upload_image.content_type};base64,{base64.b64encode(data).decode()}"
     db.commit()
     return RedirectResponse(url="/device-types", status_code=302)
 
@@ -135,16 +138,18 @@ async def update_device_type(
         if not upload_icon.content_type.startswith("image/"):
             raise HTTPException(status_code=400, detail="Invalid icon type")
         icon_name = f"{dtype.id}_icon_{os.path.basename(upload_icon.filename)}"
+        data = await upload_icon.read()
         with open(os.path.join(upload_dir, icon_name), "wb") as f:
-            f.write(await upload_icon.read())
-        dtype.upload_icon = icon_name
+            f.write(data)
+        dtype.upload_icon = f"data:{upload_icon.content_type};base64,{base64.b64encode(data).decode()}"
     if upload_image and upload_image.filename:
         if not upload_image.content_type.startswith("image/"):
             raise HTTPException(status_code=400, detail="Invalid image type")
         image_name = f"{dtype.id}_img_{os.path.basename(upload_image.filename)}"
+        data = await upload_image.read()
         with open(os.path.join(upload_dir, image_name), "wb") as f:
-            f.write(await upload_image.read())
-        dtype.upload_image = image_name
+            f.write(data)
+        dtype.upload_image = f"data:{upload_image.content_type};base64,{base64.b64encode(data).decode()}"
     db.commit()
     return RedirectResponse(url="/device-types", status_code=302)
 

--- a/web-client/templates/device_list.html
+++ b/web-client/templates/device_list.html
@@ -16,7 +16,11 @@
 <div class="flex justify-between items-center bg-[var(--card-bg)] px-2 py-1 rounded">
   <div class="flex items-center gap-2">
     {% if device_type and device_type.upload_icon %}
+    {% if device_type.upload_icon.startswith('data:') %}
+    <img src="{{ device_type.upload_icon }}" class="w-6 h-6" alt="" />
+    {% else %}
     <img src="{{ request.url_for('static', path='uploads/device-types/' ~ device_type.upload_icon) }}" class="w-6 h-6" alt="" />
+    {% endif %}
     {% else %}
     {{ include_icon('hard-drive') }}
     {% endif %}

--- a/web-client/templates/devices_grid.html
+++ b/web-client/templates/devices_grid.html
@@ -4,7 +4,7 @@
 <div class="mx-auto w-3/4">
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-0">
     {% for dt in types %}
-    <a href="/devices/type/{{ dt.id }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('/static/uploads/device-types/{{ dt.upload_image }}'); background-size:cover; background-position:center;">
+    <a href="/devices/type/{{ dt.id }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('{{ dt.upload_image if dt.upload_image.startswith('data:') else '/static/uploads/device-types/' ~ dt.upload_image }}'); background-size:cover; background-position:center;">
       <span class="bg-black bg-opacity-50 px-2 py-1 rounded">{{ dt.name }}</span>
     </a>
     {% endfor %}

--- a/web-client/templates/upload_image_list.html
+++ b/web-client/templates/upload_image_list.html
@@ -13,10 +13,18 @@
   {% for label, item in items.items() %}
   <div class="relative border rounded p-2 h-40">
     {% if item.icon %}
+    {% if item.icon.startswith('data:') %}
+    <img src="{{ item.icon }}" class="absolute top-2 left-2 w-8 h-8 object-contain" alt="">
+    {% else %}
     <img src="/static/uploads/{{ 'menu-items' if category=='menu' else 'device-types' }}/{{ item.icon }}" class="absolute top-2 left-2 w-8 h-8 object-contain" alt="">
     {% endif %}
+    {% endif %}
     {% if item.image %}
+    {% if item.image.startswith('data:') %}
+    <img src="{{ item.image }}" class="absolute top-2 right-2 h-16 object-contain" alt="">
+    {% else %}
     <img src="/static/uploads/{{ 'menu-items' if category=='menu' else 'device-types' }}/{{ item.image }}" class="absolute top-2 right-2 h-16 object-contain" alt="">
+    {% endif %}
     {% endif %}
     <div class="absolute bottom-2 left-2">
       <button hx-get="/admin/upload-image/{{ category }}/{{ item.slug if category=='menu' else item.id }}/modal" hx-target="#modal" hx-swap="innerHTML" class="px-2 py-1 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded">Update</button>

--- a/web-client/templates/upload_image_modal.html
+++ b/web-client/templates/upload_image_modal.html
@@ -6,14 +6,22 @@
         <label class="block">Icon <span class="text-xs text-gray-400">(suggested 64x64)</span></label>
         <input type="file" name="icon" accept="image/*" class="text-[var(--input-text)]">
         {% if icon %}
+        {% if icon.startswith('data:') %}
+        <img src="{{ icon }}" class="h-10 mt-1" alt="">
+        {% else %}
         <img src="/static/uploads/{{ 'menu-items' if category=='menu' else 'device-types' }}/{{ icon }}" class="h-10 mt-1" alt="">
+        {% endif %}
         {% endif %}
       </div>
       <div class="mb-2">
         <label class="block">Image <span class="text-xs text-gray-400">(suggested 200x400)</span></label>
         <input type="file" name="image" accept="image/*" class="text-[var(--input-text)]">
         {% if image %}
+        {% if image.startswith('data:') %}
+        <img src="{{ image }}" class="h-20 mt-1" alt="">
+        {% else %}
         <img src="/static/uploads/{{ 'menu-items' if category=='menu' else 'device-types' }}/{{ image }}" class="h-20 mt-1" alt="">
+        {% endif %}
         {% endif %}
       </div>
       <div class="text-right mt-2">


### PR DESCRIPTION
## Summary
- embed uploaded admin images as data URIs
- support data URI images across templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853e12292288324ad141bd6a2cc55d0