### PR TITLE
Refactor icon buttons

### DIFF
--- a/web-client/templates/admin_sync.html
+++ b/web-client/templates/admin_sync.html
@@ -119,13 +119,13 @@
               <div class="flex justify-center gap-1">
                 <form method="post" action="/admin/site-keys/{{ key.id }}/toggle" class="inline">
                   {% if key.active %}
-                  <button type="submit" aria-label="Disable" class="icon-btn" onclick="return confirm('Disable key?')">{{ include_icon('x-circle','text-red-500','5') }}</button>
+                  <span aria-label="Disable" class="icon-btn" role="button" tabindex="0" onclick="if(confirm('Disable key?')) { this.closest('form').submit() }">{{ include_icon('x-circle','text-red-500','5') }}</span>
                   {% else %}
-                  <button type="submit" aria-label="Enable" class="icon-btn">{{ include_icon('check-circle','text-green-500','5') }}</button>
+                  <span aria-label="Enable" class="icon-btn" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check-circle','text-green-500','5') }}</span>
                   {% endif %}
                 </form>
                 <form method="post" action="/admin/site-keys/{{ key.id }}/delete" class="inline">
-                  <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete key?')">{{ include_icon('trash-2','text-red-500','5') }}</button>
+                  <span aria-label="Delete" class="icon-btn" role="button" tabindex="0" onclick="if(confirm('Delete key?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','5') }}</span>
                 </form>
               </div>
             </td>
@@ -300,7 +300,7 @@
           </td>
           <td class="actions-col text-center">
             <form method="post" action="/admin/cloud-sync/{{ site.site_id }}/new-key" class="inline">
-              <button type="submit" aria-label="Issue" class="icon-btn">{{ include_icon('plus','text-blue-500','5') }}</button>
+              <span aria-label="Issue" class="icon-btn" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('plus','text-blue-500','5') }}</span>
             </form>
           </td>
         </tr>
@@ -327,7 +327,7 @@
             {% endif %}
           </td>
           <td class="actions-col text-center">
-            <button type="button" @click="open = !open" x-data="{open:false}" class="icon-btn">{{ include_icon('pencil','text-blue-500','5') }}</button>
+            <span @click="open = !open" x-data="{open:false}" class="icon-btn" role="button" tabindex="0">{{ include_icon('pencil','text-blue-500','5') }}</span>
           </td>
         </tr>
         <tr x-show="open" x-data="{open:false}" x-cloak class="border-t border-gray-700">

--- a/web-client/templates/apply_port_template.html
+++ b/web-client/templates/apply_port_template.html
@@ -20,7 +20,7 @@
   {% if message %}<p class="text-green-400">{{ message }}</p>{% endif %}
   {% if error %}<p class="p-2 rounded bg-[var(--alert-bg)]">{{ error }}</p>{% endif %}
   <div>
-    <button type="submit" aria-label="Apply" class="p-2 rounded transition">{{ include_icon('check') }}</button>
+    <span aria-label="Apply" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check') }}</span>
     <a href="/devices/{{ device.id }}/ports" class="ml-2 underline">Cancel</a>
   </div>
 </form>

--- a/web-client/templates/bulk_vlan_push.html
+++ b/web-client/templates/bulk_vlan_push.html
@@ -38,9 +38,9 @@
   <input type="hidden" name="template_id" value="{{ template_id or '' }}" />
   <input type="hidden" name="config_text" value="{{ config_text }}" />
   <input type="hidden" name="model_filter" value="{{ model_filter }}" />
-  <button type="submit" aria-label="Confirm" class="p-2 rounded transition">{{ include_icon('check-circle') }}</button>
+  <span aria-label="Confirm" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check-circle') }}</span>
   {% else %}
-  <button type="submit" aria-label="Preview" class="p-2 rounded transition">{{ include_icon('eye') }}</button>
+  <span aria-label="Preview" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('eye') }}</span>
   {% endif %}
 </form>
 {% endblock %}

--- a/web-client/templates/cloud_sync.html
+++ b/web-client/templates/cloud_sync.html
@@ -66,7 +66,7 @@
           </td>
           <td class="actions-col text-center">
             <form method="post" action="/admin/cloud-sync/{{ site.site_id }}/new-key" class="inline">
-              <button type="submit" aria-label="Issue" class="icon-btn">{{ include_icon('plus','text-blue-500','5') }}</button>
+              <span aria-label="Issue" class="icon-btn" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('plus','text-blue-500','5') }}</span>
             </form>
           </td>
         </tr>
@@ -93,7 +93,7 @@
             {% endif %}
           </td>
           <td class="actions-col text-center">
-            <button type="button" @click="open = !open" x-data="{open:false}" class="icon-btn">{{ include_icon('pencil','text-blue-500','5') }}</button>
+            <span @click="open = !open" x-data="{open:false}" class="icon-btn" role="button" tabindex="0">{{ include_icon('pencil','text-blue-500','5') }}</span>
           </td>
         </tr>
         <tr x-show="open" x-data="{open:false}" x-cloak class="border-t border-gray-700">

--- a/web-client/templates/compare_configs.html
+++ b/web-client/templates/compare_configs.html
@@ -22,7 +22,7 @@
     <option value="{{ b.id }}" {% if b.id == backup_b %}selected{% endif %}>{{ b.created_at }}</option>
     {% endfor %}
   </select>
-  <button type="submit" aria-label="Compare" class="p-2 rounded transition ml-2">{{ include_icon('eye') }}</button>
+  <span aria-label="Compare" class="p-2 rounded transition ml-2" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('eye') }}</span>
   {% endif %}
 </form>
 {% if device %}

--- a/web-client/templates/config_push_form.html
+++ b/web-client/templates/config_push_form.html
@@ -14,7 +14,7 @@
   <p class="p-2 rounded bg-[var(--alert-bg)]">{{ error }}</p>
   {% endif %}
   <div>
-    <button type="submit" aria-label="Push Config" class="p-2 rounded transition">{{ include_icon('upload','text-orange-500') }}</button>
+    <span aria-label="Push Config" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('upload','text-orange-500') }}</span>
     <a href="/devices/table" class="ml-2 underline">Cancel</a>
   </div>
 </form>

--- a/web-client/templates/dashboard_prefs.html
+++ b/web-client/templates/dashboard_prefs.html
@@ -10,6 +10,6 @@
     </label>
   </div>
   {% endfor %}
-  <button type="submit" aria-label="Save" class="p-2 rounded shadow transition">{{ include_icon('save') }}</button>
+  <span aria-label="Save" class="p-2 rounded shadow transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/debug_log.html
+++ b/web-client/templates/debug_log.html
@@ -8,10 +8,10 @@
   <form method="post" action="/admin/debug/trap-listener">
     {% if trap_running %}
     <input type="hidden" name="action" value="stop">
-    <button type="submit" aria-label="Stop Listener" class="p-2 rounded transition">{{ include_icon('stop') }}</button>
+    <span aria-label="Stop Listener" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('stop') }}</span>
     {% else %}
     <input type="hidden" name="action" value="start">
-    <button type="submit" aria-label="Start Listener" class="p-2 rounded transition">{{ include_icon('play') }}</button>
+    <span aria-label="Start Listener" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('play') }}</span>
     {% endif %}
   </form>
 </div>
@@ -21,10 +21,10 @@
   <form method="post" action="/admin/debug/syslog-listener">
     {% if syslog_running %}
     <input type="hidden" name="action" value="stop">
-    <button type="submit" aria-label="Stop Listener" class="p-2 rounded transition">{{ include_icon('stop') }}</button>
+    <span aria-label="Stop Listener" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('stop') }}</span>
     {% else %}
     <input type="hidden" name="action" value="start">
-    <button type="submit" aria-label="Start Listener" class="p-2 rounded transition">{{ include_icon('play') }}</button>
+    <span aria-label="Start Listener" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('play') }}</span>
     {% endif %}
   </form>
 </div>

--- a/web-client/templates/device_column_prefs.html
+++ b/web-client/templates/device_column_prefs.html
@@ -10,6 +10,6 @@
     </label>
   </div>
   {% endfor %}
-  <button type="submit" aria-label="Save" class="p-2 rounded shadow transition">{{ include_icon("save") }}</button>
+  <span aria-label="Save" class="p-2 rounded shadow transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon("save") }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/device_form.html
+++ b/web-client/templates/device_form.html
@@ -160,7 +160,7 @@
   </div>
   <div class="flex flex-wrap gap-x-8 gap-y-4 mb-4 items-start">
     <div class="flex flex-col flex-1 min-w-[280px]">
-      <button type="submit" aria-label="Submit" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('check') }}</button>
+      <span aria-label="Submit" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check') }}</span>
       <a href="/devices/table" class="inline-block p-2 ml-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">Cancel</a>
     </div>
   </div>
@@ -174,7 +174,7 @@
 </div>
 <form method="post" action="/devices/{{ device.id }}/damage" enctype="multipart/form-data" class="mb-4">
   <input type="file" name="photo" accept="image/*" class="mb-2" required />
-  <button type="submit" aria-label="Upload Photo" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('upload','text-orange-500') }}</button>
+  <span aria-label="Upload Photo" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('upload','text-orange-500') }}</span>
 </form>
 <h2 class="text-lg mt-4">Recent Syslog</h2>
 <ul class="mb-4">

--- a/web-client/templates/device_import_confirm.html
+++ b/web-client/templates/device_import_confirm.html
@@ -18,6 +18,6 @@
       <option value="merge">Merge</option>
     </select>
   </label>
-  <button type="submit" name="confirm" value="yes" aria-label="Import" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('check-circle') }}</button>
+  <span name="confirm" value="yes" aria-label="Import" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check-circle') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/device_import_map.html
+++ b/web-client/templates/device_import_map.html
@@ -32,6 +32,6 @@
     </label>
     {% endfor %}
   </div>
-  <button type="submit" aria-label="Next" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('arrow-right') }}</button>
+  <span aria-label="Next" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('arrow-right') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/device_import_upload.html
+++ b/web-client/templates/device_import_upload.html
@@ -18,6 +18,6 @@
       <input id="import_file" type="file" name="import_file" required class="w-full text-[var(--input-text)]" />
     </div>
   </div>
-  <button type="submit" aria-label="Next" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('arrow-right') }}</button>
+  <span aria-label="Next" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('arrow-right') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/device_list.html
+++ b/web-client/templates/device_list.html
@@ -4,7 +4,7 @@
 {% if current_user and current_user.role == 'superadmin' %}
   {% set refresh_button %}
   <form method="post" action="/admin/run-push-queue" class="inline-block ml-2">
-    <button type="submit" aria-label="Run Push Queue" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('refresh-ccw', None, '1.5') }}</button>
+    <span aria-label="Run Push Queue" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('refresh-ccw', None, '1.5') }}</span>
   </form>
   {% endset %}
 {% endif %}
@@ -105,7 +105,7 @@
           {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
           <a href="/devices/{{ device.id }}/edit" aria-label="Edit" class="icon-btn">{{ include_icon('pencil','text-blue-500','5') }}</a>
           <form method="post" action="/devices/{{ device.id }}/delete" class="inline">
-            <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete device?')">{{ include_icon('trash-2','text-red-500','5') }}</button>
+            <span aria-label="Delete" class="icon-btn" role="button" tabindex="0" onclick="if(confirm('Delete device?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','5') }}</span>
           </form>
           {% endif %}
         </div>
@@ -136,7 +136,7 @@
       {% if column_prefs.status %}<td class="table-cell"></td>{% endif %}
       {% if column_prefs.tags %}<td class="table-cell"><input name="tag_names" class="w-full bg-[var(--input-bg)] text-[var(--input-text)] rounded" /></td>{% endif %}
       <td class="table-cell"></td>
-      <td class="actions-col text-right no-resize"><button type="button" @click="bulkUpdate" aria-label="Apply" class="icon-btn">{{ include_icon('check','text-green-500','5') }}</button></td>
+      <td class="actions-col text-right no-resize"><span @click="bulkUpdate" aria-label="Apply" class="icon-btn" role="button" tabindex="0">{{ include_icon('check','text-green-500','5') }}</span></td>
     </tr>
   </tfoot>
 </table>
@@ -155,7 +155,7 @@
     </label>
     {% if current_user and current_user.role in ['editor','admin','superadmin'] %}
     <div class="relative inline-block ml-2" x-data="{open:false, ready:false}" x-init="setTimeout(() => ready = true, 50)">
-      <button aria-label="Export" class="bg-[var(--card-bg)] p-2 text-[var(--btn-text)] rounded" @click="open = !open">{{ include_icon('download','text-orange-500','1.5') }}</button>
+      <span aria-label="Export" class="bg-[var(--card-bg)] p-2 text-[var(--btn-text)] rounded" @click="open = !open" role="button" tabindex="0">{{ include_icon('download','text-orange-500','1.5') }}</span>
       <ul x-show="ready && open" x-transition.opacity.duration.150ms @click.away="open = false" class="absolute bg-[var(--card-bg)] py-2 w-48" x-cloak>
         <li><a class="block px-4 py-2 hover:bg-[var(--btn-hover)]" href="/export/inventory.csv">Export to CSV</a></li>
         <li><a class="block px-4 py-2 hover:bg-[var(--btn-hover)]" href="/export/inventory.pdf">Export to PDF</a></li>
@@ -167,6 +167,6 @@
   </div>
 </div>
 </div>
-<button type="button" @click="bulkDelete" aria-label="Delete Selected" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)] mt-2">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+<span @click="bulkDelete" aria-label="Delete Selected" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)] mt-2" role="button" tabindex="0">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/device_type_form.html
+++ b/web-client/templates/device_type_form.html
@@ -19,7 +19,7 @@
   <p class="p-2 rounded bg-[var(--alert-bg)] text-[var(--btn-text)]">{{ error }}</p>
   {% endif %}
   <div>
-    <button type="submit" aria-label="Submit" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">{{ include_icon('check') }}</button>
+    <span aria-label="Submit" class="p-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check') }}</span>
     <a href="/device-types" class="inline-block p-2 ml-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">Cancel</a>
   </div>
 </form>

--- a/web-client/templates/device_type_list.html
+++ b/web-client/templates/device_type_list.html
@@ -34,7 +34,7 @@
         <div class="flex justify-center gap-1">
           <a href="/device-types/{{ dt.id }}/edit" aria-label="Edit" class="icon-btn">{{ include_icon('pencil','text-blue-500','5') }}</a>
           <form method="post" action="/device-types/{{ dt.id }}/delete" class="inline">
-            <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete type?')">{{ include_icon('trash-2','text-red-500','5') }}</button>
+            <span aria-label="Delete" class="icon-btn" role="button" tabindex="0" onclick="if(confirm('Delete type?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','5') }}</span>
           </form>
         </div>
       </td>
@@ -50,7 +50,7 @@
   </div>
 </div>
 </div>
-<button type="submit" aria-label="Delete Selected" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)] mt-2">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+<span aria-label="Delete Selected" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)] mt-2" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
 </form>
 <script>
 document.getElementById('select-all').addEventListener('change', function(e){

--- a/web-client/templates/google_sheets.html
+++ b/web-client/templates/google_sheets.html
@@ -14,7 +14,7 @@
       <input id="spreadsheet_id" type="text" name="spreadsheet_id" value="{{ config.sheet_id }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
     </div>
   </div>
-  <button type="submit" aria-label="Save" class="p-2 rounded shadow transition">{{ include_icon('save') }}</button>
+  <span aria-label="Save" class="p-2 rounded shadow transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
 </form>
 
 <hr class="my-4">
@@ -28,7 +28,7 @@
     <option value="snmp_communities">SNMP Communities</option>
     <option value="port_config_templates">Port Config Templates</option>
   </select>
-  <button type="submit" aria-label="Export" class="p-2 rounded shadow transition">{{ include_icon('download','text-orange-500') }}</button>
+  <span aria-label="Export" class="p-2 rounded shadow transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('download','text-orange-500') }}</span>
 </form>
 
 <hr class="my-4">
@@ -42,6 +42,6 @@
     <option value="snmp_communities">SNMP Communities</option>
     <option value="port_config_templates">Port Config Templates</option>
   </select>
-  <button type="submit" aria-label="Import" class="p-2 rounded shadow transition">{{ include_icon('upload','text-orange-500') }}</button>
+  <span aria-label="Import" class="p-2 rounded shadow transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('upload','text-orange-500') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/install/step1.html
+++ b/web-client/templates/install/step1.html
@@ -4,6 +4,6 @@
 <form method="post" action="/install/step1" x-data="{mode:'local'}" class="space-y-4">
   <label class="block"><input type="radio" name="mode" value="local" x-model="mode" class="mr-2">Local</label>
   <label class="block"><input type="radio" name="mode" value="cloud" x-model="mode" class="mr-2">Cloud</label>
-  <button type="submit" aria-label="Next" class="p-2 rounded transition">{{ include_icon('chevron-right') }}</button>
+  <span aria-label="Next" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('chevron-right') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/install/step2.html
+++ b/web-client/templates/install/step2.html
@@ -7,6 +7,6 @@
   <input type="text" name="timezone" placeholder="Timezone" value="UTC" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required>
   <input type="text" name="database_url" placeholder="Database URL" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required>
   <input type="text" name="secret_key" placeholder="Secret Key" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required>
-  <button type="submit" aria-label="Next" class="p-2 rounded transition">{{ include_icon('chevron-right') }}</button>
+  <span aria-label="Next" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('chevron-right') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/install/step3.html
+++ b/web-client/templates/install/step3.html
@@ -7,6 +7,6 @@
   <div x-show="proxy=='yes'" class="space-y-2">
     <input type="text" name="install_domain" placeholder="Domain (leave blank for self-signed)" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]">
   </div>
-  <button type="submit" aria-label="Next" class="p-2 rounded transition">{{ include_icon('chevron-right') }}</button>
+  <span aria-label="Next" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('chevron-right') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/install/step4.html
+++ b/web-client/templates/install/step4.html
@@ -4,6 +4,6 @@
 <form method="post" action="/install/step4" class="space-y-4">
   <input type="email" name="admin_email" placeholder="Admin Email" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required>
   <input type="password" name="admin_password" placeholder="Password" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required>
-  <button type="submit" aria-label="Next" class="p-2 rounded transition">{{ include_icon('chevron-right') }}</button>
+  <span aria-label="Next" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('chevron-right') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/ip_ban_list.html
+++ b/web-client/templates/ip_ban_list.html
@@ -36,7 +36,7 @@
       <td class="actions-col text-center whitespace-nowrap">
         <div class="flex justify-center gap-1">
           <form method="post" action="/admin/ip-bans/{{ ban.id }}/unban" class="inline">
-          <button type='submit' aria-label='Unban' class='icon-btn' onclick="return confirm('Unban this IP?')">{{ include_icon('x-circle', '', '5') }}</button>
+          <span type='submit' aria-label='Unban' class='icon-btn' role="button" tabindex="0" onclick="return confirm('Unban this IP?')">{{ include_icon('x-circle', '', '5') }}</span>
           </form>
         </div>
       </td>

--- a/web-client/templates/ip_search.html
+++ b/web-client/templates/ip_search.html
@@ -4,7 +4,7 @@
 <h1 class="text-xl mb-4">IP Search</h1>
 <form method="get" class="mb-4">
   <input type="text" name="ip" value="{{ ip or '' }}" class="text-[var(--input-text)] px-2" placeholder="Enter IP">
-  <button type="submit" aria-label="Search" class="p-2 rounded transition">{{ include_icon('search') }}</button>
+  <span aria-label="Search" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('search') }}</span>
 </form>
 {% if ip %}
 <h2 class="text-lg mb-2">Results for '{{ ip }}'</h2>

--- a/web-client/templates/location_form.html
+++ b/web-client/templates/location_form.html
@@ -21,7 +21,7 @@
   <p class="p-2 rounded bg-[var(--alert-bg)]">{{ error }}</p>
   {% endif %}
   <div>
-    <button type="submit" aria-label="Submit" class="p-2 rounded transition">{{ include_icon('check') }}</button>
+    <span aria-label="Submit" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check') }}</span>
     <a href="/admin/locations" class="ml-2 underline">Cancel</a>
   </div>
 </form>

--- a/web-client/templates/location_list.html
+++ b/web-client/templates/location_list.html
@@ -24,7 +24,7 @@
         <div class="flex gap-1">
           <a href="/admin/locations/{{ loc.id }}/edit" aria-label="Edit" class="icon-btn">{{ include_icon('pencil','text-blue-500','5') }}</a>
           <form method="post" action="/admin/locations/{{ loc.id }}/delete" class="inline">
-            <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete location?')">{{ include_icon('trash-2','text-red-500','5') }}</button>
+            <span aria-label="Delete" class="icon-btn" role="button" tabindex="0" onclick="if(confirm('Delete location?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','5') }}</span>
           </form>
         </div>
       </td>
@@ -33,7 +33,7 @@
   </tbody>
 </table>
 </div>
-<button type="submit" aria-label="Delete Selected" class="p-2 rounded transition">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+<span aria-label="Delete Selected" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
 </form>
 <script>
 document.getElementById('select-all').addEventListener('change', function(e){

--- a/web-client/templates/login.html
+++ b/web-client/templates/login.html
@@ -9,7 +9,7 @@
     {% if error %}
     <p class="p-2 rounded bg-[var(--alert-bg)]">{{ error }}</p>
     {% endif %}
-    <button type="submit" aria-label="Login" class="p-2 rounded transition">{{ include_icon('log-in') }}</button>
+    <span aria-label="Login" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('log-in') }}</span>
   </form>
 </div>
 {% endblock %}

--- a/web-client/templates/port_config.html
+++ b/web-client/templates/port_config.html
@@ -34,7 +34,7 @@
 <form method="post" class="space-y-4">
   <textarea name="config_text" rows="5" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required></textarea>
   <div>
-    <button type="submit" aria-label="Queue Change" class="p-2 rounded transition">{{ include_icon('plus-square') }}</button>
+    <span aria-label="Queue Change" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('plus-square') }}</span>
     <a href="/devices/{{ device.id }}/ports" class="ml-2 underline">Back</a>
   </div>
 </form>

--- a/web-client/templates/port_config_template_form.html
+++ b/web-client/templates/port_config_template_form.html
@@ -16,7 +16,7 @@
   {% endif %}
   {% if error %}<p class="p-2 rounded bg-[var(--alert-bg)]">{{ error }}</p>{% endif %}
   <div>
-    <button type="submit" aria-label="Submit" class="p-2 rounded transition">{{ include_icon('check') }}</button>
+    <span aria-label="Submit" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check') }}</span>
     <a href="/network/port-configs" class="ml-2 underline">Cancel</a>
   </div>
 </form>

--- a/web-client/templates/port_config_template_list.html
+++ b/web-client/templates/port_config_template_list.html
@@ -22,7 +22,7 @@
       <td class="px-4 py-2">
         <a href="/network/port-configs/{{ tpl.id }}/edit" aria-label="Edit" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)] mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         <form method="post" action="/network/port-configs/{{ tpl.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)]" onclick="return confirm('Delete template?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+          <span aria-label="Delete" class="px-2 text-sm text-[var(--btn-text)] hover:text-[var(--btn-hover-text)]" role="button" tabindex="0" onclick="if(confirm('Delete template?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
         </form>
       </td>
     </tr>

--- a/web-client/templates/port_edit.html
+++ b/web-client/templates/port_edit.html
@@ -44,7 +44,7 @@
     </tbody>
   </table>
   </div>
-  <button type="submit" aria-label="Save" class="p-2 rounded transition">{{ include_icon('save') }}</button>
+  <span aria-label="Save" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
   <a href="/devices/{{ device.id }}/port-map" class="ml-2 underline">Back</a>
 </form>
 {% endblock %}

--- a/web-client/templates/site_form.html
+++ b/web-client/templates/site_form.html
@@ -17,7 +17,7 @@
   {% if error %}<p class="p-2 rounded bg-[var(--alert-bg)]">{{ error }}</p>{% endif %}
   <div class="form-row">
     <div class="form-item">
-      <button type="submit" aria-label="Submit" class="p-2 rounded transition">{{ include_icon('check') }}</button>
+      <span aria-label="Submit" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check') }}</span>
     </div>
   </div>
 </form>

--- a/web-client/templates/site_keys.html
+++ b/web-client/templates/site_keys.html
@@ -42,13 +42,13 @@
         <div class="flex justify-center gap-1">
           <form method="post" action="/admin/site-keys/{{ key.id }}/toggle" class="inline">
             {% if key.active %}
-            <button type="submit" aria-label="Disable" class="icon-btn" onclick="return confirm('Disable key?')">{{ include_icon('x-circle','text-red-500','5') }}</button>
+            <span aria-label="Disable" class="icon-btn" role="button" tabindex="0" onclick="if(confirm('Disable key?')) { this.closest('form').submit() }">{{ include_icon('x-circle','text-red-500','5') }}</span>
             {% else %}
-            <button type="submit" aria-label="Enable" class="icon-btn">{{ include_icon('check-circle','text-green-500','5') }}</button>
+            <span aria-label="Enable" class="icon-btn" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check-circle','text-green-500','5') }}</span>
             {% endif %}
           </form>
           <form method="post" action="/admin/site-keys/{{ key.id }}/delete" class="inline">
-            <button type="submit" aria-label="Delete" class="icon-btn" onclick="return confirm('Delete key?')">{{ include_icon('trash-2','text-red-500','5') }}</button>
+            <span aria-label="Delete" class="icon-btn" role="button" tabindex="0" onclick="if(confirm('Delete key?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','5') }}</span>
           </form>
         </div>
       </td>

--- a/web-client/templates/site_manage.html
+++ b/web-client/templates/site_manage.html
@@ -8,7 +8,7 @@
   <li>{{ u.email }} ({{ u.role }})
     <form method="post" action="/sites/{{ site.id }}/remove-user" class="inline">
       <input type="hidden" name="user_id" value="{{ u.id }}">
-      <button type="submit" aria-label="Remove" class="p-2 rounded transition">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+      <span aria-label="Remove" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
     </form>
   </li>
   {% endfor %}
@@ -19,7 +19,7 @@
     <option value="{{ u.id }}">{{ u.email }}</option>
     {% endfor %}
   </select>
-  <button type="submit" aria-label="Add User" class="p-2 underline">{{ include_icon('plus') }}</button>
+  <span aria-label="Add User" class="p-2 underline" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('plus') }}</span>
 </form>
 <h2 class="mt-4 font-bold">Devices</h2>
 <ul>
@@ -31,11 +31,11 @@
         <option value="{{ opt }}" {% if d.config_pull_interval==opt %}selected{% endif %}>{{ opt }}</option>
         {% endfor %}
       </select>
-      <button type="submit" aria-label="Update" class="p-2 underline">{{ include_icon('save') }}</button>
+      <span aria-label="Update" class="p-2 underline" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
     </form>
     <form method="post" action="/sites/{{ site.id }}/remove-device" class="inline">
       <input type="hidden" name="device_id" value="{{ d.id }}">
-      <button type="submit" aria-label="Remove" class="p-2 rounded transition">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+      <span aria-label="Remove" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
     </form>
   </li>
   {% endfor %}
@@ -46,6 +46,6 @@
     <option value="{{ d.id }}">{{ d.hostname }}</option>
     {% endfor %}
   </select>
-  <button type="submit" aria-label="Add Device" class="p-2 underline">{{ include_icon('plus') }}</button>
+  <span aria-label="Add Device" class="p-2 underline" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('plus') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/site_settings.html
+++ b/web-client/templates/site_settings.html
@@ -10,6 +10,6 @@
     </label>
   </div>
   {% endfor %}
-  <button type="submit" aria-label="Save" class="p-2 rounded shadow transition">{{ include_icon('save') }}</button>
+  <span aria-label="Save" class="p-2 rounded shadow transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/snmp_form.html
+++ b/web-client/templates/snmp_form.html
@@ -24,7 +24,7 @@
   {% endif %}
   <div class="flex flex-wrap gap-x-8 gap-y-4 mb-4 items-start">
     <div class="flex flex-col flex-1 min-w-[280px]">
-      <button type="submit" aria-label="Submit" class="p-2 rounded transition">{{ include_icon('check') }}</button>
+      <span aria-label="Submit" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check') }}</span>
       <a href="/admin/snmp" class="ml-2 underline">Cancel</a>
     </div>
   </div>

--- a/web-client/templates/snmp_list.html
+++ b/web-client/templates/snmp_list.html
@@ -25,7 +25,7 @@
       <td class="px-4 py-2">
         <a href="/admin/snmp/{{ profile.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         <form method="post" action="/admin/snmp/{{ profile.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="p-2 rounded transition" onclick="return confirm('Delete profile?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+          <span aria-label="Delete" class="p-2 rounded transition" role="button" tabindex="0" onclick="if(confirm('Delete profile?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
         </form>
       </td>
     </tr>
@@ -33,7 +33,7 @@
   </tbody>
 </table>
 </div>
-<button type="submit" aria-label="Delete Selected" class="p-2 rounded transition">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+<span aria-label="Delete Selected" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
 </form>
 <script>
 document.getElementById('select-all').addEventListener('change', function(e){

--- a/web-client/templates/ssh_bulk_port_update.html
+++ b/web-client/templates/ssh_bulk_port_update.html
@@ -19,7 +19,7 @@
     <label for="config_text" class="block">Config Snippet (use {port} for port name)</label>
     <textarea id="config_text" name="config_text" rows="5" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]"></textarea>
   </div>
-  <button type="submit" aria-label="Apply" class="p-2 rounded transition">{{ include_icon('check') }}</button>
+  <span aria-label="Apply" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check') }}</span>
 </form>
 {% if message %}<p class="mt-4 text-green-400">{{ message }}</p>{% endif %}
 {% endblock %}

--- a/web-client/templates/ssh_config_check.html
+++ b/web-client/templates/ssh_config_check.html
@@ -11,7 +11,7 @@
       {% endfor %}
     </select>
   </div>
-  <button type="submit" aria-label="Fetch Config" class="p-2 rounded transition">{{ include_icon('download','text-orange-500') }}</button>
+  <span aria-label="Fetch Config" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('download','text-orange-500') }}</span>
 </form>
 {% if error %}<p class="p-2 rounded bg-[var(--alert-bg)] mt-2">{{ error }}</p>{% endif %}
 {% if output %}

--- a/web-client/templates/ssh_form.html
+++ b/web-client/templates/ssh_form.html
@@ -30,7 +30,7 @@
   {% endif %}
   <div class="flex flex-wrap gap-x-8 gap-y-4 mb-4 items-start">
     <div class="flex flex-col flex-1 min-w-[280px]">
-      <button type="submit" aria-label="Submit" class="p-2 rounded transition">{{ include_icon('check') }}</button>
+      <span aria-label="Submit" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check') }}</span>
       <a href="/admin/ssh" class="ml-2 underline">Cancel</a>
     </div>
   </div>

--- a/web-client/templates/ssh_list.html
+++ b/web-client/templates/ssh_list.html
@@ -28,7 +28,7 @@
       <td class="px-4 py-2">
         <a href="/admin/ssh/{{ cred.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         <form method="post" action="/admin/ssh/{{ cred.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="p-2 rounded transition" onclick="return confirm('Delete profile?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+          <span aria-label="Delete" class="p-2 rounded transition" role="button" tabindex="0" onclick="if(confirm('Delete profile?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
         </form>
       </td>
     </tr>
@@ -36,7 +36,7 @@
   </tbody>
 </table>
 </div>
-<button type="submit" aria-label="Delete Selected" class="p-2 rounded transition">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+<span aria-label="Delete Selected" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
 </form>
 <script>
 document.getElementById('select-all').addEventListener('change', function(e){

--- a/web-client/templates/ssh_netbird.html
+++ b/web-client/templates/ssh_netbird.html
@@ -13,6 +13,6 @@
       {% endfor %}
     </select>
   </div>
-  <button type="submit" aria-label="Connect" class="p-2 rounded transition">{{ include_icon('log-in') }}</button>
+  <span aria-label="Connect" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('log-in') }}</span>
 </form>
 {% endblock %}

--- a/web-client/templates/ssh_port_check.html
+++ b/web-client/templates/ssh_port_check.html
@@ -17,7 +17,7 @@
       <input id="port_name" type="text" name="port_name" value="{{ port_name or '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
     </div>
   </div>
-  <button type="submit" aria-label="Check" class="p-2 rounded transition">{{ include_icon('search') }}</button>
+  <span aria-label="Check" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('search') }}</span>
 </form>
 {% if error %}<p class="p-2 rounded bg-[var(--alert-bg)] mt-2">{{ error }}</p>{% endif %}
 {% if output %}

--- a/web-client/templates/ssh_port_config.html
+++ b/web-client/templates/ssh_port_config.html
@@ -17,7 +17,7 @@
       <input id="port_name" type="text" name="port_name" value="{{ port_name or '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
     </div>
   </div>
-  <button type="submit" aria-label="Fetch Config" class="p-2 rounded transition">{{ include_icon('download','text-orange-500') }}</button>
+  <span aria-label="Fetch Config" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('download','text-orange-500') }}</span>
 </form>
 {% if error %}<p class="p-2 rounded bg-[var(--alert-bg)] mt-2">{{ error }}</p>{% endif %}
 {% if output %}

--- a/web-client/templates/ssh_port_search.html
+++ b/web-client/templates/ssh_port_search.html
@@ -16,7 +16,7 @@
     </label>
     {% endfor %}
   </div>
-  <button type="submit" aria-label="Search" class="p-2 rounded transition">{{ include_icon('search') }}</button>
+  <span aria-label="Search" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('search') }}</span>
 </form>
 {% if results %}
   {% for r in results %}

--- a/web-client/templates/tag_edit.html
+++ b/web-client/templates/tag_edit.html
@@ -23,7 +23,7 @@
   </tbody>
 </table>
 </div>
-<button type="submit" aria-label="Save" class="p-2 rounded transition mt-2">{{ include_icon('save') }}</button>
+<span aria-label="Save" class="p-2 rounded transition mt-2" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
 </form>
 <p class="mt-2 text-base text-[var(--card-text)]">Automatic tags <em>complete</em> and <em>incomplete</em> cannot be removed.</p>
 {% endblock %}

--- a/web-client/templates/tag_manager.html
+++ b/web-client/templates/tag_manager.html
@@ -21,7 +21,7 @@
       <td class="px-4 py-2">
         <form method="post" action="/admin/tags/{{ tag.id }}/rename" class="inline">
           <input type="text" name="new_name" class="w-32 p-1 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
-          <button type="submit" aria-label="Rename" class="p-2 rounded transition">{{ include_icon('pencil','text-blue-500','1.5') }}</button>
+          <span aria-label="Rename" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('pencil','text-blue-500','1.5') }}</span>
         </form>
       </td>
       <td class="px-4 py-2">
@@ -33,12 +33,12 @@
               {% endif %}
             {% endfor %}
           </select>
-          <button type="submit" aria-label="Merge" class="p-2 rounded transition">{{ include_icon('merge') }}</button>
+          <span aria-label="Merge" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('merge') }}</span>
         </form>
       </td>
       <td class="px-4 py-2">
         <form method="post" action="/admin/tags/{{ tag.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="p-2 rounded transition" onclick="return confirm('Delete tag?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+          <span aria-label="Delete" class="p-2 rounded transition" role="button" tabindex="0" onclick="if(confirm('Delete tag?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
         </form>
       </td>
     </tr>

--- a/web-client/templates/tasks.html
+++ b/web-client/templates/tasks.html
@@ -32,7 +32,7 @@
     <option value="{{ dev.id }}">{{ dev.hostname }} ({{ dev.ip | display_ip }})</option>
     {% endfor %}
   </select>
-  <button type="submit" aria-label="Connect" class="p-2 rounded transition">{{ include_icon('log-in') }}</button>
+  <span aria-label="Connect" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('log-in') }}</span>
 </form>
 
 <hr class="my-4">
@@ -53,7 +53,7 @@
   <div>
     <input type="file" name="csv_file" accept=".csv" class="rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
   </div>
-  <button type="submit" aria-label="Upload" class="p-2 rounded transition">{{ include_icon('upload','text-orange-500') }}</button>
+  <span aria-label="Upload" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('upload','text-orange-500') }}</span>
 </form>
 
 

--- a/web-client/templates/template_config_form.html
+++ b/web-client/templates/template_config_form.html
@@ -33,7 +33,7 @@
   <p class="text-green-400">{{ message }}</p>
   {% endif %}
   <div>
-    <button type="submit" aria-label="Push Config" class="p-2 rounded transition">{{ include_icon('upload','text-orange-500') }}</button>
+    <span aria-label="Push Config" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('upload','text-orange-500') }}</span>
     <a href="/devices/table" class="ml-2 underline">Cancel</a>
   </div>
 </form>

--- a/web-client/templates/user_detail.html
+++ b/web-client/templates/user_detail.html
@@ -80,7 +80,7 @@
     </div>
     <div class="form-row">
       <div class="form-item">
-        <button type="submit" aria-label="Save" class="p-2 rounded transition">{{ include_icon('save') }}</button>
+        <span aria-label="Save" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
       </div>
     </div>
   </form>
@@ -108,7 +108,7 @@
             <td class="px-4 py-2">
               <a href="/user/ssh/{{ cred.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
               <form method="post" action="/user/ssh/{{ cred.id }}/delete" class="inline">
-                <button type="submit" aria-label="Delete" class="p-2 rounded transition" onclick="return confirm('Delete profile?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+                <span aria-label="Delete" class="p-2 rounded transition" role="button" tabindex="0" onclick="if(confirm('Delete profile?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
               </form>
             </td>
           </tr>

--- a/web-client/templates/user_form.html
+++ b/web-client/templates/user_form.html
@@ -139,7 +139,7 @@
   {% endif %}
   <div class="form-row">
     <div class="form-item">
-      <button type="submit" aria-label="Submit" class="p-2 rounded transition">{{ include_icon('check') }}</button>
+      <span aria-label="Submit" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check') }}</span>
       <a href="{{ cancel_url or '/users/me' }}" class="ml-2 underline">Cancel</a>
     </div>
   </div>

--- a/web-client/templates/user_list.html
+++ b/web-client/templates/user_list.html
@@ -30,11 +30,11 @@
         <a href="/admin/users/{{ user.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         {% if user.is_active %}
         <form method="post" action="/admin/users/{{ user.id }}/deactivate" class="inline">
-          <button type="submit" aria-label="Disable" class="p-2 rounded transition mr-2" onclick="return confirm('Deactivate user?')">{{ include_icon('minus-circle','text-red-500','1.5') }}</button>
+          <span aria-label="Disable" class="p-2 rounded transition mr-2" role="button" tabindex="0" onclick="if(confirm('Deactivate user?')) { this.closest('form').submit() }">{{ include_icon('minus-circle','text-red-500','1.5') }}</span>
         </form>
         {% endif %}
         <form method="post" action="/admin/users/{{ user.id }}/reset-password" class="inline">
-          <button type="submit" aria-label="Reset Password" class="p-2 underline text-yellow-400" onclick="return confirm('Reset password?')">{{ include_icon('refresh-ccw','text-yellow-400','1.5') }}</button>
+          <span aria-label="Reset Password" class="p-2 underline text-yellow-400" role="button" tabindex="0" onclick="if(confirm('Reset password?')) { this.closest('form').submit() }">{{ include_icon('refresh-ccw','text-yellow-400','1.5') }}</span>
         </form>
       </td>
     </tr>

--- a/web-client/templates/user_ssh_list.html
+++ b/web-client/templates/user_ssh_list.html
@@ -20,7 +20,7 @@
       <td class="px-4 py-2">
         <a href="/user/ssh/{{ cred.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         <form method="post" action="/user/ssh/{{ cred.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="p-2 rounded transition" onclick="return confirm('Delete profile?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+          <span aria-label="Delete" class="p-2 rounded transition" role="button" tabindex="0" onclick="if(confirm('Delete profile?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
         </form>
       </td>
     </tr>

--- a/web-client/templates/user_theme.html
+++ b/web-client/templates/user_theme.html
@@ -92,7 +92,7 @@
     </select>
   </div>
   <div>
-    <button type="submit" aria-label="Save" class="p-2 rounded transition">{{ include_icon('save') }}</button>
+    <span aria-label="Save" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
   </div>
 </form>
 {% endblock %}

--- a/web-client/templates/vlan_form.html
+++ b/web-client/templates/vlan_form.html
@@ -18,7 +18,7 @@
   {% endif %}
   <div class="flex flex-wrap gap-x-8 gap-y-4 mb-4 items-start">
     <div class="flex flex-col flex-1 min-w-[280px]">
-      <button type="submit" aria-label="Submit" class="p-2 rounded transition">{{ include_icon('check') }}</button>
+      <span aria-label="Submit" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('check') }}</span>
       <a href="/vlans" class="ml-2 underline">Cancel</a>
     </div>
   </div>

--- a/web-client/templates/vlan_list.html
+++ b/web-client/templates/vlan_list.html
@@ -28,7 +28,7 @@
       <td class="px-4 py-2">
         <a href="/vlans/{{ vlan.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         <form method="post" action="/vlans/{{ vlan.id }}/delete" class="inline">
-          <button type="submit" aria-label="Delete" class="p-2 rounded transition" onclick="return confirm('Delete VLAN?')">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+          <span aria-label="Delete" class="p-2 rounded transition" role="button" tabindex="0" onclick="if(confirm('Delete VLAN?')) { this.closest('form').submit() }">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
         </form>
       </td>
     </tr>
@@ -36,7 +36,7 @@
   </tbody>
 </table>
 </div>
-<button type="submit" aria-label="Delete Selected" class="p-2 rounded transition">{{ include_icon('trash-2','text-red-500','1.5') }}</button>
+<span aria-label="Delete Selected" class="p-2 rounded transition" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('trash-2','text-red-500','1.5') }}</span>
 </form>
 <script>
 document.getElementById('select-all').addEventListener('change', function(e){


### PR DESCRIPTION
## Summary
- replace button wrappers around icons with interactive `<span>` elements acting as buttons
- add keyboard accessible attributes on icons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm run build:web` *(fails: unocss not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e7f761788324a06911219e80f546