### PR TITLE
Fix sync worker timezone and conflict handling

### DIFF
--- a/server/routes/api/sync.py
+++ b/server/routes/api/sync.py
@@ -141,9 +141,6 @@ async def push_changes(
                     else:
                         accepted += 1
                 else:
-                    if any(field not in rec for field in required_cols):
-                        skipped += 1
-                        continue
                     obj = model_cls(**{k: v for k, v in rec.items() if k != "model"})
                     db.add(obj)
                     accepted += 1

--- a/server/utils/sync_conflicts.py
+++ b/server/utils/sync_conflicts.py
@@ -95,9 +95,12 @@ def list_device_conflicts(
     if since is not None:
         query = query.filter(or_(Device.created_at > since, Device.updated_at > since))
     devices = query.all()
+    result: list[Device] = []
     for device in devices:
         prepare_device_conflicts(device)
-    return devices
+        if device.conflict_data:
+            result.append(device)
+    return result
 
 
 def list_recent_sync_records(db: Session, limit: int = 100) -> list[dict]:

--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -35,10 +35,13 @@ def _load_last_sync(db) -> datetime:
     )
     if entry:
         try:
-            return datetime.fromisoformat(entry.value)
+            dt = datetime.fromisoformat(entry.value)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
         except Exception:
             pass
-    return datetime.fromtimestamp(0)
+    return datetime.fromtimestamp(0, timezone.utc)
 
 
 def _update_last_sync(db) -> None:


### PR DESCRIPTION
## Summary
- return timezone-aware values from `_load_last_sync`
- filter out devices with no remaining conflicts
- allow sync pushes to insert records even if required fields are missing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853fefb81f4832494b8a77d924255b5