### PR TITLE
Fix sync workers on unconfigured cloud

### DIFF
--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -68,6 +68,9 @@ def _update_last_sync(db) -> None:
 
 async def push_once(log: logging.Logger) -> None:
     push_url, _, site_id, api_key = _get_sync_config()
+    if not push_url or not site_id:
+        log.info("Cloud sync not configured, skipping push")
+        return
     db = SessionLocal()
     try:
         since = _load_last_sync(db)


### PR DESCRIPTION
## Summary
- avoid assuming a default cloud URL in `_get_sync_config`
- skip push/pull operations when cloud sync settings are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685401b02038832488c7cd6fe97cecad