### PR TITLE
Ensure sync workers track new records

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,11 @@ connection details. The sync workers are enabled by default so manual editing of
 `ENABLE_CLOUD_SYNC`, `ENABLE_SYNC_PUSH_WORKER` and `ENABLE_SYNC_PULL_WORKER` is
 typically unnecessary.
 
+All synchronized tables now include a `created_at` timestamp. The push worker
+uses this field (or `updated_at` when present) to detect new records. Upgrade
+the database with Alembic to ensure these columns exist before relying on cloud
+sync.
+
 Local sites often run behind NAT or firewalls that block inbound traffic. The sync workers therefore initiate outbound connections to the cloud using the API key assigned to the site. As long as that key exists in the cloud server's allowed list the push and pull operations will succeed without any ports opened on the local network.
 
 The `mobile-client/` folder now contains a minimal React Native app that lists devices from the REST API. Use `npm install` then `npm start` inside that directory to launch it with Expo.

--- a/alembic/versions/0016_created_at_fields.py
+++ b/alembic/versions/0016_created_at_fields.py
@@ -1,0 +1,41 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0016"
+down_revision = "0015"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    tables = [
+        "vlans",
+        "ssh_credentials",
+        "snmp_communities",
+        "locations",
+        "device_types",
+        "tags",
+    ]
+    for table in tables:
+        op.add_column(
+            table,
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    tables = [
+        "vlans",
+        "ssh_credentials",
+        "snmp_communities",
+        "locations",
+        "device_types",
+        "tags",
+    ]
+    for table in tables:
+        op.drop_column(table, "created_at")

--- a/core/models/models.py
+++ b/core/models/models.py
@@ -25,6 +25,7 @@ class VLAN(Base):
     sync_state = Column(JSON, nullable=True)
     tag = Column(Integer, unique=True, nullable=False)
     description = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
 
     devices = relationship("Device", back_populates="vlan")
 
@@ -40,6 +41,7 @@ class SSHCredential(Base):
     username = Column(String, nullable=False)
     password = Column(String, nullable=True)
     private_key = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
 
     devices = relationship("Device", back_populates="ssh_credential")
 
@@ -51,6 +53,7 @@ class SNMPCommunity(Base):
     name = Column(String, unique=True, nullable=False)
     community_string = Column(String, nullable=False)
     version = Column(String, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
 
     devices = relationship("Device", back_populates="snmp_community")
 
@@ -64,6 +67,7 @@ class Location(Base):
     sync_state = Column(JSON, nullable=True)
     name = Column(String, unique=True, nullable=False)
     location_type = Column(String, nullable=False, default="Fixed")
+    created_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
 
     devices = relationship("Device", back_populates="location_ref")
 
@@ -78,6 +82,7 @@ class DeviceType(Base):
     name = Column(String, unique=True, nullable=False)
     upload_icon = Column(String, nullable=True)
     upload_image = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
 
     devices = relationship("Device", back_populates="device_type")
 
@@ -125,6 +130,7 @@ class Tag(Base):
     conflict_data = Column(JSON, nullable=True)
     sync_state = Column(JSON, nullable=True)
     name = Column(String, unique=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
 
     devices = relationship("Device", secondary=device_tags, back_populates="tags")
 
@@ -516,7 +522,6 @@ class ImportLog(Base):
 
     user = relationship("User")
     site = relationship("Site")
-
 
 
 class ConnectedSite(Base):


### PR DESCRIPTION
## Summary
- add `created_at` fields to key models so the push worker can detect new rows
- document the new requirement for timestamps
- include Alembic migration `0016_created_at_fields`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685419e66d6c8324970f1a499426b041