### PR TITLE
Document STATIC_DIR environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,10 +369,12 @@ backend such as Redis pub/sub.
 If the service does not restart automatically after an update, run
 `sudo systemctl restart master-ip-app` on the host.
 
-Static assets are served from the `web-client/static` directory.
-This location is fixed. When deploying inside containers or under a reverse
-proxy, ensure that `/path/to/Master-IP-App/web-client/static` is accessible at `/static` so
-the application can find its assets.
+Static assets are served from the `web-client/static` directory by default.
+If the repository is installed in a read-only location you can set the
+`STATIC_DIR` environment variable to an alternate writable path. Use an absolute
+path so the directory is found regardless of the working directory. Ensure this
+location is also accessible at `/static` when deploying behind a reverse proxy
+so the application can find its assets.
 
 If the app is exposed under a URL prefix (e.g. `/inventory/` instead of `/`),
 set the `ROOT_PATH` environment variable to that prefix so all generated links
@@ -395,6 +397,8 @@ The application reads several options from the environment. Important variables 
  - `ENABLE_SYNC_PUSH_WORKER` – set to `0` to disable pushing local changes.
  - `ENABLE_SYNC_PULL_WORKER` – set to `0` to disable pulling updates from the cloud.
 - `ENABLE_BACKGROUND_WORKERS` – disable to skip queue and scheduler startup.
+- `STATIC_DIR` – directory for uploaded images and other static assets. Set this
+  if the repository location is read-only.
 - `CLOUD_BASE_URL` – base URL of the cloud server (overrides tunable).
 - `SYNC_PUSH_URL` and `SYNC_PULL_URL` – custom endpoints for synchronization.
 - `SYNC_API_KEY` – bearer token sent with sync requests.

--- a/core/utils/paths.py
+++ b/core/utils/paths.py
@@ -1,13 +1,18 @@
 import os
 
-# Base directory of the project repository
+"""Utility paths used throughout the application."""
+
+# Base directory of the project repository.  When the application is installed
+# as a package this points inside ``site-packages`` so writes may fail.
 BASE_DIR = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
 
-# Absolute path to the ``static`` directory.
-#
-# Static assets are served from ``BASE_DIR/web-client/static``. Earlier versions
-# of the application stored them directly under ``static`` but moving them under
-# ``web-client`` keeps all client assets together.
-STATIC_DIR = os.path.join(BASE_DIR, "web-client", "static")
+# Absolute path to the ``static`` directory.  It can be overridden via the
+# ``STATIC_DIR`` environment variable to support deployments where the
+# repository location is read-only.
+_env_static = os.environ.get("STATIC_DIR")
+if _env_static:
+    STATIC_DIR = os.path.abspath(_env_static)
+else:
+    STATIC_DIR = os.path.join(BASE_DIR, "web-client", "static")


### PR DESCRIPTION
## Summary
- clarify docs for overriding STATIC_DIR when assets must be writable
- always convert STATIC_DIR to an absolute path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541cd71a708324986b6b0ed5a8641b