### PR TITLE
Add sync push worker diagnostics

### DIFF
--- a/server/workers/sync_pull_worker.py
+++ b/server/workers/sync_pull_worker.py
@@ -112,6 +112,7 @@ async def pull_once(log: logging.Logger) -> None:
     db = SessionLocal()
     try:
         since = _load_last_sync(db)
+        print(f"\U0001F4C5 Pulling records updated since: {since}")
         _, pull_url, site_id, api_key = _get_sync_config()
         payload: dict[str, Any] = {
             "since": since.isoformat(),
@@ -123,6 +124,7 @@ async def pull_once(log: logging.Logger) -> None:
         if not isinstance(data, list):
             log.error("Invalid pull response: %s", data)
             return
+        print(f"\u2B07\uFE0F Pulled {len(data)} records")
         model_map = {
             cls.__tablename__: cls for cls in model_module.Base.__subclasses__()
         }
@@ -226,3 +228,19 @@ async def stop_sync_pull_worker() -> None:
         except asyncio.CancelledError:
             pass
         _sync_task = None
+
+
+async def main() -> None:
+    print("\u27a1\ufe0f Sync Pull Worker started...")
+    start_sync_pull_worker()
+    try:
+        while True:
+            await asyncio.sleep(3600)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await stop_sync_pull_worker()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -74,6 +74,7 @@ async def push_once(log: logging.Logger) -> None:
     db = SessionLocal()
     try:
         since = _load_last_sync(db)
+        print(f"\U0001F4C5 Pushing records updated since: {since}")
         all_records: list[dict[str, Any]] = []
         for model_cls in model_module.Base.__subclasses__():
             created_col = getattr(model_cls, "created_at", None)
@@ -93,6 +94,7 @@ async def push_once(log: logging.Logger) -> None:
                     {**_serialize(obj), "model": model_cls.__tablename__}
                 )
 
+        print(f"\u2B06\uFE0F Pushing {len(all_records)} records")
         if not all_records:
             return
 
@@ -143,3 +145,19 @@ async def stop_sync_push_worker() -> None:
         except asyncio.CancelledError:
             pass
         _sync_task = None
+
+
+async def main() -> None:
+    print("\u27A1\uFE0F Sync Push Worker started...")
+    start_sync_push_worker()
+    try:
+        while True:
+            await asyncio.sleep(3600)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await stop_sync_push_worker()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- print the timestamp when pushing records
- report how many records are pushed and pulled
- add entrypoint for manual execution of the push worker

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685436bca4d883249fe3ceefbbd8bebe