### PR TITLE
Fix soft delete to respect not-null columns

### DIFF
--- a/server/routes/api/devices.py
+++ b/server/routes/api/devices.py
@@ -14,14 +14,15 @@ router = APIRouter(prefix="/api/v1/devices", tags=["devices"])
 
 
 def _soft_delete(device: Device, user_id: int, origin: str) -> None:
-    """Mark the device as deleted and clear mutable fields."""
+    """Mark the device as deleted without clearing non-nullable fields."""
     if device.is_deleted:
         return
     keep = {"mac", "asset_tag"}
     for col in device.__table__.columns:
         if col.name in keep or col.primary_key:
             continue
-        setattr(device, col.name, None)
+        if col.nullable:
+            setattr(device, col.name, None)
     device.is_deleted = True
     device.deleted_by_id = user_id
     device.deleted_at = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
- keep not-null attributes intact when soft deleting devices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68545a6a3d20832486fd74e1e234cd7b