### PR TITLE
Expand help page with user manual

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,0 +1,78 @@
+# User Manual
+
+This guide explains how to navigate the Master IP application, manage settings and resolve common issues.
+
+## Navigation Overview
+
+The main menu exposes **Inventory**, **Network** and **Admin** sections. Inventory pages manage devices, reports and related settings. The Network menu covers dashboards, configuration tasks and status utilities. Administrators see additional pages for system settings and cloud synchronisation.
+
+## Core Data Fields
+
+Devices and other records rely on a set of common variables:
+
+- **Location** – physical location of the device. Locations are created under *Admin → Locations* and assigned when editing a device.
+- **Site** – logical site used for cloud replication. Sites are managed from *Admin → Sites*.
+- **Device Type** – model category for hardware. Defined under *Admin → Inventory Settings*.
+- **VLAN** – network VLAN number. Added from *Network → Network Settings → VLANs*.
+- **SSH Profile** – credentials for SSH actions. Managed from *Network → Network Settings → SSH Credentials*.
+- **SNMP Profile** – community or v3 profile for SNMP polling. Configured under *Network → Network Settings → SNMP Profiles*.
+- **Tags** – free‑form labels applied to devices for filtering.
+- **System Tunables** – application options stored in the database. Accessible at *Admin → System Tunables*.
+
+### System Tunables
+
+Each tunable has a **name**, **value**, **function** group and optional choices. Key options include:
+
+- **Enable SSH** – turn the built‑in SSH service on or off.
+- **Config Backup Count** – number of configuration backups to keep.
+- **SNMP Version** – protocol version used when querying devices.
+- **Google Service Account JSON** – path to Google Sheets credentials.
+- **Google Spreadsheet ID** – target spreadsheet identifier.
+- **GOOGLE_MAPS_API_KEY** – API key for the Maps JavaScript library.
+- **Netbird API URL / Token** – connection info for Netbird integration.
+- **Cloud Base URL / API Key / Site ID** – parameters for cloud synchronisation.
+- **Enable Cloud Sync** – toggles the periodic heartbeat and sync workers.
+- **Queue Interval** – seconds between processing queued config pushes.
+- **Port History Retention Days** – days to keep historical port data.
+- **SSH Timeout Seconds** – inactivity timeout for the web terminal.
+- **Default SNMP Version** – preselected version when creating profiles.
+- **Enable SNMP Trap Listener** and **SNMP Trap Port** – control the trap listener.
+- **Enable Syslog Listener** and **Syslog Port** – control the syslog listener.
+- **SMTP Server / Port / Username / Password** – outgoing mail settings.
+- **Email From** – default sender address.
+- **App Version** – informational string shown on the settings page.
+- **ALLOW_SELF_UPDATE** and **FORCE_REBOOT_ON_UPDATE** – update behaviour.
+
+## Environment Variables
+
+The server also reads configuration from the environment:
+
+- `DATABASE_URL` – PostgreSQL connection string.
+- `SECRET_KEY` – signing key for sessions and tokens (change before deploying).
+- `TOKEN_TTL` – token lifetime in seconds (default 3600).
+- `SESSION_TTL` – session cookie lifetime (default 43200).
+- `ROOT_PATH` – optional URL prefix when behind a proxy.
+- `ENABLE_TRAP_LISTENER` and `SNMP_TRAP_PORT` – enable and configure the trap listener.
+- `ENABLE_SYSLOG_LISTENER` and `SYSLOG_PORT` – enable and configure the syslog listener.
+- `QUEUE_INTERVAL` and `PORT_HISTORY_RETENTION_DAYS` – worker scheduling values.
+- `WORKERS`, `TIMEOUT`, `PORT` and `AUTO_SEED` – options used by `start.sh`.
+- `ROLE` – set to `local` or `cloud` to control sync behaviour.
+- `ENABLE_CLOUD_SYNC` – disable cloud sync when set to `0`.
+- `ENABLE_SYNC_PUSH_WORKER` – disable pushing local changes.
+- `ENABLE_SYNC_PULL_WORKER` – disable pulling updates from the cloud.
+- `ENABLE_BACKGROUND_WORKERS` – disable to skip queue and scheduler startup.
+- `STATIC_DIR` – directory for uploaded images and other static assets.
+- `CLOUD_BASE_URL` – base URL of the cloud server (overrides tunable).
+- `SYNC_PUSH_URL` and `SYNC_PULL_URL` – custom sync endpoints.
+- `SYNC_API_KEY` – bearer token sent with sync requests.
+
+## Error States and Resolutions
+
+- **Red Table Row** – a device or VLAN row highlighted in dark red indicates a conflict between the local record and the cloud. Open the alert icon in the Actions column or visit *Reports → Conflicts* to merge the data. Once resolved the row colour returns to normal.
+- **Duplicate Highlighting** – cells with duplicate IP, MAC or asset tags appear with a red dot and tooltip. Review the duplicates report under *Inventory → Reports → Duplicates* and edit or remove the extra entries.
+- **Unsynced Data Warning** – the update page shows "Unsynced Data" when local changes have not been pushed to the cloud. Use *Admin → Cloud Sync / API's* to run a manual sync before updating.
+- **Terminal Disconnected** – if the web terminal only shows "*** Disconnected ***" ensure the `websockets` Python package is installed on the server.
+
+## Further Help
+
+See the README for installation instructions. Administrators can consult this manual at `/help/manual` within the application.

--- a/server/routes/ui/help.py
+++ b/server/routes/ui/help.py
@@ -11,3 +11,13 @@ async def help_page(request: Request, current_user=Depends(get_current_user)):
         'current_user': current_user,
     }
     return templates.TemplateResponse('help.html', context)
+
+
+@router.get('/help/manual')
+async def manual_page(request: Request, current_user=Depends(get_current_user)):
+    """Display the expanded user manual."""
+    context = {
+        'request': request,
+        'current_user': current_user,
+    }
+    return templates.TemplateResponse('manual.html', context)

--- a/web-client/templates/help.html
+++ b/web-client/templates/help.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="bg-[var(--card-bg)] text-[var(--card-text)] p-6 rounded shadow max-w-screen-md mx-auto">
   <h1 class="text-2xl mb-4">Application Help</h1>
-  <p class="mb-4">This page explains the main navigation items. Each menu opens a set of tools for managing your network inventory and configurations.</p>
+  <p class="mb-4">This page explains the main navigation items. Each menu opens a set of tools for managing your network inventory and configurations. A more detailed guide is available from the <a href="/help/manual" class="underline">User Manual</a>.</p>
 
   <h2 class="text-xl mt-4 mb-2">Inventory Menu</h2>
   <ul class="list-disc list-inside space-y-1">

--- a/web-client/templates/manual.html
+++ b/web-client/templates/manual.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="prose prose-invert max-w-screen-md mx-auto">
+  <h1>User Manual</h1>
+  <p>This guide explains how to navigate the Master IP application, manage settings and resolve common issues.</p>
+  <h2>Navigation Overview</h2>
+  <p>The main menu exposes <strong>Inventory</strong>, <strong>Network</strong> and <strong>Admin</strong> sections. Inventory pages manage devices, reports and related settings. The Network menu covers dashboards, configuration tasks and status utilities. Administrators see additional pages for system settings and cloud synchronisation.</p>
+  <h2>Core Data Fields</h2>
+  <ul>
+    <li><strong>Location</strong> – physical location of the device. Locations are created under <em>Admin → Locations</em> and assigned when editing a device.</li>
+    <li><strong>Site</strong> – logical site used for cloud replication. Sites are managed from <em>Admin → Sites</em>.</li>
+    <li><strong>Device Type</strong> – model category for hardware. Defined under <em>Admin → Inventory Settings</em>.</li>
+    <li><strong>VLAN</strong> – network VLAN number. Added from <em>Network → Network Settings → VLANs</em>.</li>
+    <li><strong>SSH Profile</strong> – credentials for SSH actions. Managed from <em>Network → Network Settings → SSH Credentials</em>.</li>
+    <li><strong>SNMP Profile</strong> – community or v3 profile for SNMP polling. Configured under <em>Network → Network Settings → SNMP Profiles</em>.</li>
+    <li><strong>Tags</strong> – free-form labels applied to devices for filtering.</li>
+    <li><strong>System Tunables</strong> – application options stored in the database. Accessible at <em>Admin → System Tunables</em>.</li>
+  </ul>
+  <h3>System Tunables</h3>
+  <p>Each tunable has a <strong>name</strong>, <strong>value</strong>, <strong>function</strong> group and optional choices. Key options include:</p>
+  <ul>
+    <li><strong>Enable SSH</strong> – turn the built-in SSH service on or off.</li>
+    <li><strong>Config Backup Count</strong> – number of configuration backups to keep.</li>
+    <li><strong>SNMP Version</strong> – protocol version used when querying devices.</li>
+    <li><strong>Google Service Account JSON</strong> – path to Google Sheets credentials.</li>
+    <li><strong>Google Spreadsheet ID</strong> – target spreadsheet identifier.</li>
+    <li><strong>GOOGLE_MAPS_API_KEY</strong> – API key for the Maps JavaScript library.</li>
+    <li><strong>Netbird API URL / Token</strong> – connection info for Netbird integration.</li>
+    <li><strong>Cloud Base URL / API Key / Site ID</strong> – parameters for cloud synchronisation.</li>
+    <li><strong>Enable Cloud Sync</strong> – toggles the periodic heartbeat and sync workers.</li>
+    <li><strong>Queue Interval</strong> – seconds between processing queued config pushes.</li>
+    <li><strong>Port History Retention Days</strong> – days to keep historical port data.</li>
+    <li><strong>SSH Timeout Seconds</strong> – inactivity timeout for the web terminal.</li>
+    <li><strong>Default SNMP Version</strong> – preselected version when creating profiles.</li>
+    <li><strong>Enable SNMP Trap Listener</strong> and <strong>SNMP Trap Port</strong> – control the trap listener.</li>
+    <li><strong>Enable Syslog Listener</strong> and <strong>Syslog Port</strong> – control the syslog listener.</li>
+    <li><strong>SMTP Server / Port / Username / Password</strong> – outgoing mail settings.</li>
+    <li><strong>Email From</strong> – default sender address.</li>
+    <li><strong>App Version</strong> – informational string shown on the settings page.</li>
+    <li><strong>ALLOW_SELF_UPDATE</strong> and <strong>FORCE_REBOOT_ON_UPDATE</strong> – update behaviour.</li>
+  </ul>
+  <h2>Environment Variables</h2>
+  <p>The server also reads configuration from the environment:</p>
+  <ul>
+    <li><code>DATABASE_URL</code> – PostgreSQL connection string.</li>
+    <li><code>SECRET_KEY</code> – signing key for sessions and tokens (change before deploying).</li>
+    <li><code>TOKEN_TTL</code> – token lifetime in seconds (default 3600).</li>
+    <li><code>SESSION_TTL</code> – session cookie lifetime (default 43200).</li>
+    <li><code>ROOT_PATH</code> – optional URL prefix when behind a proxy.</li>
+    <li><code>ENABLE_TRAP_LISTENER</code> and <code>SNMP_TRAP_PORT</code> – enable and configure the trap listener.</li>
+    <li><code>ENABLE_SYSLOG_LISTENER</code> and <code>SYSLOG_PORT</code> – enable and configure the syslog listener.</li>
+    <li><code>QUEUE_INTERVAL</code> and <code>PORT_HISTORY_RETENTION_DAYS</code> – worker scheduling values.</li>
+    <li><code>WORKERS</code>, <code>TIMEOUT</code>, <code>PORT</code> and <code>AUTO_SEED</code> – options used by <code>start.sh</code>.</li>
+    <li><code>ROLE</code> – set to <code>local</code> or <code>cloud</code> to control sync behaviour.</li>
+    <li><code>ENABLE_CLOUD_SYNC</code> – disable cloud sync when set to <code>0</code>.</li>
+    <li><code>ENABLE_SYNC_PUSH_WORKER</code> – disable pushing local changes.</li>
+    <li><code>ENABLE_SYNC_PULL_WORKER</code> – disable pulling updates from the cloud.</li>
+    <li><code>ENABLE_BACKGROUND_WORKERS</code> – disable to skip queue and scheduler startup.</li>
+    <li><code>STATIC_DIR</code> – directory for uploaded images and other static assets.</li>
+    <li><code>CLOUD_BASE_URL</code> – base URL of the cloud server (overrides tunable).</li>
+    <li><code>SYNC_PUSH_URL</code> and <code>SYNC_PULL_URL</code> – custom sync endpoints.</li>
+    <li><code>SYNC_API_KEY</code> – bearer token sent with sync requests.</li>
+  </ul>
+  <h2>Error States and Resolutions</h2>
+  <ul>
+    <li><strong>Red Table Row</strong> – a device or VLAN row highlighted in dark red indicates a conflict between the local record and the cloud. Open the alert icon in the Actions column or visit <em>Reports → Conflicts</em> to merge the data. Once resolved the row colour returns to normal.</li>
+    <li><strong>Duplicate Highlighting</strong> – cells with duplicate IP, MAC or asset tags appear with a red dot and tooltip. Review the duplicates report under <em>Inventory → Reports → Duplicates</em> and edit or remove the extra entries.</li>
+    <li><strong>Unsynced Data Warning</strong> – the update page shows "Unsynced Data" when local changes have not been pushed to the cloud. Use <em>Admin → Cloud Sync / API's</em> to run a manual sync before updating.</li>
+    <li><strong>Terminal Disconnected</strong> – if the web terminal only shows "*** Disconnected ***" ensure the <code>websockets</code> Python package is installed on the server.</li>
+  </ul>
+  <h2>Further Help</h2>
+  <p>See the README for installation instructions. Administrators can consult this manual at <code>/help/manual</code> within the application.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- document core variables and error states in a new manual
- add `/help/manual` route and page
- link manual from help page

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854651552848324a5fafa8174fefc2a