### PR TITLE
Sync pull returns records from all sites

### DIFF
--- a/server/routes/api/sync.py
+++ b/server/routes/api/sync.py
@@ -303,8 +303,10 @@ async def pull_changes(
         else:
             continue  # no timestamp columns to filter
 
-        if hasattr(model_cls, "site_id"):
-            query = query.filter(getattr(model_cls, "site_id") == key.site_id)
+        # Do not restrict by site_id so all records are synced across every site
+        # Previously only records matching the requesting site's ID were returned.
+        # Removing the filter ensures all data propagates between cloud and local
+        # instances, matching the desired behavior of full database replication.
 
         for obj in query.all():
             data = {c.key: getattr(obj, c.key) for c in insp.mapper.column_attrs}


### PR DESCRIPTION
## Summary
- remove filtering by `site_id` in the pull sync endpoint so that all records replicate to every instance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685466278f588324b4392157d19cbbf2