### PR TITLE
Fix sync push exception handling

### DIFF
--- a/server/utils/sync_conflicts.py
+++ b/server/utils/sync_conflicts.py
@@ -77,7 +77,9 @@ async def resolve_device_conflict(
     db.commit()
     log_audit(db, user, "resolve_conflict", device, f"choice={choice}")
     # Trigger an immediate push to the cloud
-    asyncio.create_task(sync_push_worker.push_once(logging.getLogger(__name__)))
+    asyncio.create_task(
+        sync_push_worker.push_once_safe(logging.getLogger(__name__))
+    )
 
 
 def list_device_conflicts(

--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -123,6 +123,14 @@ async def push_once(log: logging.Logger) -> None:
         db.close()
 
 
+async def push_once_safe(log: logging.Logger) -> None:
+    """Run ``push_once`` and log any exceptions."""
+    try:
+        await push_once(log)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log.error("Sync push failed: %s", exc)
+
+
 async def _push_loop() -> None:
     log = logging.getLogger(__name__)
     delay = SYNC_PUSH_INTERVAL

--- a/tests/workers/test_sync_push_worker.py
+++ b/tests/workers/test_sync_push_worker.py
@@ -210,3 +210,14 @@ def test_request_with_retry_retries(monkeypatch):
         )
     )
     assert len(calls) == 2
+
+
+@pytest.mark.unit
+def test_push_once_safe_logs_errors(monkeypatch):
+    async def fail(log):
+        raise httpx.ConnectError("fail")
+
+    monkeypatch.setattr(sync_push_worker, "push_once", fail)
+    log = mock.Mock()
+    asyncio.run(sync_push_worker.push_once_safe(log))
+    log.error.assert_called_once()


### PR DESCRIPTION
## Summary
- add `push_once_safe` helper for sync push
- use the safe helper when resolving device conflicts
- test background push error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546ea46bac8324be42f2701744a38d