### PR TITLE
Improve sync conflict tracking

### DIFF
--- a/core/schemas.py
+++ b/core/schemas.py
@@ -12,8 +12,11 @@ class ConflictEntry(BaseModel):
     field: str
     local_value: Any
     remote_value: Any
-    timestamp: datetime
+    conflict_detected_at: datetime
     source: str
+    local_version: int
+    remote_version: int
+    conflict_type: str
 
 
 class BaseSchema(BaseModel):

--- a/core/utils/versioning.py
+++ b/core/utils/versioning.py
@@ -28,8 +28,11 @@ def apply_update(
                     "field": field,
                     "local_value": lv,
                     "remote_value": rv,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "conflict_detected_at": datetime.now(timezone.utc).isoformat(),
                     "source": source,
+                    "local_version": current_version,
+                    "remote_version": incoming_version,
+                    "conflict_type": source,
                 }
             )
             continue

--- a/web-client/templates/conflict_list.html
+++ b/web-client/templates/conflict_list.html
@@ -51,7 +51,9 @@
 {% endif %}
 {% if conflicts %}
   {% for dev in conflicts %}
-  <h2 class="text-lg mt-4">{{ dev.hostname }}</h2>
+  <h2 class="text-lg mt-4">{{ dev.hostname }}
+    <span class="text-sm ml-2 text-gray-400">{{ dev.ip }} {{ dev.mac or '' }}</span>
+  </h2>
   <form method="post" action="/reports/conflicts/{{ dev.id }}" class="full-width space-y-2">
     <div class="md:flex gap-4">
       <div class="md:w-2/3 space-y-4">


### PR DESCRIPTION
## Summary
- add more metadata to `ConflictEntry`
- track extra details when conflicts are detected
- show IP and MAC on the conflict list page

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854790d75c08324aa4a060edf88dcd0