### PR TITLE
Improve sync diagnostics

### DIFF
--- a/server/routes/ui/sync_diagnostics.py
+++ b/server/routes/ui/sync_diagnostics.py
@@ -27,10 +27,18 @@ def _render_sync(request: Request, db: Session, current_user, message: str = "")
         except Exception:
             return "never"
 
+    def _num(name: str) -> str:
+        val = tunables.get(name)
+        return val or "0"
+
     last_push = _fmt("Last Sync Push")
     last_pull = _fmt("Last Sync Pull")
     last_push_worker = _fmt("Last Sync Push Worker")
     last_pull_worker = _fmt("Last Sync Pull Worker")
+    last_push_count = _num("Last Sync Push Worker Count")
+    last_pull_count = _num("Last Sync Pull Worker Count")
+    push_error = tunables.get("Last Sync Push Error") or ""
+    pull_error = tunables.get("Last Sync Pull Error") or ""
     now = datetime.now(timezone.utc)
     last_contact = tunables.get("Last Cloud Contact")
     connection_status = "Disconnected"
@@ -93,6 +101,10 @@ def _render_sync(request: Request, db: Session, current_user, message: str = "")
         "last_pull": last_pull,
         "last_push_worker": last_push_worker,
         "last_pull_worker": last_pull_worker,
+        "last_push_count": last_push_count,
+        "last_pull_count": last_pull_count,
+        "push_error": push_error,
+        "pull_error": pull_error,
     }
     return templates.TemplateResponse("admin_sync.html", context)
 

--- a/web-client/templates/admin_sync.html
+++ b/web-client/templates/admin_sync.html
@@ -71,9 +71,14 @@
       <ul class="list-disc ml-6 text-sm">
         <li>Last Push: {{ last_push }}</li>
         <li>Last Pull: {{ last_pull }}</li>
-        <li>Last Push Worker: {{ last_push_worker }}</li>
-        <li>Last Pull Worker: {{ last_pull_worker }}</li>
+        <li>Last Push Worker: {{ last_push_worker }} ({{ last_push_count }} records)</li>
+        <li>Last Pull Worker: {{ last_pull_worker }} ({{ last_pull_count }} records)</li>
       </ul>
+      {% if push_error or pull_error %}
+      <p class="p-2 mt-2 rounded bg-[var(--alert-bg)] text-red-300">
+        Sync issue: {{ push_error or pull_error }}
+      </p>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/web-client/templates/conflict_list.html
+++ b/web-client/templates/conflict_list.html
@@ -1,6 +1,31 @@
 {% extends "base.html" %}
 {% block content %}
 <h1 class="text-xl mb-4">Sync Conflicts</h1>
+{% if role == 'cloud' and sites %}
+<h2 class="text-lg mt-4">Connected Sites</h2>
+<div class="w-full overflow-auto mb-4">
+  <table class="min-w-full table-fixed text-left border-collapse">
+    <thead>
+      <tr>
+        <th class="table-cell table-header">Site ID</th>
+        <th class="table-cell table-header">Server Name</th>
+        <th class="table-cell table-header">Type</th>
+        <th class="table-cell table-header">Last Sync Time</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for s in sites %}
+      <tr class="border-t border-gray-700">
+        <td class="table-cell">{{ s.site_id }}</td>
+        <td class="table-cell">{{ name_map.get(s.site_id, '') }}</td>
+        <td class="table-cell">local</td>
+        <td class="table-cell">{{ s.last_seen or 'never' }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
 {% if recent %}
 <h2 class="text-lg mt-4">Recently Synced Records</h2>
 <div x-data="tableControls()" class="space-y-2 full-width">

--- a/web-client/templates/sync_diagnostics.html
+++ b/web-client/templates/sync_diagnostics.html
@@ -5,7 +5,12 @@
 <ul class="list-disc ml-6">
   <li>Last Push: {{ last_push }}</li>
   <li>Last Pull: {{ last_pull }}</li>
-  <li>Last Push Worker: {{ last_push_worker }}</li>
-  <li>Last Pull Worker: {{ last_pull_worker }}</li>
+  <li>Last Push Worker: {{ last_push_worker }} ({{ last_push_count }} records)</li>
+  <li>Last Pull Worker: {{ last_pull_worker }} ({{ last_pull_count }} records)</li>
 </ul>
+{% if push_error or pull_error %}
+<p class="p-2 mt-2 rounded bg-[var(--alert-bg)] text-red-300">
+  Sync issue: {{ push_error or pull_error }}
+</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- log sync attempts
- show push/pull counts and errors in sync diagnostics pages
- expose connected sites in conflict list
- track record counts for push/pull workers

## Testing
- `pip install fastapi starlette sqlalchemy httpx pydantic -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68547a852bbc8324b81b9c0bc57caf61