### PR TITLE
Enhance sync deletion handling

### DIFF
--- a/core/schemas.py
+++ b/core/schemas.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, field_validator
+from core.utils.ip_utils import normalize_ip
 
 
 class ConflictEntry(BaseModel):
@@ -74,6 +75,11 @@ class DeviceCreate(BaseModel):
     version: int = Field(1, ge=1)
     conflict_data: list[ConflictEntry] | None = None
 
+    @field_validator("ip")
+    @classmethod
+    def _validate_ip(cls, v: str) -> str:
+        return normalize_ip(v)
+
 
 class DeviceRead(DeviceBase):
     id: int
@@ -89,6 +95,13 @@ class DeviceUpdate(BaseModel):
     model: str | None = None
     version: int | None = Field(None, ge=1)
     conflict_data: list[ConflictEntry] | None = None
+
+    @field_validator("ip")
+    @classmethod
+    def _validate_ip(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return normalize_ip(v)
 
 
 class SSHCredentialBase(BaseSchema):

--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -32,7 +32,7 @@ def _serialize(obj: Any) -> dict[str, Any]:
     # When a record is marked deleted only send minimal identifying fields
     deleted = data.get("deleted_at")
     if deleted:
-        keep = {"uuid", "asset_tag", "mac", "deleted_at", "updated_at"}
+        keep = {"uuid", "asset_tag", "mac", "deleted_at", "updated_at", "is_deleted"}
         data = {k: v for k, v in data.items() if k in keep}
     return data
 

--- a/tests/workers/test_sync_push_worker.py
+++ b/tests/workers/test_sync_push_worker.py
@@ -216,7 +216,7 @@ def test_push_once_includes_deleted_records(monkeypatch):
     asyncio.run(sync_push_worker.push_once(mock.Mock()))
 
     record = sent["payload"][models.Device.__tablename__][0]
-    assert set(record.keys()) <= {"uuid", "asset_tag", "mac", "deleted_at", "updated_at"}
+    assert set(record.keys()) <= {"uuid", "asset_tag", "mac", "deleted_at", "updated_at", "is_deleted"}
     assert record["deleted_at"] is not None
 
 

--- a/web-client/templates/admin_sync.html
+++ b/web-client/templates/admin_sync.html
@@ -79,6 +79,12 @@
         Sync issue: {{ push_error or pull_error }}
       </p>
       {% endif %}
+      <form method="post" action="/admin/sync/manual-push" class="inline-block mt-2 mr-2">
+        <button type="submit" class="btn">Push Now</button>
+      </form>
+      <form method="post" action="/admin/sync/manual-pull" class="inline-block mt-2">
+        <button type="submit" class="btn">Pull Now</button>
+      </form>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- validate IP fields when creating/updating devices
- include `is_deleted` marker in push payloads
- handle delete events properly when pulling from cloud
- add manual push/pull triggers in sync admin page
- adjust tests for new fields

## Testing
- `pytest tests/workers/test_sync_push_worker.py::test_push_once_includes_deleted_records -q`
- `pytest tests/workers/test_sync_pull_worker.py::test_pull_once_updates_and_inserts -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68547cfca9f083248d2909b04f73a0a6