### PR TITLE
Fix UUID JSON serialization in sync push worker

### DIFF
--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import uuid
 from datetime import datetime, timezone
 from typing import Any
 
@@ -27,6 +28,8 @@ def _serialize(obj: Any) -> dict[str, Any]:
         val = getattr(obj, c.key)
         if isinstance(val, datetime):
             val = val.astimezone(timezone.utc).isoformat()
+        elif isinstance(val, uuid.UUID):
+            val = str(val)
         data[c.key] = val
 
     # When a record is marked deleted only send minimal identifying fields


### PR DESCRIPTION
## Summary
- fix cloud sync push worker by converting UUIDs to strings before JSON encoding
- ensure sync push worker import uuid module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552228b0d083249cf76ffd86d21270