### PR TITLE
Reduce push worker noise

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,6 +1,9 @@
 from fastapi import FastAPI, Request, WebSocket, Depends, HTTPException
 from contextlib import asynccontextmanager
 import logging
+
+# Reduce noisy INFO logs from Alembic when workers start
+logging.getLogger("alembic.runtime.migration").setLevel(logging.WARNING)
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import JSONResponse, RedirectResponse
 

--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -124,6 +124,18 @@ async def push_once(log: logging.Logger) -> None:
         pushed_objs: list[Any] = []
         invalid_count = 0
         for model_cls in model_module.Base.__subclasses__():
+            # Only process models that participate in the sync protocol.
+            if not (
+                hasattr(model_cls, "uuid")
+                and hasattr(model_cls, "version")
+                and hasattr(model_cls, "updated_at")
+            ):
+                log.debug(
+                    "Skipping %s model due to missing sync columns",
+                    getattr(model_cls, "__tablename__", str(model_cls)),
+                )
+                continue
+
             created_col = getattr(model_cls, "created_at", None)
             updated_col = getattr(model_cls, "updated_at", None)
             deleted_col = getattr(model_cls, "deleted_at", None)


### PR DESCRIPTION
## Summary
- skip non-sync models in push worker
- suppress Alembic INFO logs

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68552844d230832481f64ba4ad6ed72d