### PR TITLE
Fix sync record key conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ alembic upgrade head
 ```bash
 curl -X POST http://localhost:8000/api/v1/sync/push \
      -H 'Content-Type: application/json' \
-    -d '{"model":"devices","records":[]}'
+    -d '{"table":"devices","records":[]}'
 ```
 
 ## Running Tests

--- a/core/utils/versioning.py
+++ b/core/utils/versioning.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from typing import Any
+import uuid
 
 
 def apply_update(
@@ -21,8 +22,16 @@ def apply_update(
         changed_remote = last_value is not None and remote_value != last_value
 
         if changed_local and changed_remote and remote_value != local_value:
-            lv = local_value.isoformat() if isinstance(local_value, datetime) else local_value
-            rv = remote_value.isoformat() if isinstance(remote_value, datetime) else remote_value
+            lv = local_value
+            rv = remote_value
+            if isinstance(lv, datetime):
+                lv = lv.isoformat()
+            elif isinstance(lv, uuid.UUID):
+                lv = str(lv)
+            if isinstance(rv, datetime):
+                rv = rv.isoformat()
+            elif isinstance(rv, uuid.UUID):
+                rv = str(rv)
             conflicts.append(
                 {
                     "field": field,

--- a/server/routes/api/sync.py
+++ b/server/routes/api/sync.py
@@ -120,7 +120,7 @@ async def push_changes(
             for rec in payload["records"]:
                 if not isinstance(rec, dict):
                     continue
-                model_name = rec.get("model")
+                model_name = rec.get("table") or rec.get("model")
                 if not model_name or model_name not in model_map:
                     continue
                 records_by_model.setdefault(model_name, []).append(rec)
@@ -356,7 +356,7 @@ async def pull_changes(
 
         for obj in query.all():
             data = {c.key: getattr(obj, c.key) for c in insp.mapper.column_attrs}
-            results.append({"model": model_name, **data})
+            results.append({"table": model_name, **data})
             log_sync(db, obj.id, model_name, "read", "cloud", "local")
 
     print(f"\u2b06\ufe0f Sending {len(results)} records to site {key.site_id}")

--- a/server/workers/sync_pull_worker.py
+++ b/server/workers/sync_pull_worker.py
@@ -188,7 +188,7 @@ async def pull_once(log: logging.Logger) -> None:
         for rec in data:
             if not isinstance(rec, dict):
                 continue
-            model_name = rec.get("model")
+            model_name = rec.get("table") or rec.get("model")
             record_id = rec.get("id")
             version = rec.get("version")
             if model_name not in model_map or record_id is None or version is None:


### PR DESCRIPTION
## Summary
- prevent device "model" field from overwriting table name during sync
- allow pull/push endpoints to read `table` key
- document new key in README
- handle UUID values when logging conflict data

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685533107b188324ab2c0bafda5d0d71