### PR TITLE
Add customize columns button to table footer

### DIFF
--- a/web-client/static/js/table.js
+++ b/web-client/static/js/table.js
@@ -204,8 +204,15 @@ function initResize(table, tableId) {
 function insertCustomizeButton(table, tableId) {
   const btn = document.createElement('button')
   btn.textContent = 'Customize Columns'
-  btn.className = 'mb-2 px-2 py-1 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded'
-  table.parentNode.insertBefore(btn, table)
+  btn.className = 'px-2 py-1 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded mr-2'
+  const container = table.nextElementSibling
+  const target = container?.querySelector('div')
+  if (target) {
+    target.insertBefore(btn, target.firstChild)
+  } else {
+    btn.classList.add('mb-2')
+    table.parentNode.insertBefore(btn, table)
+  }
   btn.addEventListener('click', () => showColumnModal(table, tableId))
 }
 


### PR DESCRIPTION
## Summary
- reposition the "Customize Columns" button so it's next to the "Previous" button under tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685542207ea08324840e6f2cb2ed6100