### PR TITLE
Fix sync pull worker start after enabling cloud sync

### DIFF
--- a/server/routes/cloud.py
+++ b/server/routes/cloud.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 from core.utils.auth import require_role
 from core.utils.db_session import get_db
 from server.utils.cloud import save_cloud_connection
+from server.workers import cloud_sync, sync_pull_worker, sync_push_worker
 
 router = APIRouter()
 
@@ -20,4 +21,12 @@ async def update_cloud_config(
 ):
     enabled = enable == "on" or enable.lower() in {"true", "1", "yes"}
     save_cloud_connection(db, cloud_url, site_id, api_key, enabled)
+    if enabled:
+        cloud_sync.start_cloud_sync()
+        sync_push_worker.start_sync_push_worker()
+        sync_pull_worker.start_sync_pull_worker()
+    else:
+        await cloud_sync.stop_cloud_sync()
+        await sync_push_worker.stop_sync_push_worker()
+        await sync_pull_worker.stop_sync_pull_worker()
     return RedirectResponse("/admin/cloud-sync", status_code=302)

--- a/server/utils/cloud.py
+++ b/server/utils/cloud.py
@@ -8,6 +8,13 @@ from core.models.models import SystemTunable
 from core.utils.env_file import set_env_vars
 
 
+def _set_runtime_env(enabled: bool) -> None:
+    """Update os.environ so running workers see new settings."""
+    os.environ["ENABLE_CLOUD_SYNC"] = "1" if enabled else "0"
+    os.environ["ENABLE_SYNC_PUSH_WORKER"] = "1" if enabled else "0"
+    os.environ["ENABLE_SYNC_PULL_WORKER"] = "1" if enabled else "0"
+
+
 def ensure_env_writable(path: str = ".env") -> bool:
     """Return True if the env file can be written by the current user."""
     env_path = Path(path)
@@ -43,7 +50,9 @@ def set_tunable(db: Session, name: str, value: str) -> None:
     db.commit()
 
 
-def save_cloud_connection(db: Session, cloud_url: str, site_id: str, api_key: str, enabled: bool) -> None:
+def save_cloud_connection(
+    db: Session, cloud_url: str, site_id: str, api_key: str, enabled: bool
+) -> None:
     """Persist cloud connection settings and update the .env file."""
     set_tunable(db, "Cloud Base URL", cloud_url)
     set_tunable(db, "Cloud Site ID", site_id)
@@ -54,6 +63,10 @@ def save_cloud_connection(db: Session, cloud_url: str, site_id: str, api_key: st
         ENABLE_SYNC_PUSH_WORKER="1" if enabled else "0",
         ENABLE_SYNC_PULL_WORKER="1" if enabled else "0",
     )
+    _set_runtime_env(enabled)
+    os.environ["CLOUD_BASE_URL"] = cloud_url
+    os.environ["SITE_ID"] = site_id
+    os.environ["SYNC_API_KEY"] = api_key
 
 
 def load_sync_settings(db: Session) -> dict:
@@ -61,6 +74,6 @@ def load_sync_settings(db: Session) -> dict:
         "cloud_url": get_tunable(db, "Cloud Base URL") or "",
         "site_id": get_tunable(db, "Cloud Site ID") or "",
         "api_key": get_tunable(db, "Cloud API Key") or "",
-        "enabled": (get_tunable(db, "Enable Cloud Sync") or "false").lower() in {"true", "1", "yes"},
+        "enabled": (get_tunable(db, "Enable Cloud Sync") or "false").lower()
+        in {"true", "1", "yes"},
     }
-

--- a/server/workers/sync_pull_worker.py
+++ b/server/workers/sync_pull_worker.py
@@ -106,9 +106,11 @@ def _update_last_sync(db: Session, count: int, conflicts: int = 0) -> None:
                 data_type="text",
             )
         )
-    cnt = db.query(SystemTunable).filter(
-        SystemTunable.name == "Last Sync Pull Worker Count"
-    ).first()
+    cnt = (
+        db.query(SystemTunable)
+        .filter(SystemTunable.name == "Last Sync Pull Worker Count")
+        .first()
+    )
     if cnt:
         cnt.value = str(count)
     else:
@@ -121,9 +123,11 @@ def _update_last_sync(db: Session, count: int, conflicts: int = 0) -> None:
                 data_type="text",
             )
         )
-    conf = db.query(SystemTunable).filter(
-        SystemTunable.name == "Last Sync Pull Worker Conflicts"
-    ).first()
+    conf = (
+        db.query(SystemTunable)
+        .filter(SystemTunable.name == "Last Sync Pull Worker Conflicts")
+        .first()
+    )
     if conf:
         conf.value = str(conflicts)
     else:
@@ -162,7 +166,7 @@ async def pull_once(log: logging.Logger) -> None:
     db = SessionLocal()
     try:
         since = _load_last_sync(db)
-        msg = f"\U0001F4C5 Pulling records updated since: {since}"
+        msg = f"\U0001f4c5 Pulling records updated since: {since}"
         print(msg)
         log_audit(db, None, "debug", details=msg)
         _, pull_url, site_id, api_key = _get_sync_config()
@@ -178,7 +182,7 @@ async def pull_once(log: logging.Logger) -> None:
         if not isinstance(data, list):
             log.error("Invalid pull response: %s", data)
             return
-        msg = f"\u2B07\uFE0F Pulled {len(data)} records"
+        msg = f"\u2b07\ufe0f Pulled {len(data)} records"
         print(msg)
         log_audit(db, None, "debug", details=msg)
         model_map = {
@@ -212,7 +216,9 @@ async def pull_once(log: logging.Logger) -> None:
                             "field": "deleted_at",
                             "local_value": None,
                             "remote_value": rec.get("deleted_at"),
-                            "conflict_detected_at": datetime.now(timezone.utc).isoformat(),
+                            "conflict_detected_at": datetime.now(
+                                timezone.utc
+                            ).isoformat(),
                             "source": "sync_pull",
                             "local_version": obj.version,
                             "remote_version": version,
@@ -322,8 +328,11 @@ def start_sync_pull_worker() -> None:
     if role == "cloud":
         print("Sync pull worker not started in cloud role")
         return
-    print("Starting sync pull worker")
     global _sync_task
+    if _sync_task:
+        print("Sync pull worker already running")
+        return
+    print("Starting sync pull worker")
     _sync_task = asyncio.create_task(_pull_loop())
 
 


### PR DESCRIPTION
## Summary
- keep sync workers from spawning duplicates
- update env vars at runtime when saving cloud connection
- start or stop sync workers immediately when the cloud sync form is submitted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685543759a848324a6aa8ee8dc46720b