### PR TITLE
Implement unified soft-delete handling

### DIFF
--- a/core/utils/deletion.py
+++ b/core/utils/deletion.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timezone
+from sqlalchemy.orm.session import object_session
+from core.utils.sync_logging import log_deletion
+
+
+def soft_delete(obj, user_id: int | None = None, origin: str = "api") -> None:
+    """Soft delete a SQLAlchemy model instance."""
+    if getattr(obj, "deleted_at", None):
+        return
+    keep = {"uuid", "mac", "asset_tag"}
+    for col in obj.__table__.columns:
+        if col.name in keep or col.primary_key:
+            continue
+        if col.nullable:
+            setattr(obj, col.name, None)
+    if hasattr(obj, "is_deleted"):
+        setattr(obj, "is_deleted", True)
+    if hasattr(obj, "deleted_by_id"):
+        setattr(obj, "deleted_by_id", user_id)
+    if hasattr(obj, "deleted_origin"):
+        setattr(obj, "deleted_origin", origin)
+    obj.deleted_at = datetime.now(timezone.utc)
+    session = object_session(obj)
+    if session is not None:
+        log_deletion(session, obj.id, obj.__tablename__, user_id, origin)

--- a/server/routes/api/ssh_credentials.py
+++ b/server/routes/api/ssh_credentials.py
@@ -6,6 +6,7 @@ from core.models.models import SSHCredential
 from core import schemas
 from core.utils.versioning import apply_update
 from core.utils import auth as auth_utils
+from core.utils.deletion import soft_delete
 
 router = APIRouter(prefix="/api/v1/ssh-credentials", tags=["ssh_credentials"])
 
@@ -71,6 +72,6 @@ def delete_cred(
     obj = db.query(SSHCredential).filter_by(id=cred_id).first()
     if not obj:
         raise HTTPException(status_code=404, detail="Credential not found")
-    db.delete(obj)
+    soft_delete(obj, current_user.id, "api")
     db.commit()
     return {"status": "deleted"}

--- a/server/routes/api/users.py
+++ b/server/routes/api/users.py
@@ -6,6 +6,7 @@ from core.models.models import User
 from core import schemas
 from core.utils.versioning import apply_update
 from core.utils import auth as auth_utils
+from core.utils.deletion import soft_delete
 
 router = APIRouter(prefix="/api/v1/users", tags=["users"])
 
@@ -71,6 +72,6 @@ def delete_user(
     obj = db.query(User).filter_by(id=user_id).first()
     if not obj:
         raise HTTPException(status_code=404, detail="User not found")
-    db.delete(obj)
+    soft_delete(obj, current_user.id, "api")
     db.commit()
     return {"status": "deleted"}

--- a/server/routes/api/vlans.py
+++ b/server/routes/api/vlans.py
@@ -6,6 +6,7 @@ from core.models.models import VLAN
 from core import schemas
 from core.utils.versioning import apply_update
 from core.utils import auth as auth_utils
+from core.utils.deletion import soft_delete
 
 router = APIRouter(prefix="/api/v1/vlans", tags=["vlans"])
 
@@ -71,6 +72,6 @@ def delete_vlan(
     obj = db.query(VLAN).filter_by(id=vlan_id).first()
     if not obj:
         raise HTTPException(status_code=404, detail="VLAN not found")
-    db.delete(obj)
+    soft_delete(obj, current_user.id, "api")
     db.commit()
     return {"status": "deleted"}

--- a/server/routes/ui/admin_profiles.py
+++ b/server/routes/ui/admin_profiles.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from core.utils.db_session import get_db
 from core.utils.auth import require_role
 from core.models.models import SSHCredential, SNMPCommunity
+from core.utils.deletion import soft_delete
 import os
 
 DEFAULT_SNMP_VERSION = os.environ.get("DEFAULT_SNMP_VERSION", "2c")
@@ -148,7 +149,7 @@ async def delete_ssh_credential(
     if not cred:
         raise HTTPException(status_code=404, detail="SSH credential not found")
 
-    db.delete(cred)
+    soft_delete(cred, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/admin/ssh", status_code=302)
 
@@ -162,7 +163,7 @@ async def bulk_delete_ssh(
     for cred_id in selected:
         cred = db.query(SSHCredential).filter(SSHCredential.id == cred_id).first()
         if cred:
-            db.delete(cred)
+            soft_delete(cred, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/admin/ssh", status_code=302)
 
@@ -295,7 +296,7 @@ async def delete_snmp_profile(
     if not profile:
         raise HTTPException(status_code=404, detail="SNMP profile not found")
 
-    db.delete(profile)
+    soft_delete(profile, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/admin/snmp", status_code=302)
 
@@ -309,6 +310,6 @@ async def bulk_delete_snmp(
     for profile_id in selected:
         profile = db.query(SNMPCommunity).filter(SNMPCommunity.id == profile_id).first()
         if profile:
-            db.delete(profile)
+            soft_delete(profile, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/admin/snmp", status_code=302)

--- a/server/routes/ui/device_types.py
+++ b/server/routes/ui/device_types.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from core.utils.db_session import get_db
 from core.utils.auth import require_role
 from core.models.models import DeviceType
+from core.utils.deletion import soft_delete
 import os
 import base64
 from core.utils.paths import STATIC_DIR
@@ -164,7 +165,7 @@ async def delete_device_type(
     if not dtype:
         raise HTTPException(status_code=404, detail="Device type not found")
 
-    db.delete(dtype)
+    soft_delete(dtype, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/device-types", status_code=302)
 
@@ -178,6 +179,6 @@ async def bulk_delete_device_types(
     for t_id in selected:
         dtype = db.query(DeviceType).filter(DeviceType.id == t_id).first()
         if dtype:
-            db.delete(dtype)
+            soft_delete(dtype, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/device-types", status_code=302)

--- a/server/routes/ui/locations.py
+++ b/server/routes/ui/locations.py
@@ -6,6 +6,7 @@ from core.utils.db_session import get_db
 from core.utils.auth import require_role
 from core.utils.templates import templates
 from core.models.models import Location
+from core.utils.deletion import soft_delete
 
 LOCATION_TYPES = ["Fixed", "Remote", "Mobile"]
 
@@ -107,7 +108,7 @@ async def delete_location(loc_id: int, db: Session = Depends(get_db), current_us
     loc = db.query(Location).filter(Location.id == loc_id).first()
     if not loc:
         raise HTTPException(status_code=404, detail="Location not found")
-    db.delete(loc)
+    soft_delete(loc, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/admin/locations", status_code=302)
 
@@ -116,6 +117,6 @@ async def bulk_delete_locations(selected: list[int] = Form(...), db: Session = D
     for loc_id in selected:
         loc = db.query(Location).filter(Location.id == loc_id).first()
         if loc:
-            db.delete(loc)
+            soft_delete(loc, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/admin/locations", status_code=302)

--- a/server/routes/ui/tag_manager.py
+++ b/server/routes/ui/tag_manager.py
@@ -8,6 +8,7 @@ from core.utils.auth import require_role, get_current_user
 from core.utils.templates import templates
 from core.utils.tags import add_tag_to_device, remove_tag_from_device
 from core.models.models import Tag
+from core.utils.deletion import soft_delete
 
 router = APIRouter()
 
@@ -48,7 +49,7 @@ async def rename_tag(
             if existing not in dev.tags:
                 add_tag_to_device(db, dev, existing, current_user)
             remove_tag_from_device(db, dev, tag, current_user)
-        db.delete(tag)
+        soft_delete(tag, current_user.id, "ui")
     else:
         tag.name = name
     db.commit()
@@ -72,7 +73,7 @@ async def merge_tag(
         if target not in dev.tags:
             add_tag_to_device(db, dev, target, current_user)
         remove_tag_from_device(db, dev, source, current_user)
-    db.delete(source)
+    soft_delete(source, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/admin/tags", status_code=302)
 
@@ -87,7 +88,7 @@ async def delete_tag(
     if tag:
         for dev in list(tag.devices):
             remove_tag_from_device(db, dev, tag, current_user)
-        db.delete(tag)
+        soft_delete(tag, current_user.id, "ui")
         db.commit()
     return RedirectResponse(url="/admin/tags", status_code=302)
 

--- a/server/routes/ui/user_ssh.py
+++ b/server/routes/ui/user_ssh.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 from core.utils.db_session import get_db
 from core.utils.auth import require_role
 from core.models.models import UserSSHCredential
+from core.utils.deletion import soft_delete
 from core.utils.templates import templates
 
 router = APIRouter()
@@ -106,6 +107,6 @@ async def delete_user_cred(cred_id: int, db: Session = Depends(get_db), current_
     cred = db.query(UserSSHCredential).filter(UserSSHCredential.id == cred_id, UserSSHCredential.user_id == current_user.id).first()
     if not cred:
         raise HTTPException(status_code=404, detail="Credential not found")
-    db.delete(cred)
+    soft_delete(cred, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/user/ssh", status_code=302)

--- a/server/routes/ui/vlans.py
+++ b/server/routes/ui/vlans.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 from core.utils.db_session import get_db
 from core.utils.auth import require_role
 from core.models.models import VLAN
+from core.utils.deletion import soft_delete
 
 
 
@@ -120,7 +121,7 @@ async def delete_vlan(
     if not vlan:
         raise HTTPException(status_code=404, detail="VLAN not found")
 
-    db.delete(vlan)
+    soft_delete(vlan, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/vlans", status_code=302)
 
@@ -134,6 +135,6 @@ async def bulk_delete_vlans(
     for vlan_id in selected:
         vlan = db.query(VLAN).filter(VLAN.id == vlan_id).first()
         if vlan:
-            db.delete(vlan)
+            soft_delete(vlan, current_user.id, "ui")
     db.commit()
     return RedirectResponse(url="/vlans", status_code=302)

--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -144,7 +144,7 @@ async def push_once(log: logging.Logger) -> None:
             updated_col = getattr(model_cls, "updated_at", None)
             deleted_col = getattr(model_cls, "deleted_at", None)
             sync_col = getattr(model_cls, "sync_state", None)
-            query = db.query(model_cls)
+            query = db.query(model_cls).execution_options(include_deleted=True)
 
             ts_filter = None
             if created_col is not None and updated_col is not None:

--- a/tests/test_soft_delete.py
+++ b/tests/test_soft_delete.py
@@ -1,0 +1,84 @@
+import importlib
+from datetime import datetime, timezone
+import importlib
+from datetime import datetime, timezone
+from unittest import mock
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+
+from core.utils.deletion import soft_delete
+
+
+def _load_models():
+    with mock.patch("sqlalchemy.create_engine"), mock.patch(
+        "sqlalchemy.schema.MetaData.create_all"
+    ):
+        return importlib.import_module("core.models.models")
+
+
+def test_soft_delete_device_clears_fields():
+    models = _load_models()
+    now = datetime.now(timezone.utc)
+    dev = models.Device(
+        id=1,
+        uuid=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        hostname="dev",
+        ip="1.1.1.1",
+        mac="aa",
+        asset_tag="at",
+        manufacturer="cisco",
+        device_type_id=1,
+        version=1,
+        created_at=now,
+        updated_at=now,
+    )
+    soft_delete(dev, 2, "test")
+    assert dev.deleted_at is not None
+    assert dev.is_deleted is True
+    assert dev.mac == "aa"
+    assert dev.asset_tag == "at"
+    assert dev.hostname == "dev"
+
+
+def test_query_filters_deleted():
+    models = _load_models()
+    engine = sa.create_engine("sqlite:///:memory:")
+    Session = sessionmaker(bind=engine)
+    import core.utils.database as database
+    database.Base.metadata.create_all(bind=engine)
+    db = Session()
+    now = datetime.now(timezone.utc)
+    db.add_all([
+        models.Device(
+            id=1,
+            uuid=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+            hostname="d1",
+            ip="1.1.1.1",
+            manufacturer="cisco",
+            device_type_id=1,
+            version=1,
+            created_at=now,
+            updated_at=now,
+        ),
+        models.Device(
+            id=2,
+            uuid=uuid.UUID("33333333-3333-3333-3333-333333333333"),
+            hostname="d2",
+            ip="2.2.2.2",
+            manufacturer="cisco",
+            device_type_id=1,
+            version=1,
+            created_at=now,
+            updated_at=now,
+            deleted_at=now,
+        ),
+    ])
+    db.commit()
+    # default should exclude deleted
+    res = db.query(models.Device).all()
+    assert len(res) == 1
+    # including deleted should return both
+    res_all = db.query(models.Device).execution_options(include_deleted=True).all()
+    assert len(res_all) == 2


### PR DESCRIPTION
## Summary
- add `soft_delete` helper for consistent deletion behavior
- filter deleted records automatically in `Session`
- replace hard deletes across API and UI routes
- ensure workers query deleted rows
- test soft-delete helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685557605c088324b10baed53e6d3c53