### PR TITLE
Remove demo data seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ The instructions below assume you are starting on a fresh Ubuntu system. Every c
    uvicorn server.main:app --host 0.0.0.0 --port 8000 --reload
    ```
 
-Visit [http://localhost:8000](http://localhost:8000) and log in using the superuser credentials created by `seed_superuser.py`:
+Visit [http://localhost:8000](http://localhost:8000) and log in using the default Super Admin account:
 
-- **Email:** `Barny@CESTechnologies.com`
-- **Password:** `C0pperpa!r`
+- **Email:** `admin`
+- **Password:** `12345678`
 
 ### Ubuntu Production Setup
 
@@ -117,7 +117,7 @@ sudo -u postgres psql -c "CREATE DATABASE master_ip_db OWNER masteruser;"
 
 echo "DATABASE_URL=postgresql://masteruser:masterpass@localhost:5432/master_ip_db" > .env
 
-# optionally seed
+# initialize the database
 ./init_db.sh
 
 # start the production server
@@ -302,7 +302,7 @@ adjusted from the same **Edit Profile** form.
 
 ## System Tunables
 
-The application stores various settings in the `system_tunables` table. These are seeded with default values by `seed_tunables.py` and can be adjusted from the **System Tunables** page in the web UI (admin role required).
+The application stores various settings in the `system_tunables` table. These can be adjusted from the **System Tunables** page in the web UI (admin role required).
 Superadmins can manage the connection to a cloud server from **Cloud Sync / API's** at `/admin/cloud-sync`.
 
 After installation you can configure the cloud connection from this page. Look for the following tunables under the **Sync** function:
@@ -346,7 +346,7 @@ Start the server with reasonable defaults using the provided `start.sh` script:
 ```
 
 This script loads variables from `.env` if present, applies pending Alembic migrations,
-automatically runs the seed scripts (unless `AUTO_SEED=0` or `false`), and then executes:
+creates the default Super Admin account (unless `AUTO_SEED=0` or `false`), and then executes:
 
 ```bash
 gunicorn server.main:app \
@@ -356,7 +356,7 @@ gunicorn server.main:app \
     --bind 0.0.0.0:${PORT:-8000}
 ```
 
-Set the `AUTO_SEED` environment variable to `0` or `false` to skip the automatic seeding step if the database is already populated.
+Set the `AUTO_SEED` environment variable to `0` or `false` to skip the automatic creation step if the database is already populated.
 
 Adjust `WORKERS`, `TIMEOUT` and `PORT` as needed. The server listens on
 `0.0.0.0` so it can be proxied by a web server such as Nginx.

--- a/init_db.sh
+++ b/init_db.sh
@@ -49,9 +49,7 @@ PY
 # Mark database as up-to-date with migrations
 alembic stamp head
 
-# Seed tables
-python seed_tunables.py
+# Seed default superuser account
 python seed_superuser.py
-python seed_data.py
 
 echo "Database '$DB_NAME' initialized and seeded."

--- a/seed_superuser.py
+++ b/seed_superuser.py
@@ -14,19 +14,19 @@ from core.utils.auth import get_password_hash, verify_password
 def main():
     db = SessionLocal()
     try:
-        existing = db.query(User).filter_by(email="Barny@CESTechnologies.com").first()
+        existing = db.query(User).filter_by(email="admin").first()
         if existing:
-            if not verify_password("C0pperpa!r", existing.hashed_password):
-                existing.hashed_password = get_password_hash("C0pperpa!r")
+            if not verify_password("12345678", existing.hashed_password):
+                existing.hashed_password = get_password_hash("12345678")
                 db.commit()
                 print("Superuser password updated.")
             else:
                 print("Superuser already exists.")
             return
 
-        hashed_pw = get_password_hash("C0pperpa!r")
+        hashed_pw = get_password_hash("12345678")
         user = User(
-            email="Barny@CESTechnologies.com",
+            email="admin",
             hashed_password=hashed_pw,
             role="superadmin",
             is_active=True,

--- a/server/routes/install.py
+++ b/server/routes/install.py
@@ -96,9 +96,6 @@ async def install_finish(request: Request, seed: str = Form("no")):
         "SECRET_KEY": data["secret_key"],
     })
     subprocess.run(["alembic", "upgrade", "head"], check=True, env=env)
-    subprocess.run([sys.executable, "seed_tunables.py"], check=True, env=env)
-    if seed == "yes":
-        subprocess.run([sys.executable, "seed_data.py"], check=True, env=env)
 
     import json, base64
     payload = {

--- a/start.sh
+++ b/start.sh
@@ -37,9 +37,7 @@ sleep 2
 alembic upgrade head
 
 if [ "${AUTO_SEED:-1}" != "0" ] && [ "${AUTO_SEED}" != "false" ]; then
-    python seed_tunables.py
     python seed_superuser.py
-    python seed_data.py
 fi
 
 exec gunicorn server.main:app \

--- a/web-client/templates/install/step5.html
+++ b/web-client/templates/install/step5.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
-<h1 class="text-xl mb-4">Step 5: Seed Sample Data</h1>
-<form method="post" action="/install/finish" x-data="{seed:false}" class="space-y-4">
-  <label class="inline-flex items-center"><input type="checkbox" name="seed" value="yes" x-model="seed" class="mr-2">Load sample devices</label>
+<h1 class="text-xl mb-4">Step 5: Complete Installation</h1>
+<form method="post" action="/install/finish" class="space-y-4">
   <button type="submit" class="p-2 rounded transition">Finish</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- stop seeding tunables and demo data during install/start
- keep only a default super admin account via `seed_superuser.py`
- update installer finish page
- document new default login credentials

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855878983588324b63a9d7c804752b4