### PR TITLE
Remove GUI installer routing

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -62,7 +62,6 @@ from server.routes import (
     api_vlans_router,
     api_ssh_credentials_router,
     api_system_router,
-    install_router,
 )
 from server.routes.api.sync import router as api_sync_router
 from server.routes.api.register_site import router as register_site_router
@@ -146,8 +145,10 @@ app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 
 @app.middleware("http")
 async def install_redirect(request: Request, call_next):
-    if INSTALL_REQUIRED and not request.url.path.startswith("/install") and not request.url.path.startswith("/static"):
-        return RedirectResponse("/install")
+    if INSTALL_REQUIRED and not request.url.path.startswith("/static"):
+        return templates.TemplateResponse(
+            "install_cli.html", {"request": request}, status_code=503
+        )
     return await call_next(request)
 
 
@@ -183,7 +184,6 @@ app.add_middleware(
     max_age=int(os.environ.get("SESSION_TTL", "43200")),
 )
 
-app.include_router(install_router)
 app.include_router(auth_router, prefix="/auth")
 app.include_router(devices_router)
 app.include_router(vlans_router)

--- a/server/routes/__init__.py
+++ b/server/routes/__init__.py
@@ -51,7 +51,6 @@ from .api.ssh_credentials import router as api_ssh_credentials_router
 from .api.sync import router as api_sync_router
 from .api.register_site import router as register_site_router
 from .api.system import router as api_system_router
-from .install import router as install_router
 
 __all__ = [
     "auth_router",
@@ -107,5 +106,4 @@ __all__ = [
     "api_sync_router",
     "register_site_router",
     "api_system_router",
-    "install_router",
 ]

--- a/web-client/templates/install_cli.html
+++ b/web-client/templates/install_cli.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="flex flex-col items-center justify-center text-center min-h-[60vh]">
+  <div class="bg-[var(--card-bg)] text-[var(--card-text)] p-6 rounded shadow max-w-lg">
+    <h1 class="text-2xl font-bold mb-4">Installation Required</h1>
+    <p>The web installer has been disabled. Please run the command below on the server:</p>
+    <pre class="bg-gray-800 text-white p-2 rounded mt-4">sudo python3 installer.py</pre>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- remove GUI installer routing from `server.main` and router initialization
- add middleware to display instructions for running the CLI installer
- keep existing installer module and templates but add a small page with CLI instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a13593308324acdaead2f5519964