### PR TITLE
Fix HTMX upload redirect

### DIFF
--- a/server/routes/ui/admin_images.py
+++ b/server/routes/ui/admin_images.py
@@ -206,5 +206,11 @@ async def update_images(
         db.commit()
     redirect_url = str(request.url_for("upload_image_page")) + f"?category={category}&message=Images+updated"
     if request.headers.get("HX-Request"):
-        return HTMLResponse(status_code=204, headers={"HX-Redirect": redirect_url})
+        return HTMLResponse(
+            status_code=200,
+            headers={
+                "HX-Redirect": redirect_url,
+                "HX-Refresh": "true",
+            },
+        )
     return RedirectResponse(url=redirect_url, status_code=302)

--- a/tests/test_admin_image_upload.py
+++ b/tests/test_admin_image_upload.py
@@ -61,6 +61,7 @@ def test_update_images_hx_redirect(tmp_path, monkeypatch):
         files={"icon": ("icon.png", BytesIO(b"data"), "image/png")},
         headers={"HX-Request": "true"},
     )
-    assert resp.status_code == 204
+    assert resp.status_code == 200
     assert resp.headers.get("HX-Redirect")
+    assert resp.headers.get("HX-Refresh") == "true"
     assert db.committed


### PR DESCRIPTION
## Summary
- return HX-Refresh header for uploaded images and adjust test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855d017811483249a0a3653959726f1