### PR TITLE
Fix bulk actions in tables

### DIFF
--- a/web-client/static/js/table.js
+++ b/web-client/static/js/table.js
@@ -37,8 +37,18 @@ function tableControls() {
         if (state) this.selectedIds.push(cb.value)
       })
     },
-    bulkDelete() { this.$el.action = this.$el.dataset.bulkDeleteUrl; this.$el.submit() },
-    bulkUpdate() { this.$el.action = this.$el.dataset.bulkUpdateUrl; this.$el.submit() },
+    bulkDelete() {
+      if (this.$el.dataset.bulkDeleteUrl) {
+        this.$el.action = this.$el.dataset.bulkDeleteUrl
+      }
+      this.$el.submit()
+    },
+    bulkUpdate() {
+      if (this.$el.dataset.bulkUpdateUrl) {
+        this.$el.action = this.$el.dataset.bulkUpdateUrl
+      }
+      this.$el.submit()
+    },
     sort(idx) {
       if (this.sortIndex === idx) {
         if (this.sortAsc) {


### PR DESCRIPTION
## Summary
- ensure bulkDelete/bulkUpdate keep existing action when dataset URLs are missing
- add missing dependencies during tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566f928ebc8324b0006977ffad030d