### PR TITLE
Fix base export names

### DIFF
--- a/base/__init__.py
+++ b/base/__init__.py
@@ -1,6 +1,17 @@
+"""Expose core routers and constants used across the application."""
+
 from server.routes.ui.auth import router as auth_router
+from server.routes.ui.user_pages import router as user_pages_router
+from server.routes.ui.welcome import (
+    router as dashboard_router,
+    WELCOME_TEXT,
+    INVENTORY_TEXT,
+)
 
-from server.routes.ui.user_pages import router as user_router
-from server.routes.ui.welcome import router as dashboard_router
-
-__all__ = ["auth_router", "user_router", "dashboard_router"]
+__all__ = [
+    "auth_router",
+    "user_pages_router",
+    "dashboard_router",
+    "WELCOME_TEXT",
+    "INVENTORY_TEXT",
+]

--- a/modules/inventory/__init__.py
+++ b/modules/inventory/__init__.py
@@ -1,3 +1,5 @@
+"""Inventory module exports."""
+
 from server.routes.ui.inventory import router as inventory_router
 
 __all__ = ["inventory_router"]

--- a/modules/network/__init__.py
+++ b/modules/network/__init__.py
@@ -1,3 +1,5 @@
+"""Network module exports."""
+
 from server.routes.ui.network import router as network_router
 
 __all__ = ["network_router"]


### PR DESCRIPTION
## Summary
- export user_pages_router and welcome constants from `base`
- add docstrings to inventory and network modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68568c05349c832492d0d431fbdccecd