### PR TITLE
Fix imports after model move

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Tailwind CSS has been removed from the project. Styling and components now rely 
 
 ## Repository Layout
 
-- `core/` contains database models, authentication helpers and common utilities.
+- `core/` contains shared models, authentication helpers and common utilities.
+- `modules/inventory/` defines device and location models.
+- `modules/network/` defines VLAN, interface and other network models.
 - `server/` holds the FastAPI application, API routes and background workers.
 - `web-client/` stores HTML templates and static assets served by the app.
 - `mobile-client/` is a placeholder for a future mobile application.

--- a/base/routes/welcome.py
+++ b/base/routes/welcome.py
@@ -8,15 +8,14 @@ from core.utils.auth import get_current_user, get_user_site_ids
 from core.utils.db_session import get_db
 from core.models.models import (
     LoginEvent,
-    Device,
-    DeviceType,
     ConfigBackup,
-    PortStatusHistory,
     SNMPTrapLog,
     SyslogEntry,
     Site,
     DashboardWidget,
 )
+from modules.inventory.models import Device, DeviceType
+from modules.network.models import PortStatusHistory
 from core.utils.dashboard import (
     load_widget_preferences,
     DEFAULT_WIDGETS,

--- a/server/routes/ui/task_views.py
+++ b/server/routes/ui/task_views.py
@@ -8,15 +8,10 @@ from fastapi import UploadFile, File, Form
 from core.utils.auth import get_current_user, require_role
 from core.models.models import (
     ConfigBackup,
-    Device,
-    VLAN,
-    DeviceType,
-    SSHCredential,
-    SNMPCommunity,
-    PortConfigTemplate,
     SystemTunable,
-    Tag,
 )
+from modules.inventory.models import Device, DeviceType, Tag
+from modules.network.models import VLAN, SSHCredential, SNMPCommunity, PortConfigTemplate
 import csv
 import io
 import urllib.parse


### PR DESCRIPTION
## Summary
- update welcome route imports for device models from modules
- update task view imports for module-specific models
- clarify README layout to mention module model locations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856d010a1408324adab0054daf59de0