### PR TITLE
Modularize inventory utilities

### DIFF
--- a/modules/inventory/utils.py
+++ b/modules/inventory/utils.py
@@ -1,0 +1,98 @@
+# Utility functions for inventory-related views
+from sqlalchemy.orm import Session
+from modules.inventory.models import DeviceType, Device, Location
+from modules.network.models import VLAN, SSHCredential, SNMPCommunity
+from core.models.models import Site
+from core.utils.ip_utils import normalize_ip
+from core.utils.mac_utils import normalize_mac, MAC_RE
+
+__all__ = [
+    "format_ip",
+    "format_mac",
+    "suggest_vlan_from_ip",
+    "load_form_options",
+    "create_device_from_row",
+]
+
+
+def format_ip(ip: str) -> str:
+    """Normalize an IP address."""
+    return normalize_ip(ip)
+
+
+def format_mac(mac: str | None) -> str | None:
+    """Normalize a MAC address if provided."""
+    return normalize_mac(mac) if mac else None
+
+
+def suggest_vlan_from_ip(db: Session, ip: str):
+    """Return VLAN suggestion based on the IP's second octet."""
+    try:
+        second_octet = int(ip.split(".")[1])
+    except (IndexError, ValueError):
+        return None, None
+
+    if second_octet == 100:
+        # Special case mapping
+        return 1, None
+    if second_octet == 101:
+        # Label for CAPWAP networks
+        return None, "CAPWAP"
+
+    vlan = db.query(VLAN).filter(VLAN.tag == second_octet).first()
+    if vlan:
+        return vlan.id, vlan.description
+    return None, None
+
+
+def load_form_options(db: Session):
+    """Helper to load dropdown options for device forms."""
+    device_types = db.query(DeviceType).all()
+    vlans = db.query(VLAN).all()
+    ssh_credentials = db.query(SSHCredential).all()
+    snmp_communities = db.query(SNMPCommunity).all()
+    locations = db.query(Location).all()
+    sites = db.query(Site).all()
+    models = [m[0] for m in db.query(Device.model).filter(Device.model.is_not(None)).distinct()]
+    return (
+        device_types,
+        vlans,
+        ssh_credentials,
+        snmp_communities,
+        locations,
+        models,
+        sites,
+    )
+
+
+def create_device_from_row(db: Session, row: dict, user) -> None:
+    """Create a Device from a CSV/Google Sheets row."""
+    hostname = row.get("hostname", "").strip()
+    ip = row.get("ip", "").strip()
+    manufacturer = row.get("manufacturer", "").strip()
+    dtype_name = row.get("device_type")
+    if not hostname or not ip or not manufacturer or not dtype_name:
+        raise ValueError("Missing required fields")
+    dtype = db.query(DeviceType).filter(DeviceType.name.ilike(dtype_name.strip())).first()
+    if not dtype:
+        raise ValueError(f"Unknown device type {dtype_name}")
+    location = None
+    if row.get("location"):
+        location = db.query(Location).filter(Location.name.ilike(row["location"].strip())).first()
+    try:
+        norm_ip = format_ip(ip)
+    except ValueError:
+        raise ValueError(f"Invalid IP address {ip}")
+    device = Device(
+        hostname=hostname,
+        ip=norm_ip,
+        mac=row.get("mac") or None,
+        asset_tag=row.get("asset_tag") or None,
+        model=row.get("model") or None,
+        serial_number=row.get("serial_number") or None,
+        manufacturer=manufacturer,
+        device_type_id=dtype.id,
+        location_id=location.id if location else None,
+        created_by_id=user.id,
+    )
+    db.add(device)

--- a/server/routes/api/legacy.py
+++ b/server/routes/api/legacy.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 
 from core.utils.db_session import get_db
 from core.utils.auth import get_current_user
-from server.routes.ui.devices import suggest_vlan_from_ip
+from modules.inventory.utils import suggest_vlan_from_ip
 from modules.network.models import VLAN
 from core.models.models import TablePreference
 import json

--- a/server/routes/ui/bulk.py
+++ b/server/routes/ui/bulk.py
@@ -21,7 +21,7 @@ from core.utils.device_detect import detect_ssh_platform
 from core.utils.templates import templates
 from core.utils.audit import log_audit
 from core.utils.tags import get_or_create_tag, add_tag_to_device
-from server.routes.ui.devices import _format_ip
+from modules.inventory.utils import format_ip
 
 router = APIRouter(prefix="/bulk")
 
@@ -279,7 +279,7 @@ async def device_import_wizard(
                 errors.append(f"Missing required fields in row {row}")
                 continue
             try:
-                ip = _format_ip(ip)
+                ip = format_ip(ip)
             except ValueError:
                 errors.append(f"Invalid IP address {ip} in row {row}")
                 continue


### PR DESCRIPTION
## Summary
- centralize inventory helper functions in `modules/inventory/utils.py`
- import new utilities in devices, bulk and add_device routes
- update legacy API to reference new utility module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856dcc563a8832493738ba5caa10932