### PR TITLE
Modularize inventory and network forms

### DIFF
--- a/core/schemas.py
+++ b/core/schemas.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field, ConfigDict, field_validator
-from core.utils.ip_utils import normalize_ip
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class ConflictEntry(BaseModel):
@@ -33,106 +32,6 @@ class ColumnSelection(BaseModel):
     selected: list[str] = []
 
 
-class VLANBase(BaseSchema):
-    tag: int
-    description: str | None = None
-
-
-class VLANCreate(BaseModel):
-    tag: int
-    description: str | None = None
-    version: int = Field(1, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
-
-
-class VLANRead(VLANBase):
-    id: int
-
-    model_config = ConfigDict(from_attributes=True)
-
-
-class VLANUpdate(BaseModel):
-    tag: int | None = None
-    description: str | None = None
-    version: int | None = Field(None, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
-
-
-class DeviceBase(BaseSchema):
-    hostname: str
-    ip: str
-    vlan_id: int | None = None
-    manufacturer: str | None = None
-    model: str | None = None
-
-
-class DeviceCreate(BaseModel):
-    hostname: str
-    ip: str
-    vlan_id: int | None = None
-    manufacturer: str | None = None
-    model: str | None = None
-    version: int = Field(1, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
-
-    @field_validator("ip")
-    @classmethod
-    def _validate_ip(cls, v: str) -> str:
-        return normalize_ip(v)
-
-
-class DeviceRead(DeviceBase):
-    id: int
-
-    model_config = ConfigDict(from_attributes=True)
-
-
-class DeviceUpdate(BaseModel):
-    hostname: str | None = None
-    ip: str | None = None
-    vlan_id: int | None = None
-    manufacturer: str | None = None
-    model: str | None = None
-    version: int | None = Field(None, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
-
-    @field_validator("ip")
-    @classmethod
-    def _validate_ip(cls, v: str | None) -> str | None:
-        if v is None:
-            return None
-        return normalize_ip(v)
-
-
-class SSHCredentialBase(BaseSchema):
-    name: str
-    username: str
-    password: str | None = None
-    private_key: str | None = None
-
-
-class SSHCredentialCreate(BaseModel):
-    name: str
-    username: str
-    password: str | None = None
-    private_key: str | None = None
-    version: int = Field(1, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
-
-
-class SSHCredentialRead(SSHCredentialBase):
-    id: int
-
-    model_config = ConfigDict(from_attributes=True)
-
-
-class SSHCredentialUpdate(BaseModel):
-    name: str | None = None
-    username: str | None = None
-    password: str | None = None
-    private_key: str | None = None
-    version: int | None = Field(None, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
 
 
 class UserBase(BaseSchema):
@@ -187,57 +86,6 @@ class TagUpdate(BaseModel):
     conflict_data: list[ConflictEntry] | None = None
 
 
-class DeviceTypeBase(BaseSchema):
-    name: str
-    upload_icon: str | None = None
-    upload_image: str | None = None
-
-
-class DeviceTypeCreate(BaseModel):
-    name: str
-    version: int = Field(1, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
-    upload_icon: str | None = None
-    upload_image: str | None = None
-
-
-class DeviceTypeRead(DeviceTypeBase):
-    id: int
-
-    model_config = ConfigDict(from_attributes=True)
-
-
-class DeviceTypeUpdate(BaseModel):
-    name: str | None = None
-    version: int | None = Field(None, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
-    upload_icon: str | None = None
-    upload_image: str | None = None
-
-
-class LocationBase(BaseSchema):
-    name: str
-    location_type: str = "Fixed"
-
-
-class LocationCreate(BaseModel):
-    name: str
-    location_type: str = "Fixed"
-    version: int = Field(1, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
-
-
-class LocationRead(LocationBase):
-    id: int
-
-    model_config = ConfigDict(from_attributes=True)
-
-
-class LocationUpdate(BaseModel):
-    name: str | None = None
-    location_type: str | None = None
-    version: int | None = Field(None, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
 
 
 class SiteBase(BaseSchema):

--- a/modules/inventory/__init__.py
+++ b/modules/inventory/__init__.py
@@ -1,4 +1,6 @@
 """Inventory module exports."""
 
 # Router is defined in modules.inventory.routes
-__all__ = []
+from . import forms, utils
+
+__all__ = ["forms", "utils"]

--- a/modules/inventory/forms.py
+++ b/modules/inventory/forms.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, ConfigDict, field_validator
+from core.schemas import BaseSchema, ConflictEntry
+from core.utils.ip_utils import normalize_ip
+
+__all__ = [
+    "DeviceBase",
+    "DeviceCreate",
+    "DeviceRead",
+    "DeviceUpdate",
+    "DeviceTypeBase",
+    "DeviceTypeCreate",
+    "DeviceTypeRead",
+    "DeviceTypeUpdate",
+    "LocationBase",
+    "LocationCreate",
+    "LocationRead",
+    "LocationUpdate",
+]
+
+
+class DeviceBase(BaseSchema):
+    hostname: str
+    ip: str
+    vlan_id: int | None = None
+    manufacturer: str | None = None
+    model: str | None = None
+
+
+class DeviceCreate(BaseModel):
+    hostname: str
+    ip: str
+    vlan_id: int | None = None
+    manufacturer: str | None = None
+    model: str | None = None
+    version: int = Field(1, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+
+    @field_validator("ip")
+    @classmethod
+    def _validate_ip(cls, v: str) -> str:
+        return normalize_ip(v)
+
+
+class DeviceRead(DeviceBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DeviceUpdate(BaseModel):
+    hostname: str | None = None
+    ip: str | None = None
+    vlan_id: int | None = None
+    manufacturer: str | None = None
+    model: str | None = None
+    version: int | None = Field(None, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+
+    @field_validator("ip")
+    @classmethod
+    def _validate_ip(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return normalize_ip(v)
+
+
+class DeviceTypeBase(BaseSchema):
+    name: str
+    upload_icon: str | None = None
+    upload_image: str | None = None
+
+
+class DeviceTypeCreate(BaseModel):
+    name: str
+    version: int = Field(1, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+    upload_icon: str | None = None
+    upload_image: str | None = None
+
+
+class DeviceTypeRead(DeviceTypeBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DeviceTypeUpdate(BaseModel):
+    name: str | None = None
+    version: int | None = Field(None, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+    upload_icon: str | None = None
+    upload_image: str | None = None
+
+
+class LocationBase(BaseSchema):
+    name: str
+    location_type: str = "Fixed"
+
+
+class LocationCreate(BaseModel):
+    name: str
+    location_type: str = "Fixed"
+    version: int = Field(1, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+
+
+class LocationRead(LocationBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LocationUpdate(BaseModel):
+    name: str | None = None
+    location_type: str | None = None
+    version: int | None = Field(None, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+

--- a/modules/inventory/utils.py
+++ b/modules/inventory/utils.py
@@ -1,0 +1,98 @@
+# Utility functions for inventory-related views
+from sqlalchemy.orm import Session
+from modules.inventory.models import DeviceType, Device, Location
+from modules.network.models import VLAN, SSHCredential, SNMPCommunity
+from core.models.models import Site
+from core.utils.ip_utils import normalize_ip
+from core.utils.mac_utils import normalize_mac, MAC_RE
+
+__all__ = [
+    "format_ip",
+    "format_mac",
+    "suggest_vlan_from_ip",
+    "load_form_options",
+    "create_device_from_row",
+]
+
+
+def format_ip(ip: str) -> str:
+    """Normalize an IP address."""
+    return normalize_ip(ip)
+
+
+def format_mac(mac: str | None) -> str | None:
+    """Normalize a MAC address if provided."""
+    return normalize_mac(mac) if mac else None
+
+
+def suggest_vlan_from_ip(db: Session, ip: str):
+    """Return VLAN suggestion based on the IP's second octet."""
+    try:
+        second_octet = int(ip.split(".")[1])
+    except (IndexError, ValueError):
+        return None, None
+
+    if second_octet == 100:
+        # Special case mapping
+        return 1, None
+    if second_octet == 101:
+        # Label for CAPWAP networks
+        return None, "CAPWAP"
+
+    vlan = db.query(VLAN).filter(VLAN.tag == second_octet).first()
+    if vlan:
+        return vlan.id, vlan.description
+    return None, None
+
+
+def load_form_options(db: Session):
+    """Helper to load dropdown options for device forms."""
+    device_types = db.query(DeviceType).all()
+    vlans = db.query(VLAN).all()
+    ssh_credentials = db.query(SSHCredential).all()
+    snmp_communities = db.query(SNMPCommunity).all()
+    locations = db.query(Location).all()
+    sites = db.query(Site).all()
+    models = [m[0] for m in db.query(Device.model).filter(Device.model.is_not(None)).distinct()]
+    return (
+        device_types,
+        vlans,
+        ssh_credentials,
+        snmp_communities,
+        locations,
+        models,
+        sites,
+    )
+
+
+def create_device_from_row(db: Session, row: dict, user) -> None:
+    """Create a Device from a CSV/Google Sheets row."""
+    hostname = row.get("hostname", "").strip()
+    ip = row.get("ip", "").strip()
+    manufacturer = row.get("manufacturer", "").strip()
+    dtype_name = row.get("device_type")
+    if not hostname or not ip or not manufacturer or not dtype_name:
+        raise ValueError("Missing required fields")
+    dtype = db.query(DeviceType).filter(DeviceType.name.ilike(dtype_name.strip())).first()
+    if not dtype:
+        raise ValueError(f"Unknown device type {dtype_name}")
+    location = None
+    if row.get("location"):
+        location = db.query(Location).filter(Location.name.ilike(row["location"].strip())).first()
+    try:
+        norm_ip = format_ip(ip)
+    except ValueError:
+        raise ValueError(f"Invalid IP address {ip}")
+    device = Device(
+        hostname=hostname,
+        ip=norm_ip,
+        mac=row.get("mac") or None,
+        asset_tag=row.get("asset_tag") or None,
+        model=row.get("model") or None,
+        serial_number=row.get("serial_number") or None,
+        manufacturer=manufacturer,
+        device_type_id=dtype.id,
+        location_id=location.id if location else None,
+        created_by_id=user.id,
+    )
+    db.add(device)

--- a/modules/network/__init__.py
+++ b/modules/network/__init__.py
@@ -1,4 +1,6 @@
 """Network module exports."""
 
 # Router is defined in modules.network.routes
-__all__ = []
+from . import forms
+
+__all__ = ["forms"]

--- a/modules/network/forms.py
+++ b/modules/network/forms.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, ConfigDict
+from core.schemas import BaseSchema, ConflictEntry
+
+__all__ = [
+    "VLANBase",
+    "VLANCreate",
+    "VLANRead",
+    "VLANUpdate",
+    "SSHCredentialBase",
+    "SSHCredentialCreate",
+    "SSHCredentialRead",
+    "SSHCredentialUpdate",
+]
+
+
+class VLANBase(BaseSchema):
+    tag: int
+    description: str | None = None
+
+
+class VLANCreate(BaseModel):
+    tag: int
+    description: str | None = None
+    version: int = Field(1, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+
+
+class VLANRead(VLANBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class VLANUpdate(BaseModel):
+    tag: int | None = None
+    description: str | None = None
+    version: int | None = Field(None, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+
+
+class SSHCredentialBase(BaseSchema):
+    name: str
+    username: str
+    password: str | None = None
+    private_key: str | None = None
+
+
+class SSHCredentialCreate(BaseModel):
+    name: str
+    username: str
+    password: str | None = None
+    private_key: str | None = None
+    version: int = Field(1, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+
+
+class SSHCredentialRead(SSHCredentialBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SSHCredentialUpdate(BaseModel):
+    name: str | None = None
+    username: str | None = None
+    password: str | None = None
+    private_key: str | None = None
+    version: int | None = Field(None, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+

--- a/server/routes/api/devices.py
+++ b/server/routes/api/devices.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 
 from core.utils.db_session import get_db
 from modules.inventory.models import Device
-from core import schemas
+from modules.inventory import forms as inventory_forms
 from core.utils.versioning import apply_update
 from core.utils import auth as auth_utils
 from core.utils.deletion import soft_delete
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 
 router = APIRouter(prefix="/api/v1/devices", tags=["devices"])
 
-@router.get("/", response_model=list[schemas.DeviceRead])
+@router.get("/", response_model=list[inventory_forms.DeviceRead])
 def list_devices(
     skip: int = 0,
     limit: int = 100,
@@ -25,9 +25,9 @@ def list_devices(
     devices = q.offset(skip).limit(limit).all()
     return [d for d in devices if not getattr(d, "is_deleted", False)]
 
-@router.post("/", response_model=schemas.DeviceRead)
+@router.post("/", response_model=inventory_forms.DeviceRead)
 def create_device(
-    device: schemas.DeviceCreate,
+    device: inventory_forms.DeviceCreate,
     db: Session = Depends(get_db),
     current_user: Device = Depends(auth_utils.require_role("editor")),
 ):
@@ -38,7 +38,7 @@ def create_device(
     db.refresh(obj)
     return obj
 
-@router.get("/{device_id}", response_model=schemas.DeviceRead)
+@router.get("/{device_id}", response_model=inventory_forms.DeviceRead)
 def get_device(
     device_id: int,
     db: Session = Depends(get_db),
@@ -49,10 +49,10 @@ def get_device(
         raise HTTPException(status_code=404, detail="Device not found")
     return obj
 
-@router.put("/{device_id}", response_model=schemas.DeviceRead)
+@router.put("/{device_id}", response_model=inventory_forms.DeviceRead)
 def update_device(
     device_id: int,
-    update: schemas.DeviceUpdate,
+    update: inventory_forms.DeviceUpdate,
     db: Session = Depends(get_db),
     current_user: Device = Depends(auth_utils.require_role("editor")),
 ):

--- a/server/routes/api/legacy.py
+++ b/server/routes/api/legacy.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 
 from core.utils.db_session import get_db
 from core.utils.auth import get_current_user
-from server.routes.ui.devices import suggest_vlan_from_ip
+from modules.inventory.utils import suggest_vlan_from_ip
 from modules.network.models import VLAN
 from core.models.models import TablePreference
 import json

--- a/server/routes/api/ssh_credentials.py
+++ b/server/routes/api/ssh_credentials.py
@@ -3,14 +3,14 @@ from sqlalchemy.orm import Session
 
 from core.utils.db_session import get_db
 from modules.network.models import SSHCredential
-from core import schemas
+from modules.network import forms as network_forms
 from core.utils.versioning import apply_update
 from core.utils import auth as auth_utils
 from core.utils.deletion import soft_delete
 
 router = APIRouter(prefix="/api/v1/ssh-credentials", tags=["ssh_credentials"])
 
-@router.get("/", response_model=list[schemas.SSHCredentialRead])
+@router.get("/", response_model=list[network_forms.SSHCredentialRead])
 def list_creds(
     skip: int = 0,
     limit: int = 100,
@@ -23,9 +23,9 @@ def list_creds(
         q = q.filter(SSHCredential.name.ilike(f"%{search}%"))
     return q.offset(skip).limit(limit).all()
 
-@router.post("/", response_model=schemas.SSHCredentialRead)
+@router.post("/", response_model=network_forms.SSHCredentialRead)
 def create_cred(
-    cred: schemas.SSHCredentialCreate,
+    cred: network_forms.SSHCredentialCreate,
     db: Session = Depends(get_db),
     current_user: SSHCredential = Depends(auth_utils.require_role("admin")),
 ):
@@ -36,7 +36,7 @@ def create_cred(
     db.refresh(obj)
     return obj
 
-@router.get("/{cred_id}", response_model=schemas.SSHCredentialRead)
+@router.get("/{cred_id}", response_model=network_forms.SSHCredentialRead)
 def get_cred(
     cred_id: int,
     db: Session = Depends(get_db),
@@ -47,10 +47,10 @@ def get_cred(
         raise HTTPException(status_code=404, detail="Credential not found")
     return obj
 
-@router.put("/{cred_id}", response_model=schemas.SSHCredentialRead)
+@router.put("/{cred_id}", response_model=network_forms.SSHCredentialRead)
 def update_cred(
     cred_id: int,
-    update: schemas.SSHCredentialUpdate,
+    update: network_forms.SSHCredentialUpdate,
     db: Session = Depends(get_db),
     current_user: SSHCredential = Depends(auth_utils.require_role("admin")),
 ):

--- a/server/routes/api/vlans.py
+++ b/server/routes/api/vlans.py
@@ -3,14 +3,14 @@ from sqlalchemy.orm import Session
 
 from core.utils.db_session import get_db
 from modules.network.models import VLAN
-from core import schemas
+from modules.network import forms as network_forms
 from core.utils.versioning import apply_update
 from core.utils import auth as auth_utils
 from core.utils.deletion import soft_delete
 
 router = APIRouter(prefix="/api/v1/vlans", tags=["vlans"])
 
-@router.get("/", response_model=list[schemas.VLANRead])
+@router.get("/", response_model=list[network_forms.VLANRead])
 def list_vlans(
     skip: int = 0,
     limit: int = 100,
@@ -23,9 +23,9 @@ def list_vlans(
         q = q.filter(VLAN.description.ilike(f"%{search}%"))
     return q.offset(skip).limit(limit).all()
 
-@router.post("/", response_model=schemas.VLANRead)
+@router.post("/", response_model=network_forms.VLANRead)
 def create_vlan(
-    vlan: schemas.VLANCreate,
+    vlan: network_forms.VLANCreate,
     db: Session = Depends(get_db),
     current_user: VLAN = Depends(auth_utils.require_role("editor")),
 ):
@@ -36,7 +36,7 @@ def create_vlan(
     db.refresh(obj)
     return obj
 
-@router.get("/{vlan_id}", response_model=schemas.VLANRead)
+@router.get("/{vlan_id}", response_model=network_forms.VLANRead)
 def get_vlan(
     vlan_id: int,
     db: Session = Depends(get_db),
@@ -47,10 +47,10 @@ def get_vlan(
         raise HTTPException(status_code=404, detail="VLAN not found")
     return obj
 
-@router.put("/{vlan_id}", response_model=schemas.VLANRead)
+@router.put("/{vlan_id}", response_model=network_forms.VLANRead)
 def update_vlan(
     vlan_id: int,
-    update: schemas.VLANUpdate,
+    update: network_forms.VLANUpdate,
     db: Session = Depends(get_db),
     current_user: VLAN = Depends(auth_utils.require_role("editor")),
 ):

--- a/server/routes/ui/bulk.py
+++ b/server/routes/ui/bulk.py
@@ -21,7 +21,7 @@ from core.utils.device_detect import detect_ssh_platform
 from core.utils.templates import templates
 from core.utils.audit import log_audit
 from core.utils.tags import get_or_create_tag, add_tag_to_device
-from server.routes.ui.devices import _format_ip
+from modules.inventory.utils import format_ip
 
 router = APIRouter(prefix="/bulk")
 
@@ -279,7 +279,7 @@ async def device_import_wizard(
                 errors.append(f"Missing required fields in row {row}")
                 continue
             try:
-                ip = _format_ip(ip)
+                ip = format_ip(ip)
             except ValueError:
                 errors.append(f"Invalid IP address {ip} in row {row}")
                 continue


### PR DESCRIPTION
## Summary
- create `modules/inventory/forms.py` with Device and Location schemas
- create `modules/network/forms.py` with VLAN and SSH credential schemas
- export forms via each module's `__init__`
- update API routes to import the new form modules
- remove moved schemas from `core/schemas.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856dcc563a8832493738ba5caa10932