### PR TITLE
Modularize inventory utilities and forms

### DIFF
--- a/core/schemas.py
+++ b/core/schemas.py
@@ -64,27 +64,6 @@ class UserUpdate(BaseModel):
     conflict_data: list[ConflictEntry] | None = None
 
 
-class TagBase(BaseSchema):
-    name: str
-
-
-class TagCreate(BaseModel):
-    name: str
-    version: int = Field(1, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
-
-
-class TagRead(TagBase):
-    id: int
-
-    model_config = ConfigDict(from_attributes=True)
-
-
-class TagUpdate(BaseModel):
-    name: str | None = None
-    version: int | None = Field(None, ge=1)
-    conflict_data: list[ConflictEntry] | None = None
-
 
 
 

--- a/core/utils/templates.py
+++ b/core/utils/templates.py
@@ -1,6 +1,6 @@
 from fastapi.templating import Jinja2Templates
 from core.utils.db_session import SessionLocal
-from modules.inventory.models import DeviceType, Tag
+from modules.inventory.utils import get_device_types, get_tags
 from core.models.models import SystemTunable
 from datetime import datetime, timedelta
 from jinja2 import Environment, ChoiceLoader, FileSystemLoader
@@ -34,27 +34,12 @@ def format_uptime(seconds: int | None) -> str:
     return " ".join(parts)
 
 
-def get_device_types():
-    db = SessionLocal()
-    types = db.query(DeviceType).all()
-    db.close()
-    return types
-
-# Make function available in Jinja templates
-templates.env.globals["get_device_types"] = get_device_types
 templates.env.filters["format_uptime"] = format_uptime
 from core.utils.ip_utils import display_ip
 from core.utils.mac_utils import display_mac
 templates.env.filters["display_ip"] = display_ip
 templates.env.filters["display_mac"] = display_mac
-
-
-def get_tags():
-    db = SessionLocal()
-    tags = db.query(Tag).order_by(Tag.name).all()
-    db.close()
-    return tags
-
+templates.env.globals["get_device_types"] = get_device_types
 templates.env.globals["get_tags"] = get_tags
 
 import os

--- a/modules/inventory/forms.py
+++ b/modules/inventory/forms.py
@@ -17,6 +17,10 @@ __all__ = [
     "LocationCreate",
     "LocationRead",
     "LocationUpdate",
+    "TagBase",
+    "TagCreate",
+    "TagRead",
+    "TagUpdate",
 ]
 
 
@@ -115,6 +119,28 @@ class LocationRead(LocationBase):
 class LocationUpdate(BaseModel):
     name: str | None = None
     location_type: str | None = None
+    version: int | None = Field(None, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+
+
+class TagBase(BaseSchema):
+    name: str
+
+
+class TagCreate(BaseModel):
+    name: str
+    version: int = Field(1, ge=1)
+    conflict_data: list[ConflictEntry] | None = None
+
+
+class TagRead(TagBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TagUpdate(BaseModel):
+    name: str | None = None
     version: int | None = Field(None, ge=1)
     conflict_data: list[ConflictEntry] | None = None
 

--- a/modules/inventory/utils.py
+++ b/modules/inventory/utils.py
@@ -1,10 +1,11 @@
 # Utility functions for inventory-related views
 from sqlalchemy.orm import Session
-from modules.inventory.models import DeviceType, Device, Location
+from modules.inventory.models import DeviceType, Device, Location, Tag
 from modules.network.models import VLAN, SSHCredential, SNMPCommunity
 from core.models.models import Site
 from core.utils.ip_utils import normalize_ip
-from core.utils.mac_utils import normalize_mac, MAC_RE
+from core.utils.mac_utils import normalize_mac
+from core.utils.db_session import SessionLocal
 
 __all__ = [
     "format_ip",
@@ -12,6 +13,8 @@ __all__ = [
     "suggest_vlan_from_ip",
     "load_form_options",
     "create_device_from_row",
+    "get_device_types",
+    "get_tags",
 ]
 
 
@@ -96,3 +99,19 @@ def create_device_from_row(db: Session, row: dict, user) -> None:
         created_by_id=user.id,
     )
     db.add(device)
+
+
+def get_device_types():
+    """Return all device types."""
+    db = SessionLocal()
+    types = db.query(DeviceType).all()
+    db.close()
+    return types
+
+
+def get_tags():
+    """Return all tags ordered by name."""
+    db = SessionLocal()
+    tags = db.query(Tag).order_by(Tag.name).all()
+    db.close()
+    return tags


### PR DESCRIPTION
## Summary
- move tag forms from core schemas to inventory module
- move inventory-specific helper functions into `modules.inventory.utils`
- expose inventory utilities and forms in `__all__`
- remove unused imports
- restore necessary import for template utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856e339fdc0832488878118a2f597c4