### PR TITLE
Fix script path resolution for CLI tools

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,4 +1,5 @@
-import os
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + '/../'))
 from dotenv import load_dotenv
 load_dotenv()
 from alembic import context

--- a/installer.py
+++ b/installer.py
@@ -1,4 +1,5 @@
-import os
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + '/../'))
 import subprocess
 from pathlib import Path
 

--- a/seed_data.py
+++ b/seed_data.py
@@ -1,3 +1,5 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + '/../'))
 from core.utils.db_session import SessionLocal, reset_pk_sequence
 import subprocess
 

--- a/seed_superuser.py
+++ b/seed_superuser.py
@@ -1,3 +1,5 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + '/../'))
 from core.utils.db_session import SessionLocal, reset_pk_sequence
 from core.models.models import User, Site, SiteMembership
 import subprocess

--- a/seed_tunables.py
+++ b/seed_tunables.py
@@ -1,3 +1,5 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + '/../'))
 from core.utils.db_session import SessionLocal
 from core.models.models import SystemTunable
 import subprocess

--- a/setup_cloud_connection.py
+++ b/setup_cloud_connection.py
@@ -1,5 +1,6 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + '/../'))
 import asyncio
-import sys
 import httpx
 
 from core.utils.env_file import set_env_vars


### PR DESCRIPTION
## Summary
- resolve pathing for CLI scripts to support modular imports
- enable env configuration in Alembic and seed/setup scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f467d30083249e9eaf76b8c8e016