### PR TITLE
Ensure inventory models loaded for cloud sync

### DIFF
--- a/server/utils/sync_conflicts.py
+++ b/server/utils/sync_conflicts.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import or_
 
 from modules.inventory.models import Device
+from modules.inventory import models as inventory_models  # noqa: F401
 from core.utils.versioning import clear_conflicts
 from core.utils.audit import log_audit
 from server.workers import sync_push_worker

--- a/server/workers/cloud_sync.py
+++ b/server/workers/cloud_sync.py
@@ -9,6 +9,7 @@ import httpx
 
 from core.utils.db_session import SessionLocal
 from modules.inventory.models import Device
+from modules.inventory import models as inventory_models  # noqa: F401
 from core.models.models import SystemTunable
 
 SYNC_INTERVAL = int(os.environ.get("SYNC_FREQUENCY", "300"))

--- a/server/workers/sync_pull_worker.py
+++ b/server/workers/sync_pull_worker.py
@@ -12,6 +12,7 @@ from core.utils.db_session import SessionLocal
 from modules.inventory.models import DeviceEditLog, Device
 from core.models.models import SystemTunable
 from core.models import models as model_module
+from modules.inventory import models as inventory_models  # noqa: F401
 from core.utils.versioning import apply_update
 from .cloud_sync import _get_sync_config, ensure_schema
 from core.utils.audit import log_audit

--- a/server/workers/sync_push_worker.py
+++ b/server/workers/sync_push_worker.py
@@ -14,6 +14,7 @@ from core.utils.db_session import SessionLocal
 from sqlalchemy import event
 from core.models.models import SystemTunable
 from core.models import models as model_module
+from modules.inventory import models as inventory_models  # noqa: F401
 from .cloud_sync import _request_with_retry, _get_sync_config, ensure_schema
 from core.utils.audit import log_audit
 from core.utils.sync_logging import log_sync_attempt

--- a/tests/test_inventory_sync_models.py
+++ b/tests/test_inventory_sync_models.py
@@ -1,0 +1,25 @@
+import importlib
+from core.models import models as model_module
+
+
+def get_model_names():
+    return {cls.__tablename__ for cls in model_module.Base.__subclasses__()}
+
+
+def test_workers_import_inventory_models():
+    inv = importlib.import_module("modules.inventory.models")
+    # Reload workers to trigger imports
+    import server.workers.sync_push_worker as push
+    import server.workers.sync_pull_worker as pull
+    importlib.reload(push)
+    importlib.reload(pull)
+
+    names = get_model_names()
+    expected = {
+        inv.Device.__tablename__,
+        inv.DeviceType.__tablename__,
+        inv.Tag.__tablename__,
+        inv.Location.__tablename__,
+        inv.DeviceDamage.__tablename__,
+    }
+    assert expected <= names


### PR DESCRIPTION
## Summary
- load inventory models in sync workers and helpers
- test that worker imports register all inventory models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68570dd7340483248535edc1822b2dbc