### PR TITLE
Finalize modular loader

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,14 +1,17 @@
 from fastapi import FastAPI
-import os
+
+# Rely on the settings module so tests can toggle modules using
+# environment variables before the app starts up.
+from settings import settings
 
 
 def load_modules(app: FastAPI) -> None:
     """Register enabled modules with the application."""
-    if os.environ.get("INVENTORY_ENABLED", "1") == "1":
+    if settings.inventory_enabled:
         from modules.inventory.routes import router as inventory_router
         __import__("modules.inventory.models")  # ensure models registered
         app.include_router(inventory_router)
-    if os.environ.get("NETWORK_ENABLED", "1") == "1":
+    if settings.network_enabled:
         from modules.network.routes import router as network_router
         __import__("modules.network.models")
         app.include_router(network_router)

--- a/tests/test_module_loader.py
+++ b/tests/test_module_loader.py
@@ -1,0 +1,19 @@
+import importlib
+from fastapi import FastAPI
+
+
+def test_inventory_only_module_loading(monkeypatch):
+    monkeypatch.setenv("INVENTORY_ENABLED", "1")
+    monkeypatch.setenv("NETWORK_ENABLED", "0")
+
+    settings_mod = importlib.import_module("settings")
+    importlib.reload(settings_mod)
+    modules_mod = importlib.import_module("modules")
+    importlib.reload(modules_mod)
+
+    app = FastAPI()
+    modules_mod.load_modules(app)
+    paths = [route.path for route in app.routes]
+    assert "/inventory/audit" in paths
+    assert "/network/ip-search" not in paths
+


### PR DESCRIPTION
## Summary
- rely on `settings` in `modules.load_modules`
- add test validating loader uses environment settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572973a6f48324b3dc6f15222a0601