### PR TITLE
Fix authentication checks and UI tweaks

### DIFF
--- a/base/templates/base/login.html
+++ b/base/templates/base/login.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="max-w-sm mx-auto mt-10">
   <h1 class="text-xl mb-4">Login</h1>
-  <form method="post" class="space-y-4">
+  <form method="post" class="space-y-5">
     <input type="text" name="email" placeholder="Email" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
     <input type="password" name="password" placeholder="Password" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
     {% if error %}

--- a/base/templates/base/user_detail.html
+++ b/base/templates/base/user_detail.html
@@ -57,40 +57,34 @@
   </div>
 </div>
 
+<a href="/users/me/edit" class="mt-4 inline-block px-4 py-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">Edit Profile</a>
+
 {% if current_user and current_user.id == user.id %}
-  <h2 class="text-lg mt-6 mb-2">SSH Credentials</h2>
-  <form method="post" action="/users/me/ssh" class="space-y-4">
-    <div class="form-row">
-      <div class="form-item">
-        <label for="ssh_username" class="block">SSH Username</label>
-        <input id="ssh_username" name="ssh_username" value="{{ user.ssh_username or '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
-      </div>
-    </div>
-    <div class="form-row">
-      <div class="form-item">
-        <label for="ssh_password" class="block">SSH Password</label>
-        <input id="ssh_password" type="password" name="ssh_password" value="{{ user.ssh_password or '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
-      </div>
-    </div>
-    <div class="form-row">
-      <div class="form-item">
-        <label for="ssh_port" class="block">SSH Port</label>
-        <input id="ssh_port" type="number" min="1" max="65535" name="ssh_port" value="{{ user.ssh_port or 22 }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
-      </div>
-    </div>
-    <div class="form-row">
-      <div class="form-item">
-        <span aria-label="Save" class="p-2 rounded transition cursor-pointer" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
-      </div>
-    </div>
-  </form>
 
 
 
-  <a href="/users/me/edit" class="block px-4 py-2 text-[var(--btn-text)] bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] rounded transition mt-4">Edit Profile</a>
   </div> {# end profile tab #}
   <div x-show="tab === 'ssh'" x-cloak>
     <a href="/user/ssh/new" class="underline">Add SSH Credential</a>
+    <form method="post" action="/users/me/ssh" class="my-4">
+      <div class="form-row">
+        <div class="form-item">
+          <label for="ssh_username" class="block">SSH Username</label>
+          <input id="ssh_username" name="ssh_username" value="{{ user.ssh_username or '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
+        </div>
+        <div class="form-item">
+          <label for="ssh_password" class="block">SSH Password</label>
+          <input id="ssh_password" type="password" name="ssh_password" value="{{ user.ssh_password or '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
+        </div>
+        <div class="form-item">
+          <label for="ssh_port" class="block">SSH Port</label>
+          <input id="ssh_port" type="number" min="1" max="65535" name="ssh_port" value="{{ user.ssh_port or 22 }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
+        </div>
+        <div class="form-item flex items-end">
+          <span aria-label="Save" class="p-2 rounded transition cursor-pointer" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
+        </div>
+      </div>
+    </form>
     <div class="w-full overflow-auto">
       <table class="min-w-full table-fixed text-left mt-4">
         <thead>

--- a/base/templates/base/user_theme.html
+++ b/base/templates/base/user_theme.html
@@ -96,3 +96,28 @@
   </div>
 </form>
 {% endblock %}
+
+{% block extra_scripts %}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const stick = document.getElementById('menu_stick_theme');
+    const fields = ['theme','font','icon_style','menu_style','table_grid_style','admin_color','inventory_color','network_color','menu_tab_color','menu_bg_color'];
+    function update() {
+      const disabled = stick.checked;
+      fields.forEach(id => {
+        const el = document.getElementById(id);
+        if (el) {
+          if (disabled) {
+            el.value = '';
+            el.setAttribute('disabled','');
+          } else {
+            el.removeAttribute('disabled');
+          }
+        }
+      });
+    }
+    stick.addEventListener('change', update);
+    update();
+  });
+</script>
+{% endblock %}

--- a/server/routes/ui/configs.py
+++ b/server/routes/ui/configs.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 import difflib
 
 from core.utils.db_session import get_db
-from core.utils.auth import get_current_user
+from core.utils.auth import require_role
 from modules.inventory.models import Device
 from core.models.models import ConfigBackup
 from core.utils.audit import log_audit
@@ -18,10 +18,8 @@ async def list_device_configs(
     device_id: int,
     request: Request,
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_role("viewer")),
 ):
-    if not current_user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
 
     device = db.query(Device).filter(Device.id == device_id).first()
     if not device:
@@ -47,10 +45,8 @@ async def diff_config(
     config_id: int,
     request: Request,
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_role("viewer")),
 ):
-    if not current_user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
 
     backup = db.query(ConfigBackup).filter(ConfigBackup.id == config_id).first()
     if not backup:
@@ -97,11 +93,9 @@ async def compare_configs(
     backup_a: int | None = None,
     backup_b: int | None = None,
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_role("viewer")),
 ):
     """Manually compare two config backups from any device."""
-    if not current_user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
 
     devices = (
         db.query(Device)

--- a/server/routes/ui/help.py
+++ b/server/routes/ui/help.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, Request, Depends
 from core.utils.templates import templates
-from core.utils.auth import get_current_user
+from core.utils.auth import require_role
 
 router = APIRouter()
 
 @router.get('/help')
-async def help_page(request: Request, current_user=Depends(get_current_user)):
+async def help_page(request: Request, current_user=Depends(require_role("viewer"))):
     context = {
         'request': request,
         'current_user': current_user,
@@ -14,7 +14,7 @@ async def help_page(request: Request, current_user=Depends(get_current_user)):
 
 
 @router.get('/help/manual')
-async def manual_page(request: Request, current_user=Depends(get_current_user)):
+async def manual_page(request: Request, current_user=Depends(require_role("viewer"))):
     """Display the expanded user manual."""
     context = {
         'request': request,

--- a/server/routes/ui/tag_manager.py
+++ b/server/routes/ui/tag_manager.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func
 
 from core.utils.db_session import get_db
-from core.utils.auth import require_role, get_current_user
+from core.utils.auth import require_role
 from core.utils.templates import templates
 from modules.inventory.utils import add_tag_to_device, remove_tag_from_device
 from modules.inventory.models import Tag
@@ -98,10 +98,8 @@ async def devices_by_tag(
     tag_name: str,
     request: Request,
     db: Session = Depends(get_db),
-    current_user=Depends(get_current_user),
+    current_user=Depends(require_role("viewer")),
 ):
-    if not current_user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
     tag = db.query(Tag).filter(func.lower(Tag.name) == tag_name.lower()).first()
     if not tag:
         raise HTTPException(status_code=404, detail="Tag not found")

--- a/web-client/static/css/unocss.css
+++ b/web-client/static/css/unocss.css
@@ -1,5 +1,4 @@
-/* build timestamp: 2025-06-21T13:06:01.033Z */
-
+/* build timestamp: 2025-06-21T23:43:47.658Z */
 /* layer: preflights */
 *,::before,::after{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgb(0 0 0 / 0);--un-ring-shadow:0 0 rgb(0 0 0 / 0);--un-shadow-inset: ;--un-shadow:0 0 rgb(0 0 0 / 0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgb(147 197 253 / 0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}::backdrop{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-pan-x: ;--un-pan-y: ;--un-pinch-zoom: ;--un-scroll-snap-strictness:proximity;--un-ordinal: ;--un-slashed-zero: ;--un-numeric-figure: ;--un-numeric-spacing: ;--un-numeric-fraction: ;--un-border-spacing-x:0;--un-border-spacing-y:0;--un-ring-offset-shadow:0 0 rgb(0 0 0 / 0);--un-ring-shadow:0 0 rgb(0 0 0 / 0);--un-shadow-inset: ;--un-shadow:0 0 rgb(0 0 0 / 0);--un-ring-inset: ;--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-width:0px;--un-ring-color:rgb(147 197 253 / 0.5);--un-blur: ;--un-brightness: ;--un-contrast: ;--un-drop-shadow: ;--un-grayscale: ;--un-hue-rotate: ;--un-invert: ;--un-saturate: ;--un-sepia: ;--un-backdrop-blur: ;--un-backdrop-brightness: ;--un-backdrop-contrast: ;--un-backdrop-grayscale: ;--un-backdrop-hue-rotate: ;--un-backdrop-invert: ;--un-backdrop-opacity: ;--un-backdrop-saturate: ;--un-backdrop-sepia: ;}
 /* layer: shortcuts */
@@ -134,6 +133,7 @@
 .list-inside{list-style-position:inside;}
 .list-none{list-style-type:none;}
 .items-start{align-items:flex-start;}
+.items-end{align-items:flex-end;}
 .items-center{align-items:center;}
 .justify-start{justify-content:flex-start;}
 .justify-end{justify-content:flex-end;}
@@ -155,6 +155,7 @@
 .space-y-2>:not([hidden])~:not([hidden]){--un-space-y-reverse:0;margin-top:calc(0.5rem * calc(1 - var(--un-space-y-reverse)));margin-bottom:calc(0.5rem * var(--un-space-y-reverse));}
 .space-y-3>:not([hidden])~:not([hidden]){--un-space-y-reverse:0;margin-top:calc(0.75rem * calc(1 - var(--un-space-y-reverse)));margin-bottom:calc(0.75rem * var(--un-space-y-reverse));}
 .space-y-4>:not([hidden])~:not([hidden]){--un-space-y-reverse:0;margin-top:calc(1rem * calc(1 - var(--un-space-y-reverse)));margin-bottom:calc(1rem * var(--un-space-y-reverse));}
+.space-y-5>:not([hidden])~:not([hidden]){--un-space-y-reverse:0;margin-top:calc(1.25rem * calc(1 - var(--un-space-y-reverse)));margin-bottom:calc(1.25rem * var(--un-space-y-reverse));}
 .overflow-auto{overflow:auto;}
 .overflow-hidden{overflow:hidden;}
 .overflow-x-hidden{overflow-x:hidden;}

--- a/web-client/templates/base.html
+++ b/web-client/templates/base.html
@@ -56,11 +56,11 @@
             <span class="text-[var(--btn-text)] text-base">CEST Master IP and Config Tool</span>
           </a>
             <div class="login-area flex items-center space-x-2">
-              <a href="/help" class="px-4 py-1.5 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded shadow transition">Help</a>
+              <a href="/help" class="px-4 py-1.5 text-base bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded shadow transition">Help</a>
               {% if current_user %}
-              <a href="/auth/logout" class="px-4 py-1.5 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded shadow transition logged-in">Logout</a>
+              <a href="/auth/logout" class="px-4 py-1.5 text-base bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded shadow transition logged-in">Logout</a>
               {% else %}
-              <a href="/auth/login" class="px-4 py-1.5 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded shadow transition logged-out">Login</a>
+              <a href="/auth/login" class="px-4 py-1.5 text-base bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded shadow transition logged-out">Login</a>
               {% endif %}
             </div>
         </div>

--- a/web-client/templates/tag_edit.html
+++ b/web-client/templates/tag_edit.html
@@ -23,6 +23,10 @@
   </tbody>
 </table>
 </div>
+<label class="block mt-4">
+  <span class="block mb-1">New Tags (comma separated)</span>
+  <input type="text" name="new_tags" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
+</label>
 <span aria-label="Save" class="p-2 rounded transition mt-2 cursor-pointer" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
 </form>
 <p class="mt-2 text-base text-[var(--card-text)]">Automatic tags <em>complete</em> and <em>incomplete</em> cannot be removed.</p>

--- a/web-client/templates/user_list.html
+++ b/web-client/templates/user_list.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">Users</h1>
-<a href="/admin/users/new" class="underline">Add User</a>
+<a href="/admin/users/new" class="inline-block mb-2 px-4 py-2 bg-[var(--btn-bg)] hover:bg-[var(--btn-hover)] text-[var(--btn-text)] rounded transition">Add User</a>
 <div class="w-full overflow-auto">
 <table class="min-w-full table-fixed text-left mt-4">
   <thead>
@@ -27,14 +27,14 @@
       </td>
       <td class="px-4 py-2">{{ user.created_at }}</td>
       <td class="px-4 py-2" style="width: 100px; min-width: 100px; max-width: 100px;">
-        <a href="/admin/users/{{ user.id }}/edit" aria-label="Edit" class="p-2 rounded transition mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
+        <a href="/admin/users/{{ user.id }}/edit" aria-label="Edit" class="icon-btn h-full flex items-center p-2 mr-2">{{ include_icon('pencil','text-blue-500','1.5') }}</a>
         {% if user.is_active %}
         <form method="post" action="/admin/users/{{ user.id }}/deactivate" class="inline">
-          <span aria-label="Disable" class="p-2 rounded transition mr-2 cursor-pointer" role="button" tabindex="0" onclick="if(confirm('Deactivate user?')) { this.closest('form').submit() }">{{ include_icon('minus-circle','text-red-500','1.5') }}</span>
+          <span aria-label="Disable" class="icon-btn h-full flex items-center mr-2 cursor-pointer" role="button" tabindex="0" onclick="if(confirm('Deactivate user?')) { this.closest('form').submit() }">{{ include_icon('minus-circle','text-red-500','1.5') }}</span>
         </form>
         {% endif %}
         <form method="post" action="/admin/users/{{ user.id }}/reset-password" class="inline">
-          <span aria-label="Reset Password" class="p-2 underline text-yellow-400 cursor-pointer" role="button" tabindex="0" onclick="if(confirm('Reset password?')) { this.closest('form').submit() }">{{ include_icon('refresh-ccw','text-yellow-400','1.5') }}</span>
+          <span aria-label="Reset Password" class="icon-btn h-full flex items-center text-yellow-400 cursor-pointer" role="button" tabindex="0" onclick="if(confirm('Reset password?')) { this.closest('form').submit() }">{{ include_icon('refresh-ccw','text-yellow-400','1.5') }}</span>
         </form>
       </td>
     </tr>

--- a/web-client/templates/user_ssh_list.html
+++ b/web-client/templates/user_ssh_list.html
@@ -2,6 +2,26 @@
 
 {% block content %}
 <h1 class="text-xl mb-4">My SSH Credentials</h1>
+<h2 class="text-lg mb-2">Default Credentials</h2>
+<form method="post" action="/users/me/ssh" class="mb-6">
+  <div class="form-row">
+    <div class="form-item">
+      <label for="ssh_username" class="block">SSH Username</label>
+      <input id="ssh_username" name="ssh_username" value="{{ current_user.ssh_username or '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" required />
+    </div>
+    <div class="form-item">
+      <label for="ssh_password" class="block">SSH Password</label>
+      <input id="ssh_password" type="password" name="ssh_password" value="{{ current_user.ssh_password or '' }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
+    </div>
+    <div class="form-item">
+      <label for="ssh_port" class="block">SSH Port</label>
+      <input id="ssh_port" type="number" min="1" max="65535" name="ssh_port" value="{{ current_user.ssh_port or 22 }}" class="w-full p-2 rounded bg-[var(--input-bg)] text-[var(--input-text)] border border-[var(--border-color)]" />
+    </div>
+    <div class="form-item flex items-end">
+      <span aria-label="Save" class="p-2 rounded transition cursor-pointer" role="button" tabindex="0" onclick="this.closest('form').submit()">{{ include_icon('save') }}</span>
+    </div>
+  </div>
+</form>
 <a href="/user/ssh/new" class="underline">Add SSH Credential</a>
 <div class="w-full overflow-auto">
 <table class="min-w-full table-fixed text-left mt-4">


### PR DESCRIPTION
## Summary
- require at least viewer role for remaining UI routes
- improve login page spacing
- make Help/Logout buttons consistent
- allow creating new tags in tag edit form
- update profile layout and default SSH credential forms
- move SSH credential settings to SSH tab
- disable theme overrides when sticking with theme
- tidy user list UI icons and add "Add User" button
- rebuild UnoCSS

## Testing
- `npm install`
- `npm run build:web`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573f6eb5208324b1b4b51f24b8cd0d