### PR TITLE
Organize super admin menu grid

### DIFF
--- a/server/routes/ui/admin_menu.py
+++ b/server/routes/ui/admin_menu.py
@@ -10,6 +10,37 @@ import os
 
 router = APIRouter()
 
+
+@router.get("/admin/menu")
+async def super_admin_menu(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user=Depends(require_role("superadmin")),
+):
+    items = [
+        {"label": "My Profile", "href": "/users/me"},
+        {"label": "Organisation Settings", "href": "/admin/org-settings", "category": "System"},
+        {"label": "Users", "href": "/admin/users", "category": "System"},
+        {"label": "System Monitor", "href": "/admin/system-monitor", "category": "System"},
+        {"label": "Cloud Sync / API's", "href": "/admin/cloud-sync"},
+    ]
+    for item in items:
+        item["img"] = _menu_image(db, item["label"])
+    categories = []
+    general = [i for i in items if not i.get("category")]
+    if general:
+        categories.append({"label": None, "items": general})
+    system_items = [i for i in items if i.get("category") == "System"]
+    if system_items:
+        categories.append({"label": "System", "items": system_items})
+    context = {
+        "request": request,
+        "categories": categories,
+        "title": "Super Admin",
+        "current_user": current_user,
+    }
+    return templates.TemplateResponse("admin_menu_grid.html", context)
+
 def _slug(label: str) -> str:
     return label.lower().replace(" ", "_")
 

--- a/web-client/templates/admin_menu_grid.html
+++ b/web-client/templates/admin_menu_grid.html
@@ -3,6 +3,20 @@
 {% block content %}
 <div class="mx-auto w-3/4">
   <h1 class="text-xl mb-4">{{ title }}</h1>
+  {% if categories is defined %}
+    {% for section in categories %}
+      {% if section.label %}
+      <h2 class="text-lg mt-4 mb-2">{{ section.label }}</h2>
+      {% endif %}
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-0 mb-4">
+        {% for item in section.items %}
+        <a href="{{ item.href }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('{{ item.img or '' }}'); background-size:cover; background-position:center;">
+          <span class="bg-black bg-opacity-50 px-2 py-1 rounded">{{ item.label }}</span>
+        </a>
+        {% endfor %}
+      </div>
+    {% endfor %}
+  {% else %}
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-0">
     {% for item in items %}
     <a href="{{ item.href }}" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image:url('{{ item.img or '' }}'); background-size:cover; background-position:center;">
@@ -10,5 +24,6 @@
     </a>
     {% endfor %}
   </div>
+  {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- group super admin menu items by category in route
- render menu sections with optional headings

## Testing
- `npm run build:web` *(fails: unocss not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685760f1a2208324a13507893386ddb1