### PR TITLE
Remove users tab from super admin submenu

### DIFF
--- a/server/routes/ui/admin_menu.py
+++ b/server/routes/ui/admin_menu.py
@@ -20,7 +20,6 @@ async def super_admin_menu(
     items = [
         {"label": "My Profile", "href": "/users/me"},
         {"label": "Organisation Settings", "href": "/admin/org-settings", "category": "System"},
-        {"label": "Users", "href": "/admin/users", "category": "System"},
         {"label": "System Monitor", "href": "/admin/system-monitor", "category": "System"},
         {"label": "Cloud Sync / API's", "href": "/admin/cloud-sync"},
     ]


### PR DESCRIPTION
## Summary
- clean up `/admin/menu` by removing the Users entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857b5ac15788324898deab4469a15a8