### PR TITLE
Fix system monitor metrics

### DIFF
--- a/server/routes/ui/system_monitor.py
+++ b/server/routes/ui/system_monitor.py
@@ -1,34 +1,18 @@
 from fastapi import APIRouter, Request, Depends
 from core.utils.auth import require_role
 from core.utils.templates import templates
-import psutil
-import shutil
-import os
+from server.utils.system_metrics import gather_metrics
 
 router = APIRouter()
 
 
 @router.get("/admin/system-monitor")
 async def system_monitor(request: Request, current_user=Depends(require_role("superadmin"))):
-    cpu = psutil.cpu_percent(interval=1)
-    mem = psutil.virtual_memory().percent
-    load = os.getloadavg()
-    net = psutil.net_io_counters()._asdict()
-    disk = shutil.disk_usage("/")
+    metrics = gather_metrics()
 
     context = {
         "request": request,
         "current_user": current_user,
-        "metrics": {
-            "cpu": cpu,
-            "mem": mem,
-            "load": load,
-            "net": net,
-            "disk": {
-                "total": disk.total,
-                "used": disk.used,
-                "free": disk.free,
-            },
-        },
+        "metrics": metrics,
     }
     return templates.TemplateResponse("system_monitor.html", context)


### PR DESCRIPTION
## Summary
- use `gather_metrics()` when rendering the system monitor page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857c0284c1483249eef080a2658f2e8