### PR TITLE
Add Google Sheets tile to system menu

### DIFF
--- a/web-client/templates/admin_menu_grid.html
+++ b/web-client/templates/admin_menu_grid.html
@@ -14,6 +14,11 @@
           <span class="bg-black bg-opacity-50 px-2 py-1 rounded">{{ item.label }}</span>
         </a>
         {% endfor %}
+        {% if section.label in ["System", "Organisation Settings"] %}
+        <a href="/tasks/google-sheets" class="relative h-40 flex items-center justify-center text-white font-bold text-xl transition transform hover:scale-105" style="background-image: url(''); background-size: cover; background-position: center;">
+          <span class="bg-black bg-opacity-50 px-2 py-1 rounded">Google Sheets</span>
+        </a>
+        {% endif %}
       </div>
     {% endfor %}
   {% else %}


### PR DESCRIPTION
## Summary
- show a Google Sheets tile in admin menus when listing System or Organisation Settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857e3bc4c788324bacd82d5698e987a