### PR TITLE
Auto reset local DB when schema invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,14 @@ credentials, whether you want a real domain or a self-signed certificate and the
 admin user password. The script writes a `.env` file and starts the application
 once installation completes.
 
+## Automatic Schema Recovery
+
+Local instances verify the database schema at startup. If a mismatch is detected
+the application will wipe the local database, fetch the schema and seed data
+from the configured cloud server and then re-run the initial sync. **All local
+data will be erased** during this process. This safety net is never executed on
+cloud deployments.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/alembic/versions/b41a94cd99a1_schema_resets.py
+++ b/alembic/versions/b41a94cd99a1_schema_resets.py
@@ -1,0 +1,30 @@
+"""add schema_resets table
+
+Revision ID: b41a94cd99a1
+Revises: 2e4e28454f6b
+Create Date: 2025-06-22 17:00:00
+"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b41a94cd99a1'
+down_revision: Union[str, None] = '2e4e28454f6b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'schema_resets',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('timestamp', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('reason', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('schema_resets')

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -30,6 +30,7 @@ from .models import (
     ManualSQLError,
     SchemaValidationIssue,
     SchemaVersion,
+    SchemaReset,
 )
 
 __all__ = [
@@ -64,4 +65,5 @@ __all__ = [
     "ManualSQLError",
     "SchemaValidationIssue",
     "SchemaVersion",
+    "SchemaReset",
 ]

--- a/core/models/models.py
+++ b/core/models/models.py
@@ -454,6 +454,14 @@ class SchemaVersion(Base):
     updated_at = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
     instance_type = Column(String, nullable=False)
 
+
+class SchemaReset(Base):
+    __tablename__ = "schema_resets"
+
+    id = Column(Integer, primary_key=True)
+    timestamp = Column(DateTime(timezone=True), default=datetime.now(timezone.utc))
+    reason = Column(String, nullable=False)
+
 def _update_timestamp(mapper, connection, target) -> None:
     """Refresh the updated_at field before persisting changes."""
     target.updated_at = datetime.now(timezone.utc)

--- a/tests/test_reset_local_database.py
+++ b/tests/test_reset_local_database.py
@@ -1,0 +1,41 @@
+import sys
+import types
+from core.utils.database import Base
+import core.utils.db_session as db_session
+import core.utils.schema as schema
+import core.models.models as models
+
+import modules.inventory.models  # noqa
+import modules.network.models  # noqa
+
+from tests.test_schema_validation import _setup_engine
+
+
+def test_reset_local_database(monkeypatch):
+    engine = _setup_engine(monkeypatch)
+    Base.metadata.create_all(engine)
+
+    dummy_mod = types.SimpleNamespace()
+    async def fake_sync():
+        dummy_mod.called = True
+    dummy_mod.run_sync_once = fake_sync
+    sys.modules['server.workers.cloud_sync'] = dummy_mod
+
+    called = []
+    def fake_run(cmd, check=True):
+        called.append(cmd)
+        if "alembic" in cmd:
+            Base.metadata.create_all(engine)
+    monkeypatch.setattr(schema.subprocess, 'run', fake_run)
+
+    schema.reset_local_database('test')
+
+    db = db_session.SessionLocal()
+    try:
+        row = db.query(models.SchemaReset).first()
+        assert row is not None
+        assert row.reason == 'test'
+    finally:
+        db.close()
+
+    assert any('alembic' in c[0] for c in called)


### PR DESCRIPTION
## Summary
- add `SchemaReset` model and migration
- implement `reset_local_database` utility
- auto-run reset on startup if schema mismatch detected
- document automatic recovery in README
- test `reset_local_database`

## Testing
- `pytest -q tests/test_reset_local_database.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685831e7cb7483248f2c36f48ecfb58c