### PR TITLE
Enforce postgres use in tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ httpx<0.28
 alembic==1.12.0
 questionary
 Pillow
+testing.postgresql

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import os
+import subprocess
+import importlib
+
+import pytest
+import sqlalchemy as sa
+import testing.postgresql
+
+from core.utils import db_session, schema
+
+@pytest.fixture(scope="session")
+def pg_engine():
+    with testing.postgresql.Postgresql() as pg:
+        os.environ['DATABASE_URL'] = pg.url()
+        engine = sa.create_engine(pg.url())
+        db_session.engine = engine
+        db_session.SessionLocal.configure(bind=engine)
+        db_session._BaseSessionLocal.configure(bind=engine)
+        schema.engine = engine
+        subprocess.run(["alembic", "upgrade", "head"], check=True)
+        yield engine
+        engine.dispose()
+

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,9 +1,6 @@
-import os
-import sqlalchemy as sa
 from sqlalchemy import text
 
 from core.utils.database import Base
-import core.utils.db_session as db_session
 import core.utils.schema as schema
 
 import modules.inventory.models  # register tables
@@ -11,30 +8,18 @@ import modules.network.models
 import core.models.models
 
 
-def _setup_engine(monkeypatch):
-    os.environ['DATABASE_URL'] = 'postgresql://user:pass@localhost/test'
-    engine = sa.create_engine('sqlite:///:memory:')
-    db_session.engine = engine
-    db_session.SessionLocal.configure(bind=engine)
-    db_session._BaseSessionLocal.configure(bind=engine)
-    schema.engine = engine
-    return engine
-
-
-def test_validate_schema_integrity_missing_table(monkeypatch):
-    engine = _setup_engine(monkeypatch)
-    Base.metadata.create_all(engine)
-    with engine.connect() as conn:
+def test_validate_schema_integrity_missing_table(pg_engine):
+    Base.metadata.create_all(pg_engine)
+    with pg_engine.connect() as conn:
         conn.execute(text('DROP TABLE login_events'))
     result = schema.validate_schema_integrity()
     assert result['valid'] is False
     assert 'login_events' in result['missing_tables']
 
 
-def test_validate_schema_integrity_mismatched_column(monkeypatch):
-    engine = _setup_engine(monkeypatch)
-    Base.metadata.create_all(engine)
-    with engine.connect() as conn:
+def test_validate_schema_integrity_mismatched_column(pg_engine):
+    Base.metadata.create_all(pg_engine)
+    with pg_engine.connect() as conn:
         conn.execute(text('DROP TABLE users'))
         conn.execute(text('CREATE TABLE users(id INTEGER PRIMARY KEY, email INTEGER)'))
     result = schema.validate_schema_integrity()

--- a/tests/test_soft_delete.py
+++ b/tests/test_soft_delete.py
@@ -11,16 +11,13 @@ from core.utils.deletion import soft_delete
 
 
 def _load_models():
-    with mock.patch("sqlalchemy.create_engine"), mock.patch(
-        "sqlalchemy.schema.MetaData.create_all"
-    ):
-        inv = importlib.import_module("modules.inventory.models")
-        net = importlib.import_module("modules.network.models")
-        core = importlib.import_module("core.models")
-        attrs = {name: getattr(core, name) for name in dir(core) if not name.startswith("_")}
-        attrs.update({name: getattr(inv, name) for name in dir(inv) if not name.startswith("_")})
-        attrs.update({name: getattr(net, name) for name in dir(net) if not name.startswith("_")})
-        return types.SimpleNamespace(**attrs)
+    inv = importlib.import_module("modules.inventory.models")
+    net = importlib.import_module("modules.network.models")
+    core = importlib.import_module("core.models")
+    attrs = {name: getattr(core, name) for name in dir(core) if not name.startswith("_")}
+    attrs.update({name: getattr(inv, name) for name in dir(inv) if not name.startswith("_")})
+    attrs.update({name: getattr(net, name) for name in dir(net) if not name.startswith("_")})
+    return types.SimpleNamespace(**attrs)
 
 
 def test_soft_delete_device_clears_fields():
@@ -47,12 +44,11 @@ def test_soft_delete_device_clears_fields():
     assert dev.hostname == "dev"
 
 
-def test_query_filters_deleted():
+def test_query_filters_deleted(pg_engine):
     models = _load_models()
-    engine = sa.create_engine("sqlite:///:memory:")
-    Session = sessionmaker(bind=engine)
+    Session = sessionmaker(bind=pg_engine)
     import core.utils.database as database
-    database.Base.metadata.create_all(bind=engine)
+    database.Base.metadata.create_all(bind=pg_engine)
     db = Session()
     now = datetime.now(timezone.utc)
     db.add_all([


### PR DESCRIPTION
## Summary
- add `testing.postgresql` dependency
- spin up a PostgreSQL instance for tests
- ensure schema validation and reset tests run against PostgreSQL
- remove SQLite usage from soft delete tests

## Testing
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_6858451979588324b70e4b2dc2b6da44