### PR TITLE
Implement schema mismatch logging and reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,10 +572,11 @@ once installation completes.
 ## Automatic Schema Recovery
 
 Local instances verify the database schema at startup. If a mismatch is detected
-the application will wipe the local database, fetch the schema and seed data
-from the configured cloud server and then re-run the initial sync. **All local
-data will be erased** during this process. This safety net is never executed on
-cloud deployments.
+the application records the details in the `boot_errors` table and wipes the
+local database. It fetches the schema and seed data from the configured cloud
+server, logs the rebuild in the `schema_resets` table and then re-runs the
+initial sync. **All local data will be erased** during this process. This safety
+net is never executed on cloud deployments.
 
 ## License
 

--- a/core/utils/schema.py
+++ b/core/utils/schema.py
@@ -180,6 +180,27 @@ def validate_schema_integrity() -> dict:
     }
 
 
+def log_schema_validation_details(result: dict, instance: str) -> None:
+    """Store a summary of schema validation issues in ``boot_errors``."""
+    parts: list[str] = []
+    if result.get("missing_tables"):
+        parts.append(
+            "missing tables: " + ", ".join(sorted(result["missing_tables"]))
+        )
+    for table, cols in result.get("missing_columns", {}).items():
+        joined = ", ".join(sorted(cols))
+        parts.append(f"missing columns in {table}: {joined}")
+    for table, cols in result.get("mismatched_columns", {}).items():
+        for col, types in cols.items():
+            parts.append(
+                f"mismatched column {table}.{col} expected {types[0]} got {types[1]}"
+            )
+    if not parts:
+        parts.append("schema mismatch detected")
+    message = "; ".join(parts)
+    log_boot_error(message, "", instance)
+
+
 def log_boot_error(msg: str, tb: str, instance: str) -> None:
     db = _BaseSessionLocal()
     try:

--- a/server/main.py
+++ b/server/main.py
@@ -95,6 +95,7 @@ from core.utils.schema import (
     log_boot_error,
     validate_schema_integrity,
     reset_local_database,
+    log_schema_validation_details,
 )
 from alembic.config import Config
 from alembic import command
@@ -138,6 +139,7 @@ async def lifespan(app: FastAPI):
     validation = validate_schema_integrity()
     schema_ok = validation["valid"]
     if not schema_ok:
+        log_schema_validation_details(validation, settings.role)
         db = SessionLocal()
         try:
             for tbl in validation["missing_tables"]:
@@ -175,7 +177,6 @@ async def lifespan(app: FastAPI):
             db.commit()
         finally:
             db.close()
-        log_boot_error("Schema mismatch detected", "", settings.role)
         if settings.role != "cloud":
             try:
                 reset_local_database("schema mismatch")

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -26,3 +26,19 @@ def test_validate_schema_integrity_mismatched_column(pg_engine):
     assert result['valid'] is False
     assert 'users' not in result['missing_tables']
     assert 'email' in result['mismatched_columns']['users']
+
+
+def test_log_schema_validation_details(monkeypatch, pg_engine):
+    Base.metadata.create_all(pg_engine)
+    with pg_engine.connect() as conn:
+        conn.execute(text('DROP TABLE login_events'))
+    messages: list[str] = []
+
+    def fake_log_boot_error(msg: str, tb: str, instance: str) -> None:
+        messages.append(msg)
+
+    monkeypatch.setattr(schema, 'log_boot_error', fake_log_boot_error)
+    result = schema.validate_schema_integrity()
+    schema.log_schema_validation_details(result, 'local')
+    assert messages
+    assert 'login_events' in messages[0]


### PR DESCRIPTION
## Summary
- log database schema issues to boot_errors via new helper
- reset local DB when validation fails and log details
- document boot_errors/schema_resets in README
- test logging function

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685849f9b76883249ef048e8518f51bc