### PR TITLE
Speed up test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,11 @@ pip install -r requirements.txt
 pytest -q
 ```
 
+The tests spin up an ephemeral PostgreSQL instance. Migrations run only during
+the first invocation and the initialised database is cached under
+`tests/.pg_cache` for subsequent runs. Delete this directory or set
+`RESET_TEST_DB=1` if migrations change and the cache needs rebuilding.
+
 All tests should pass without errors. Node.js packages are not required when
 running the tests.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,39 @@
 import os
 import subprocess
-import importlib
 
 import pytest
 import sqlalchemy as sa
 import testing.postgresql
+import shutil
+
+PG_CACHE_DIR = os.path.join(os.path.dirname(__file__), ".pg_cache")
+if os.environ.get("RESET_TEST_DB"):
+    shutil.rmtree(PG_CACHE_DIR, ignore_errors=True)
+
+
+def _init_db(pg: testing.postgresql.Postgresql) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = pg.url()
+    subprocess.run(["alembic", "upgrade", "head"], env=env, check=True)
+
+
+PostgresqlFactory = testing.postgresql.PostgresqlFactory(
+    base_dir=PG_CACHE_DIR,
+    cache_initialized_db=True,
+    on_initialized=_init_db,
+)
 
 from core.utils import db_session, schema
 
 @pytest.fixture(scope="session")
 def pg_engine():
-    with testing.postgresql.Postgresql() as pg:
+    with PostgresqlFactory() as pg:
         os.environ['DATABASE_URL'] = pg.url()
         engine = sa.create_engine(pg.url())
         db_session.engine = engine
         db_session.SessionLocal.configure(bind=engine)
         db_session._BaseSessionLocal.configure(bind=engine)
         schema.engine = engine
-        subprocess.run(["alembic", "upgrade", "head"], check=True)
         yield engine
         engine.dispose()
 


### PR DESCRIPTION
## Summary
- cache the temporary PostgreSQL database used by tests
- document the new cached database directory in the README

## Testing
- `pytest -q` *(fails: command not found: initdb)*

------
https://chatgpt.com/codex/tasks/task_e_6858518f35b483249a664312d36fd427