### PR TITLE
Add docs on unsynced record recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,13 @@ server, logs the rebuild in the `schema_resets` table and then re-runs the
 initial sync. **All local data will be erased** during this process. This safety
 net is never executed on cloud deployments.
 
+Before wiping the database, any rows that have not yet synced are exported to
+`backups/unsynced_backup.json`. The export runs only on local instances and is
+skipped if a recent backup already exists. After the database is rebuilt the
+file is replayed, reinserting the rows with `sync_status` set to `pending`. Both
+the export and the restore are recorded in the `local_recovery_events` table so
+administrators can audit recovery attempts.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- document automatic export and replay of unsynced records during local DB resets

## Testing
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_68585c8e61d88324ac9aa1e5a745f35f