### PR TITLE
Enhance CLI installer with cloud admin selection

### DIFF
--- a/scripts/run_migrations.py
+++ b/scripts/run_migrations.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 """Apply Alembic migrations safely."""
 import logging
+import os
+import sys
+
+# Ensure repository root is on the Python path so ``core`` imports resolve
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + "/../"))
+
 from core.utils.schema import safe_alembic_upgrade
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix migration script import path
- support selecting a cloud super admin during install

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb failed cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685866540a848324afbf9ca6716c9c7a