### PR TITLE
Improve CLI installer cloud user handling

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -88,11 +88,20 @@ def lookup_cloud_user(base_url: str, api_key: str, email: str) -> dict | None:
     url = base_url.rstrip("/") + "/api/users/lookup"
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     try:
-        resp = httpx.get(url, params={"email": email}, headers=headers, timeout=10)
+        resp = httpx.get(
+            url,
+            params={"email": email},
+            headers=headers,
+            timeout=10,
+        )
         if resp.status_code == 404:
             return None
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+        # Treat empty responses as not found
+        if not data:
+            return None
+        return data
     except Exception as exc:  # pragma: no cover - best effort
         print(f"User lookup failed: {exc}")
         return None
@@ -107,7 +116,10 @@ def create_cloud_user(base_url: str, api_key: str, data: dict) -> dict | None:
     try:
         resp = httpx.post(url, json=data, headers=headers, timeout=10)
         resp.raise_for_status()
-        return resp.json()
+        result = resp.json()
+        if not result:
+            return None
+        return result
     except Exception as exc:  # pragma: no cover - best effort
         print(f"User creation failed: {exc}")
         return None

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -25,9 +25,25 @@ def test_lookup_cloud_user_404(monkeypatch):
     assert result is None
 
 
+def test_lookup_cloud_user_empty(monkeypatch):
+    def fake_get(url, params=None, headers=None, timeout=10):
+        return httpx.Response(200, json={})
+    monkeypatch.setattr('installer.httpx.get', fake_get)
+    result = lookup_cloud_user('https://cloud', 'k', 'a@b.com')
+    assert result is None
+
+
 def test_create_cloud_user_success(monkeypatch):
     def fake_post(url, json=None, headers=None, timeout=10):
         return httpx.Response(200, json={'id': 'u1'})
     monkeypatch.setattr('installer.httpx.post', fake_post)
     result = create_cloud_user('https://cloud', 'k', {'email': 'x'})
     assert result == {'id': 'u1'}
+
+
+def test_create_cloud_user_empty(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=10):
+        return httpx.Response(200, json={})
+    monkeypatch.setattr('installer.httpx.post', fake_post)
+    result = create_cloud_user('https://cloud', 'k', {'email': 'x'})
+    assert result is None


### PR DESCRIPTION
## Summary
- improve lookup and creation helpers to treat empty responses as missing
- add tests for empty lookup and empty create cases

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_68588004e8088324b25d002ecbf1d141