### PR TITLE
Improve cloud user linking

### DIFF
--- a/alembic/versions/5f6cc3ec7313_unique_cloud_user_id_index.py
+++ b/alembic/versions/5f6cc3ec7313_unique_cloud_user_id_index.py
@@ -1,0 +1,30 @@
+"""add unique index for cloud_user_id
+
+Revision ID: 5f6cc3ec7313
+Revises: ec96754a9596
+Create Date: 2025-06-23 00:00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '5f6cc3ec7313'
+down_revision: Union[str, None] = 'ec96754a9596'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        'ix_users_cloud_user_id_unique',
+        'users',
+        ['cloud_user_id'],
+        unique=True,
+        postgresql_where=sa.text('cloud_user_id IS NOT NULL'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_users_cloud_user_id_unique', table_name='users')

--- a/core/models/models.py
+++ b/core/models/models.py
@@ -12,6 +12,8 @@ from sqlalchemy import (
     Float,
     JSON,
     event,
+    Index,
+    text,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy import Table
@@ -70,6 +72,14 @@ class User(Base):
     """User account with role-based permissions."""
 
     __tablename__ = "users"
+    __table_args__ = (
+        Index(
+            "ix_users_cloud_user_id_unique",
+            "cloud_user_id",
+            unique=True,
+            postgresql_where=text("cloud_user_id IS NOT NULL"),
+        ),
+    )
 
     id = Column(Integer, primary_key=True)
     uuid = Column(GUID(), default=uuid4, unique=True, nullable=False, index=True)

--- a/installer.py
+++ b/installer.py
@@ -284,51 +284,34 @@ def install():
             api_key = questionary.text("Cloud API Key (optional)").ask().strip()
 
         if cloud_url and api_key:
-            while True:
-                admin_email = questionary.text("Admin email").ask().strip()
-                admin_data = lookup_cloud_user(cloud_url, api_key, admin_email)
-                if admin_data:
-                    if str(admin_data.get("role", "")).lower() not in {
-                        "superadmin",
-                        "super_admin",
-                    }:
-                        print("Cloud user lacks super admin privileges.")
-                        if questionary.confirm(
-                            "Enter a different cloud user?",
-                            default=True,
-                        ).ask():
-                            continue
-                        admin_data = None
-                    else:
-                        from_cloud = True
-                    break
-                else:
-                    print("Admin not found on cloud.")
-                    if questionary.confirm(
-                        "Create this user on the cloud?",
-                        default=True,
-                    ).ask():
-                        name = questionary.text("Name").ask()
-                        password = questionary.password("Password").ask()
-                        payload = {
-                            "email": admin_email,
-                            "name": name,
-                            "hashed_password": get_password_hash(password),
-                            "role": "superadmin",
-                            "is_active": True,
-                        }
-                        created = create_cloud_user(cloud_url, api_key, payload)
-                        if created:
-                            created["hashed_password"] = payload["hashed_password"]
-                            admin_data = created
-                            from_cloud = True
-                            break
-                        print("Cloud user creation failed")
-                    if not questionary.confirm(
-                        "Try another email?",
-                        default=False,
-                    ).ask():
-                        break
+            admin_email = questionary.text("Admin email").ask().strip()
+            admin_data = lookup_cloud_user(cloud_url, api_key, admin_email)
+            if admin_data:
+                if str(admin_data.get("role", "")).lower() not in {
+                    "superadmin",
+                    "super_admin",
+                }:
+                    print("Cloud user lacks super admin privileges. Aborting install.")
+                    return
+                from_cloud = True
+            else:
+                print("Admin not found on cloud. Creating...")
+                name = questionary.text("Name").ask()
+                password = questionary.password("Password").ask()
+                payload = {
+                    "email": admin_email,
+                    "name": name,
+                    "hashed_password": get_password_hash(password),
+                    "role": "superadmin",
+                    "is_active": True,
+                }
+                created = create_cloud_user(cloud_url, api_key, payload)
+                if not created:
+                    print("Cloud user creation failed. Aborting install.")
+                    return
+                created["hashed_password"] = payload["hashed_password"]
+                admin_data = created
+                from_cloud = True
         else:
             print("No cloud information provided; creating standalone admin")
 


### PR DESCRIPTION
## Summary
- enforce unique cloud user ID with partial index
- create index model annotation
- validate cloud user roles in installer

## Testing
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685887f2ce68832489833e6e0ec4924c