### PR TITLE
Update installer run helper with env support

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -33,9 +33,10 @@ def write_env_file(content: str, path: str = ".env") -> None:
     Path(path).write_text(content, encoding="utf-8")
 
 
-def run(cmd: str) -> None:
+def run(cmd: str, env: dict | None = None) -> None:
+    """Run a shell command, optionally with a custom environment."""
     print(f"Running: {cmd}")
-    subprocess.run(cmd, shell=True, check=True)
+    subprocess.run(cmd, shell=True, check=True, env=env)
 
 
 def pg_role_exists(role: str) -> bool:
@@ -355,7 +356,9 @@ def install():
         db.close()
 
     try:
-        run("./start.sh")
+        start_env = os.environ.copy()
+        start_env["PATH"] = str(Path("venv/bin")) + os.pathsep + start_env.get("PATH", "")
+        run("./start.sh", env=start_env)
     except KeyboardInterrupt:
         print("Start script interrupted; exiting installer")
 

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,4 +1,5 @@
 from installer import build_env_content
+from installer import run
 
 
 def test_build_env_content_handles_quotes():
@@ -47,3 +48,17 @@ def test_create_cloud_user_empty(monkeypatch):
     monkeypatch.setattr('installer.httpx.post', fake_post)
     result = create_cloud_user('https://cloud', 'k', {'email': 'x'})
     assert result is None
+
+
+def test_run_passes_env(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, shell=True, check=True, env=None):
+        captured['cmd'] = cmd
+        captured['env'] = env
+
+    monkeypatch.setattr('installer.subprocess.run', fake_run)
+
+    run('echo hi', env={'FOO': 'BAR'})
+
+    assert captured['env'] == {'FOO': 'BAR'}


### PR DESCRIPTION
## Summary
- allow `run()` to pass custom environments
- ensure `start.sh` runs with the venv in PATH
- test `run()` environment handling

## Testing
- `sudo -u tester -E /root/.pyenv/versions/3.12.10/bin/python -m pytest tests/test_installer.py::test_run_passes_env -q`

------
https://chatgpt.com/codex/tasks/task_e_6859155f61a8832491ab7a5cee389994