### PR TITLE
Fix installer venv detection

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -433,5 +433,6 @@ if __name__ == "__main__":
             run("apt-get install -y python3-venv")
             run(f"{sys.executable} -m venv venv")
         print("🔁 Re-running installer inside virtualenv...")
-        os.execv("venv/bin/python", ["venv/bin/python", "installer.py"])
+        os.environ["VIRTUAL_ENV"] = str(Path("venv").resolve())
+        os.execve("venv/bin/python", ["venv/bin/python", "installer.py"], os.environ)
     install()


### PR DESCRIPTION
## Summary
- ensure `VIRTUAL_ENV` is propagated when restarting installer
- keep using `venv/bin/python` for installer subprocesses

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_68593572e0b083248af5644e5a1891d4