### PR TITLE
Fix installer start.sh invocation

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -451,7 +451,7 @@ def install():
     try:
         start_env = os.environ.copy()
         start_env["PATH"] = str(Path("venv/bin")) + os.pathsep + start_env.get("PATH", "")
-        run("venv/bin/python start.sh", env=start_env)
+        run("bash start.sh", env=start_env)
     except KeyboardInterrupt:
         print("Start script interrupted; exiting installer")
 


### PR DESCRIPTION
## Summary
- run `start.sh` using Bash instead of Python

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685945dd34a083249e2b47fb703e8898