### PR TITLE
Add run_app.sh and update launch scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ RUN npm install
 # Build static assets
 RUN npm run build:web
 
-RUN chmod +x start.sh init_db.sh
+RUN chmod +x start.sh init_db.sh run_app.sh
 
-CMD ["./start.sh"]
+CMD ["./run_app.sh"]

--- a/deploy/docker/docker-compose.cloud.yml
+++ b/deploy/docker/docker-compose.cloud.yml
@@ -15,7 +15,7 @@ services:
   app:
     build:
       context: ../..
-    command: ./start.sh
+    command: ./run_app.sh
     env_file:
       - .env.cloud
     depends_on:

--- a/deploy/docker/docker-compose.local.yml
+++ b/deploy/docker/docker-compose.local.yml
@@ -15,7 +15,7 @@ services:
   web:
     build:
       context: ../..
-    command: ./start.sh
+    command: ./run_app.sh
     env_file:
       - .env.local
     depends_on:

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -11,7 +11,7 @@ services:
       - postgres_data:/var/lib/postgresql/data
   web:
     build: .
-    command: ./start.sh
+    command: ./run_app.sh
     depends_on:
       - db
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   web:
     build: .
-    command: ./start.sh
+    command: ./run_app.sh
     depends_on:
       - db
     environment:

--- a/installer.py
+++ b/installer.py
@@ -451,7 +451,7 @@ def install():
     try:
         start_env = os.environ.copy()
         start_env["PATH"] = str(Path("venv/bin")) + os.pathsep + start_env.get("PATH", "")
-        run("bash start.sh", env=start_env)
+        run("bash run_app.sh", env=start_env)
     except KeyboardInterrupt:
         print("Start script interrupted; exiting installer")
 

--- a/run_app.sh
+++ b/run_app.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Ensure we're in the project root
+cd "$(dirname "$0")"
+
+# Activate the virtual environment
+source venv/bin/activate
+
+# Set PYTHONPATH so core/, base/, modules/ are available
+export PYTHONPATH="$(pwd)"
+
+# Start the app using Gunicorn with Uvicorn workers
+exec venv/bin/gunicorn server.main:app \
+    --workers 4 \
+    --worker-class uvicorn.workers.UvicornWorker \
+    --bind 0.0.0.0:8000


### PR DESCRIPTION
## Summary
- add a dedicated `run_app.sh` script that enforces `PYTHONPATH`
- update Dockerfile and docker-compose files to use the new script
- call `run_app.sh` from the installer instead of `start.sh`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685949bdcc2c832480f272f815afc0e5