### PR TITLE
Add success indicator before server startup

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -44,6 +44,8 @@ if [ "${AUTO_SEED:-1}" != "0" ] && [ "${AUTO_SEED}" != "false" ]; then
     venv/bin/python seed_superuser.py
 fi
 
+echo "✔ Installation complete. Starting server on port ${PORT:-8000}..."
+
 exec gunicorn server.main:app \
     --worker-class uvicorn.workers.UvicornWorker \
     --workers "${WORKERS:-4}" \


### PR DESCRIPTION
## Summary
- show installation success before starting Gunicorn

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_68594d12a5d4832494e0eebf67fb3e40