### PR TITLE
Improve cloud user lookup robustness

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -157,9 +157,20 @@ def lookup_cloud_user(base_url: str, api_key: str, email: str) -> dict | None:
             return None
         resp.raise_for_status()
         data = resp.json()
-        # Treat empty responses as not found
-        if not data:
+
+        # Log the result for debugging
+        print("🔍 Cloud user lookup response:", data)
+
+        # If unauthorized or malformed, abort early
+        if "detail" in data and "not authenticated" in str(data["detail"]).lower():
+            print("❌ API key is not authorized to look up users.")
             return None
+
+        # If 'id' is missing, this is not a valid user record
+        if "id" not in data:
+            print("⚠️ Cloud response did not include a user ID; treating as not found.")
+            return None
+
         return data
     except Exception as exc:  # pragma: no cover - best effort
         print(f"User lookup failed: {exc}")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -34,6 +34,22 @@ def test_lookup_cloud_user_empty(monkeypatch):
     assert result is None
 
 
+def test_lookup_cloud_user_unauthorized(monkeypatch):
+    def fake_get(url, params=None, headers=None, timeout=10):
+        return httpx.Response(401, json={'detail': 'Not authenticated'})
+    monkeypatch.setattr('installer.httpx.get', fake_get)
+    result = lookup_cloud_user('https://cloud', 'k', 'a@b.com')
+    assert result is None
+
+
+def test_lookup_cloud_user_missing_id(monkeypatch):
+    def fake_get(url, params=None, headers=None, timeout=10):
+        return httpx.Response(200, json={'email': 'a@b.com'})
+    monkeypatch.setattr('installer.httpx.get', fake_get)
+    result = lookup_cloud_user('https://cloud', 'k', 'a@b.com')
+    assert result is None
+
+
 def test_create_cloud_user_success(monkeypatch):
     def fake_post(url, json=None, headers=None, timeout=10):
         return httpx.Response(200, json={'id': 'u1'})


### PR DESCRIPTION
## Summary
- handle malformed cloud responses in `lookup_cloud_user`
- add unit tests for unauthorized and malformed lookup results

## Testing
- `pip install -r requirements.txt`
- `pip3 install --break-system-packages -r requirements.txt`
- `pip3 install --break-system-packages pytest`
- `pytest tests/test_installer.py::test_lookup_cloud_user_unauthorized tests/test_installer.py::test_lookup_cloud_user_missing_id -q` *(fails: Permission denied creating /workspace/Master-IP-App/tests/.pg_cache)*

------
https://chatgpt.com/codex/tasks/task_e_68595bb0b28483248c9e8d1b2b89d58e