### PR TITLE
Fix cloud user lookup endpoint

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -144,7 +144,7 @@ def lookup_cloud_user(base_url: str, api_key: str, email: str) -> dict | None:
     """Return user data from the cloud if it exists."""
     import httpx
 
-    url = base_url.rstrip("/") + "/api/users/lookup"
+    url = base_url.rstrip("/") + "/api/v1/users/lookup"
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     try:
         resp = httpx.get(


### PR DESCRIPTION
## Summary
- correct `/api` URL for cloud user lookup

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_installer.py::test_lookup_cloud_user_404 tests/test_installer.py::test_lookup_cloud_user_empty -q` *(fails: initdb failed - cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_68596b2b4484832486cf40b609fc3e3f