### PR TITLE
Add auto-install logic to installer

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -1,5 +1,22 @@
-import os
+import subprocess
 import sys
+import os
+
+REQUIRED_MODULES = ["sqlalchemy", "psycopg2", "dotenv", "questionary"]
+
+missing = []
+for mod in REQUIRED_MODULES:
+    try:
+        __import__(mod)
+    except ImportError:
+        missing.append(mod)
+
+if missing:
+    print(f"\ud83d\udce6 Installing missing Python modules: {', '.join(missing)}")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
+    print("\u2705 Dependencies installed. Re-running installer...")
+    os.execv(sys.executable, [sys.executable] + sys.argv)
+
 from pathlib import Path
 import secrets
 
@@ -9,7 +26,6 @@ except ImportError:  # pragma: no cover - environment may lack dependency
     load_dotenv = None
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-import subprocess
 
 # -- Environment setup -----------------------------------------------------
 if not os.path.exists(".env"):


### PR DESCRIPTION
## Summary
- ensure missing dependencies are installed before running installer

## Testing
- `pip install -r requirements.txt`
- `pytest -k installer -q` *(fails: initdb cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_6859cf7f9fdc8324941585512990d86c