### PR TITLE
Fix emoji errors in installer dependency log

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -12,11 +12,13 @@ for mod in REQUIRED_MODULES:
         missing.append(mod)
 
 if missing:
-    print(f"\ud83d\udce6 Installing missing Python modules: {', '.join(missing)}")
-    subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]
-    )
-    print("\u2705 Dependencies installed. Re-running installer...")
+    try:
+        print(f"📦 Installing missing Python modules: {', '.join(missing)}")
+    except UnicodeEncodeError:
+        print(f"Installing missing Python modules: {', '.join(missing)}")
+
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
+    print("✅ Dependencies installed. Re-running installer...")
     os.execv(sys.executable, [sys.executable] + sys.argv)
 
 from pathlib import Path


### PR DESCRIPTION
## Summary
- catch UnicodeEncodeError when printing emoji in `installer.py`
- fall back to ASCII and continue installing requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: could not launch Postgresql due to permission errors)*

------
https://chatgpt.com/codex/tasks/task_e_685ada6af4b883248780b98c778540f7