### PR TITLE
Fix core package lazy loading

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,18 +1,9 @@
 """Core utilities and data models for server modules."""
 
-from . import models
-from .schemas import ColumnSelection
-from .utils.auth import (
-    get_current_user,
-    require_role,
-    user_in_site,
-    get_user_site_ids,
-    get_password_hash,
-    verify_password,
-    ROLE_CHOICES,
-    ROLE_HIERARCHY,
-)
-from .auth import issue_token, verify_token
+# Avoid importing heavy dependencies at module import time.  The submodules are
+# loaded lazily when accessed via ``core.<name>``.  This keeps ``import core``
+# lightweight and prevents import errors during installer execution when
+# optional dependencies may not yet be available.
 
 __all__ = [
     "models",
@@ -28,3 +19,32 @@ __all__ = [
     "ROLE_CHOICES",
     "ROLE_HIERARCHY",
 ]
+
+
+def __getattr__(name):
+    if name == "models":
+        from . import models as _m
+
+        return _m
+    if name == "ColumnSelection":
+        from .schemas import ColumnSelection as _c
+
+        return _c
+    if name in {
+        "get_current_user",
+        "require_role",
+        "user_in_site",
+        "get_user_site_ids",
+        "get_password_hash",
+        "verify_password",
+        "ROLE_CHOICES",
+        "ROLE_HIERARCHY",
+    }:
+        from .utils import auth as _a
+
+        return getattr(_a, name)
+    if name in {"issue_token", "verify_token"}:
+        from . import auth as _auth
+
+        return getattr(_auth, name)
+    raise AttributeError(name)

--- a/core/utils/db_session.py
+++ b/core/utils/db_session.py
@@ -5,11 +5,13 @@ import os
 from core.utils.database import Base
 
 # Import models so that Base.metadata is aware of them before creating tables
-from core import models  # noqa: F401
+import core.models  # noqa: F401
 
 DATABASE_URL = os.environ.get("DATABASE_URL")
 if DATABASE_URL and not DATABASE_URL.startswith("postgresql"):
-    raise RuntimeError("Only PostgreSQL is supported. DATABASE_URL must begin with 'postgresql'.")
+    raise RuntimeError(
+        "Only PostgreSQL is supported. DATABASE_URL must begin with 'postgresql'."
+    )
 engine = create_engine(DATABASE_URL) if DATABASE_URL else None
 
 
@@ -58,7 +60,10 @@ class SafeSession(Session):
             import traceback
             from core.utils.schema import log_db_error
 
-            models = {obj.__class__.__name__ for obj in self.new.union(self.dirty).union(self.deleted)}
+            models = {
+                obj.__class__.__name__
+                for obj in self.new.union(self.dirty).union(self.deleted)
+            }
             log_db_error(
                 ",".join(sorted(models)) or "unknown",
                 "commit",
@@ -67,15 +72,21 @@ class SafeSession(Session):
                 getattr(self, "current_user", None),
             )
 
-_BaseSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, class_=SafeSession)
 
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, class_=SafeSession)
+_BaseSessionLocal = sessionmaker(
+    autocommit=False, autoflush=False, bind=engine, class_=SafeSession
+)
+
+SessionLocal = sessionmaker(
+    autocommit=False, autoflush=False, bind=engine, class_=SafeSession
+)
 
 # Import module models so all tables are registered before creation
 import modules.inventory.models  # noqa: F401
 import modules.network.models  # noqa: F401
 
 # Database schema managed exclusively via Alembic migrations
+
 
 @event.listens_for(Session, "do_orm_execute")
 def _filter_deleted(execute_state):


### PR DESCRIPTION
## Summary
- avoid heavy imports in `core/__init__` to prevent ModuleNotFound errors
- adjust `db_session` to import models without relying on `core.__init__`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685b30cbbc208324a19959ded8589b1f