### PR TITLE
Improve sync conflict handling

### DIFF
--- a/core/utils/timestamp.py
+++ b/core/utils/timestamp.py
@@ -1,0 +1,52 @@
+from contextlib import contextmanager
+from typing import Iterable, Tuple
+
+from sqlalchemy import event
+
+# Mapping of models to their timestamp update hook functions
+try:
+    from modules.inventory import models as inventory_models
+    from modules.network import models as network_models
+    from core.models import models as core_models
+except Exception:  # pragma: no cover - module import guard
+    inventory_models = None
+    network_models = None
+    core_models = None
+
+MODEL_UPDATE_EVENTS: list[Tuple[object, object]] = []
+if inventory_models is not None:
+    for m in (inventory_models.Device, inventory_models.DeviceType,
+              inventory_models.Location, inventory_models.Tag):
+        MODEL_UPDATE_EVENTS.append((m, inventory_models._update_timestamp))
+if network_models is not None:
+    for m in (
+        network_models.VLAN,
+        network_models.SSHCredential,
+        network_models.SNMPCommunity,
+        network_models.ConnectedSite,
+    ):
+        MODEL_UPDATE_EVENTS.append((m, network_models._update_timestamp))
+if core_models is not None:
+    for m in (core_models.Site, core_models.User):
+        MODEL_UPDATE_EVENTS.append((m, core_models._update_timestamp))
+
+
+@contextmanager
+def suspend_timestamp_updates(models: Iterable[type] | None = None):
+    """Temporarily disable before_update timestamp hooks for given models."""
+    targets = MODEL_UPDATE_EVENTS
+    if models is not None:
+        targets = [pair for pair in MODEL_UPDATE_EVENTS if pair[0] in models]
+    for model, fn in targets:
+        try:
+            event.remove(model, "before_update", fn)
+        except Exception:  # pragma: no cover - defensive
+            pass
+    try:
+        yield
+    finally:
+        for model, fn in targets:
+            try:
+                event.listen(model, "before_update", fn)
+            except Exception:  # pragma: no cover - defensive
+                pass

--- a/core/utils/versioning.py
+++ b/core/utils/versioning.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Iterable, Set
 import uuid
 
 from .serialization import to_jsonable
@@ -10,12 +10,17 @@ def apply_update(
     update_data: dict,
     incoming_version: int | None = None,
     source: str = "api",
+    ignore_fields: Iterable[str] | None = None,
 ):
     """Apply updates to an ORM object with version increment and optional conflict detection."""
 
     current_version = getattr(obj, "version", 0) or 0
     sync_state = getattr(obj, "sync_state", None) or {}
     conflicts: list[dict] = []
+    ignore: Set[str] = set(ignore_fields or {"created_at", "updated_at", "deleted_at"})
+
+    is_remote_newer = incoming_version is not None and incoming_version > current_version
+    is_local_newer = current_version > (incoming_version or 0)
 
     for field, remote_value in update_data.items():
         local_value = getattr(obj, field, None)
@@ -23,7 +28,20 @@ def apply_update(
         changed_local = last_value is not None and local_value != last_value
         changed_remote = last_value is not None and remote_value != last_value
 
+        if field in ignore:
+            setattr(obj, field, remote_value)
+            sync_state[field] = getattr(obj, field)
+            continue
+
         if changed_local and changed_remote and remote_value != local_value:
+            if is_remote_newer and not is_local_newer:
+                setattr(obj, field, remote_value)
+                sync_state[field] = getattr(obj, field)
+                continue
+            if is_local_newer and not is_remote_newer:
+                sync_state[field] = getattr(obj, field)
+                continue
+
             lv = local_value
             rv = remote_value
             if isinstance(lv, datetime):

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -6,6 +6,9 @@ class Dummy:
         self.conflict_data = None
         self.sync_state = {"name": "a"}
         self.name = "a"
+        self.created_at = None
+        self.updated_at = None
+        self.deleted_at = None
 
 
 def test_apply_update_increments_version():
@@ -22,8 +25,30 @@ def test_apply_update_conflict():
     d.name = "b"
     apply_update(d, {"name": "x"}, incoming_version=0, source="test")
     assert d.version == 2
-    assert d.conflict_data is not None
-    assert d.conflict_data[0]["source"] == "test"
-    assert d.conflict_data[0]["field"] == "name"
-    assert d.conflict_data[0]["remote_value"] == "x"
+    assert d.conflict_data is None
     assert d.name == "b"
+
+
+def test_apply_update_conflict_equal_versions():
+    d = Dummy()
+    d.name = "b"
+    apply_update(d, {"name": "x"}, incoming_version=1, source="test")
+    assert d.conflict_data is not None
+    assert d.conflict_data[0]["field"] == "name"
+    assert d.name == "b"
+
+
+def test_ignore_timestamp_fields():
+    d = Dummy()
+    apply_update(
+        d,
+        {
+            "updated_at": "2024-01-01T00:00:00Z",
+            "created_at": "2024-01-01T00:00:00Z",
+        },
+        incoming_version=2,
+        source="test",
+    )
+    assert d.conflict_data is None
+
+


### PR DESCRIPTION
## Summary
- ignore timestamp fields when checking for sync conflicts
- auto resolve based on version differences
- keep remote timestamps when applying deletes
- add helper to disable timestamp update events
- update versioning tests

## Testing
- `pytest tests/test_versioning.py::test_apply_update_increments_version -q`


------
https://chatgpt.com/codex/tasks/task_e_685b389099108324951c16410b0dc790