### PR TITLE
Remove duplicate System Monitor menu

### DIFF
--- a/server/routes/ui/admin_menu.py
+++ b/server/routes/ui/admin_menu.py
@@ -20,7 +20,6 @@ async def super_admin_menu(
     items = [
         {"label": "My Profile", "href": "/users/me"},
         {"label": "Organisation Settings", "href": "/admin/org-settings", "category": "System"},
-        {"label": "System Monitor", "href": "/admin/system-monitor", "category": "System"},
         {"label": "Cloud Sync / API's", "href": "/admin/cloud-sync"},
     ]
     for item in items:

--- a/web-client/templates/nav_dropdown.html
+++ b/web-client/templates/nav_dropdown.html
@@ -20,7 +20,6 @@
           <a href="/users/me" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">My Profile</a>
           <a href="/admin/system" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">System</a>
           <a href="/admin/users" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Users</a>
-          <a href="/admin/system-monitor" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">System Monitor</a>
           <a href="/admin/cloud-sync" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Cloud Sync / API's</a>
           <a href="/admin/logs" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded transition">Logs</a>
           {% else %}

--- a/web-client/templates/nav_folder.html
+++ b/web-client/templates/nav_folder.html
@@ -39,7 +39,6 @@
         <a href="/users/me" :class="active('/users/me')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">My Profile</a>
         <a href="/admin/system" :class="active('/admin/system')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">System</a>
         <a href="/admin/users" :class="active('/admin/users')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Users</a>
-        <a href="/admin/system-monitor" :class="active('/admin/system-monitor')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">System Monitor</a>
         <a href="/admin/cloud-sync" :class="active('/admin/cloud-sync')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Cloud Sync / API's</a>
         <a href="/admin/logs" :class="active('/admin/logs')" class="block px-2 py-1 rounded hover:bg-[var(--submenu-hover-bg)]">Logs</a>
         {% else %}

--- a/web-client/templates/nav_tabbed.html
+++ b/web-client/templates/nav_tabbed.html
@@ -54,7 +54,6 @@
           {% if current_user.role == 'superadmin' %}
           <a href="/users/me" @click="setSub('/users/me')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/users/me'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">My Profile</a>
           <a href="/admin/system" @click="setSub('/admin/system')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/admin/system'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">System</a>
-          <a href="/admin/system-monitor" @click="setSub('/admin/system-monitor')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/admin/system-monitor'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">System Monitor</a>
           <a href="/admin/cloud-sync" @click="setSub('/admin/cloud-sync')" :class="{'bg-[var(--submenu-hover-bg)]': activeSubMenu === '/admin/cloud-sync'}" class="px-4 py-2 text-[var(--font-size)] text-[var(--tab-text)] bg-[var(--tab-bg)] hover:bg-[var(--tab-hover)] rounded-t-lg transition">Cloud Sync / API's</a>
           {% else %}
           {% for item in admin_items %}


### PR DESCRIPTION
## Summary
- remove direct System Monitor link from Super Admin menu
- update tabbed, folder and dropdown menus accordingly

## Testing
- `pytest -q` *(fails: PermissionError when tests attempt to write .env)*

------
https://chatgpt.com/codex/tasks/task_e_685bb90640c883248ca705b3c5fed1b1