### PR TITLE
Add onupdate timestamp handling

### DIFF
--- a/alembic/versions/92afc614eeae_add_updated_at_onupdate.py
+++ b/alembic/versions/92afc614eeae_add_updated_at_onupdate.py
@@ -1,0 +1,32 @@
+"""add updated_at onupdate
+
+Revision ID: 92afc614eeae
+Revises: 193aae3f5005
+Create Date: 2025-06-25 19:03:32.652540
+
+"""
+from typing import Sequence, Union
+
+# No schema changes are required for this revision. It only ensures
+# instances upgrade to the new software version where updated_at columns
+# now include an ``onupdate`` clause handled in application code.
+
+from alembic import op  # noqa: F401 - imported for Alembic context
+import sqlalchemy as sa  # noqa: F401 - imported for Alembic context
+
+
+# revision identifiers, used by Alembic.
+revision: str = '92afc614eeae'
+down_revision: Union[str, None] = '193aae3f5005'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """No-op migration for application version tracking."""
+    pass
+
+
+def downgrade() -> None:
+    """No-op downgrade."""
+    pass

--- a/core/models/models.py
+++ b/core/models/models.py
@@ -32,7 +32,12 @@ class Site(Base):
     name = Column(String, unique=True, nullable=False)
     description = Column(Text, nullable=True)
     created_by_id = Column(Integer, ForeignKey("users.id"), nullable=True)
-    updated_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
+    updated_at = Column(
+        TIMESTAMP(timezone=False),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+        nullable=False,
+    )
     deleted_at = Column(TIMESTAMP(timezone=False), nullable=True)
     created_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
 
@@ -103,7 +108,12 @@ class User(Base):
     ssh_username = Column(String, nullable=True)
     ssh_password = Column(String, nullable=True)
     ssh_port = Column(Integer, nullable=True, default=22)
-    updated_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
+    updated_at = Column(
+        TIMESTAMP(timezone=False),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+        nullable=False,
+    )
     deleted_at = Column(TIMESTAMP(timezone=False), nullable=True)
     created_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
     last_login = Column(TIMESTAMP(timezone=False), nullable=True)

--- a/modules/inventory/models.py
+++ b/modules/inventory/models.py
@@ -33,7 +33,12 @@ class Location(Base):
     sync_state = Column(JSON, nullable=True)
     name = Column(String, unique=True, nullable=False)
     location_type = Column(String, nullable=False, default="Fixed")
-    updated_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
+    updated_at = Column(
+        TIMESTAMP(timezone=False),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+        nullable=False,
+    )
     deleted_at = Column(TIMESTAMP(timezone=False), nullable=True)
     created_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
 
@@ -55,7 +60,12 @@ class DeviceType(Base):
     name = Column(String, unique=True, nullable=False)
     upload_icon = Column(String, nullable=True)
     upload_image = Column(String, nullable=True)
-    updated_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
+    updated_at = Column(
+        TIMESTAMP(timezone=False),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+        nullable=False,
+    )
     deleted_at = Column(TIMESTAMP(timezone=False), nullable=True)
     created_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
 
@@ -79,7 +89,12 @@ class Tag(Base):
     conflict_data = Column(JSON, nullable=True)
     sync_state = Column(JSON, nullable=True)
     name = Column(String, unique=True, nullable=False)
-    updated_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
+    updated_at = Column(
+        TIMESTAMP(timezone=False),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+        nullable=False,
+    )
     deleted_at = Column(TIMESTAMP(timezone=False), nullable=True)
     created_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
 
@@ -119,7 +134,12 @@ class Device(Base):
     snmp_community_id = Column(Integer, ForeignKey("snmp_communities.id"))
     created_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
     created_by_id = Column(Integer, ForeignKey("users.id"), nullable=True)
-    updated_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
+    updated_at = Column(
+        TIMESTAMP(timezone=False),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+        nullable=False,
+    )
     last_seen = Column(TIMESTAMP(timezone=False), nullable=True)
 
     uptime_seconds = Column(Integer, nullable=True)

--- a/modules/network/models.py
+++ b/modules/network/models.py
@@ -27,7 +27,12 @@ class VLAN(Base):
     sync_state = Column(JSON, nullable=True)
     tag = Column(Integer, unique=True, nullable=False)
     description = Column(String, nullable=True)
-    updated_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
+    updated_at = Column(
+        TIMESTAMP(timezone=False),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+        nullable=False,
+    )
     deleted_at = Column(TIMESTAMP(timezone=False), nullable=True)
     created_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
 
@@ -46,7 +51,12 @@ class SSHCredential(Base):
     username = Column(String, nullable=False)
     password = Column(String, nullable=True)
     private_key = Column(Text, nullable=True)
-    updated_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
+    updated_at = Column(
+        TIMESTAMP(timezone=False),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+        nullable=False,
+    )
     deleted_at = Column(TIMESTAMP(timezone=False), nullable=True)
     created_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
 
@@ -64,7 +74,12 @@ class SNMPCommunity(Base):
     name = Column(String, unique=True, nullable=False)
     community_string = Column(String, nullable=False)
     snmp_version = Column(String, nullable=False)
-    updated_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
+    updated_at = Column(
+        TIMESTAMP(timezone=False),
+        default=datetime.now(timezone.utc),
+        onupdate=datetime.now(timezone.utc),
+        nullable=False,
+    )
     deleted_at = Column(TIMESTAMP(timezone=False), nullable=True)
     created_at = Column(TIMESTAMP(timezone=False), default=datetime.now(timezone.utc))
 


### PR DESCRIPTION
## Summary
- ensure `updated_at` columns include `onupdate` handling
- provide migration for revision tracking

## Testing
- `pytest -q` *(fails: initdb failed: cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685c469e1fd88324898283ca6500790b