### PR TITLE
Fix site hierarchy migration

### DIFF
--- a/alembic/versions/193aae3f5005_site_location_hierarchy.py
+++ b/alembic/versions/193aae3f5005_site_location_hierarchy.py
@@ -29,8 +29,7 @@ def upgrade() -> None:
             "INSERT INTO sites (id, uuid, version, name, created_at, updated_at) "
             "VALUES (100, :uuid, 1, 'Virtual Warehouse', now(), now()) "
             "ON CONFLICT (id) DO NOTHING"
-        ),
-        {"uuid": str(uuid4())},
+        ).bindparams(uuid=str(uuid4()))
     )
 
     op.execute(


### PR DESCRIPTION
## Summary
- correct parameter handling for `op.execute` in site hierarchy migration

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685c4a88b2b88324b1af8c51ea258e3b