### PR TITLE
Fix device constraint migration

### DIFF
--- a/alembic/versions/193aae3f5005_site_location_hierarchy.py
+++ b/alembic/versions/193aae3f5005_site_location_hierarchy.py
@@ -36,6 +36,8 @@ def upgrade() -> None:
         "UPDATE devices SET site_id = 100 WHERE site_id IS NULL OR site_id NOT IN (SELECT id FROM sites)"
     )
 
+    op.execute("UPDATE devices SET location_id = NULL WHERE site_id = 100")
+
     op.execute(
         "UPDATE locations SET site_id = (SELECT id FROM sites WHERE id <> 100 ORDER BY id LIMIT 1) WHERE site_id IS NULL"
     )


### PR DESCRIPTION
## Summary
- ensure `ck_devices_virtual_no_location` passes
- null `location_id` when assigning devices to Virtual Warehouse

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685c4eb36f208324921448ed43856b37