### PR TITLE
Fix missing os import

### DIFF
--- a/scripts/run_migrations.py
+++ b/scripts/run_migrations.py
@@ -2,6 +2,7 @@
 """Apply Alembic migrations safely."""
 import logging
 import sys
+import os
 from pathlib import Path
 
 # Ensure repository root is on the Python path so ``core`` imports resolve


### PR DESCRIPTION
## Summary
- add missing `os` import to `scripts/run_migrations.py`

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_install.py::test_install_finish_handles_quotes -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685daaa97f608324afc8681f7bc4858b