### PR TITLE
Fix model reload after migrations

### DIFF
--- a/core/utils/schema.py
+++ b/core/utils/schema.py
@@ -87,6 +87,8 @@ def safe_alembic_upgrade(
                 mod = sys.modules.get("core")
                 if mod and not getattr(mod, "__path__", None):
                     for name in [
+                        "core.utils.db_session",
+                        "core.utils.database",
                         "core.utils",
                         "core.models.models",
                         "core.models",


### PR DESCRIPTION
## Summary
- clear Base-related modules during `safe_alembic_upgrade`
- this prevents duplicate table definitions when reloading models

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb cannot run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685dc69469a483248226c5b19adfd86f