### PR TITLE
Fix installer distutils support

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -28,7 +28,14 @@ def ensure_min_python() -> None:
         )
         subprocess.check_call(["apt-get", "update"])
         subprocess.check_call(
-            ["apt-get", "install", "-y", "python3.12", "python3.12-venv"]
+            [
+                "apt-get",
+                "install",
+                "-y",
+                "python3.12",
+                "python3.12-venv",
+                "python3.12-distutils",
+            ]
         )
     except Exception as exc:  # pragma: no cover - best effort
         try:
@@ -60,10 +67,27 @@ def fix_python_runtime():
         print("⚠️ pip not found. Attempting to install via apt...")
         try:
             subprocess.run(["apt", "update"], check=True)
-            subprocess.run(["apt", "install", "-y", "python3-pip", "python3-venv"], check=True)
+            subprocess.run(
+                [
+                    "apt",
+                    "install",
+                    "-y",
+                    "python3-pip",
+                    "python3-venv",
+                    "python3-distutils",
+                ],
+                check=True,
+            )
         except Exception as e:
             print(f"❌ Failed to install pip/venv via apt: {e}")
             sys.exit(1)
+
+    # Ensure distutils for the running Python version is installed
+    try:
+        import distutils  # noqa: F401
+    except Exception:
+        pkg = f"python{sys.version_info.major}.{sys.version_info.minor}-distutils"
+        subprocess.run(["apt-get", "install", "-y", pkg])
 
 fix_python_runtime()
 
@@ -464,7 +488,7 @@ def install():
     # Ensure the venv module is available before any pip or venv commands
     run("apt-get update")
     try:
-        run("apt-get install -y python3-venv")
+        run("apt-get install -y python3-venv python3-distutils")
     except subprocess.CalledProcessError:
         print(
             "\N{CROSS MARK} Failed to install python3-venv. This is required to create a virtual environment."
@@ -526,7 +550,7 @@ def install():
 
     run("apt-get update")
     run(
-        "apt-get install -y git python3 python3-venv python3-pip postgresql curl python-is-python3"
+        "apt-get install -y git python3 python3-venv python3-pip python3-distutils postgresql curl python-is-python3"
     )
     if install_nginx:
         run("apt-get install -y nginx")
@@ -819,7 +843,7 @@ if __name__ == "__main__":
     if not os.environ.get("VIRTUAL_ENV"):
         if not Path("venv/bin/activate").exists():
             run("apt-get update")
-            run("apt-get install -y python3-venv")
+            run("apt-get install -y python3-venv python3-distutils")
             run(f"{sys.executable} -m venv venv")
         print("🔁 Re-running installer inside virtualenv...")
         os.environ["VIRTUAL_ENV"] = str(Path("venv").resolve())


### PR DESCRIPTION
## Summary
- ensure python3.12-distutils is installed when Python is installed
- install python3-distutils in several places to ensure pip works
- check for distutils and install per-runtime package if missing

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: initdb cannot be run as root)*

------
https://chatgpt.com/codex/tasks/task_e_685dd813b3ac8324a4fa3fb014e548bb