### PR TITLE
Fix tests by allowing PG cache dir override

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,10 @@ import sqlalchemy as sa
 import testing.postgresql
 import shutil
 
-PG_CACHE_DIR = os.path.join(os.path.dirname(__file__), ".pg_cache")
+PG_CACHE_DIR = os.environ.get(
+    "PG_CACHE_DIR",
+    os.path.join(os.path.dirname(__file__), ".pg_cache"),
+)
 if os.environ.get("RESET_TEST_DB"):
     shutil.rmtree(PG_CACHE_DIR, ignore_errors=True)
 


### PR DESCRIPTION
## Summary
- allow custom PostgreSQL cache directory in tests to run without root permissions

## Testing
- `PG_CACHE_DIR=/tmp/pg_cache pytest tests/test_index.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685e9f14d9948324b859fe375d3206cf